### PR TITLE
Uncapitalize error messages

### DIFF
--- a/cmd/migration-manager-worker/main_worker.go
+++ b/cmd/migration-manager-worker/main_worker.go
@@ -44,11 +44,11 @@ func (c *cmdWorker) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if os.Geteuid() != 0 {
-		return fmt.Errorf("This tool must be run as root\n")
+		return fmt.Errorf("this tool must be run as root\n")
 	}
 
 	if !util.PathExists("/dev/virtio-ports/org.linuxcontainers.incus") {
-		return fmt.Errorf("This tool is designed to be run within an Incus VM\n")
+		return fmt.Errorf("this tool is designed to be run within an Incus VM\n")
 	}
 
 	w, err := newWorker(c.flagMMEndpoint, c.flagUUID)

--- a/cmd/migration-manager-worker/worker.go
+++ b/cmd/migration-manager-worker/worker.go
@@ -283,7 +283,7 @@ func (w *Worker) doHttpRequestV1(endpoint string, method string, content []byte)
 	if err != nil {
 		return nil, err
 	} else if jsonResp.Code != 0 {
-		return &jsonResp, fmt.Errorf("Received an error from the endpoint: %s", jsonResp.Error)
+		return &jsonResp, fmt.Errorf("received an error from the endpoint: %s", jsonResp.Error)
 	}
 
 	return &jsonResp, nil

--- a/cmd/migration-manager/main.go
+++ b/cmd/migration-manager/main.go
@@ -165,7 +165,7 @@ func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, ma
 			return true, nil
 		}
 
-		return true, fmt.Errorf("Invalid number of arguments")
+		return true, fmt.Errorf("invalid number of arguments")
 	}
 
 	return false, nil
@@ -206,7 +206,7 @@ func (c *cmdGlobal) doHttpRequestV1(endpoint string, method string, query string
 	if err != nil {
 		return nil, err
 	} else if jsonResp.Code != 0 {
-		return &jsonResp, fmt.Errorf("Received an error from the server: %s", jsonResp.Error)
+		return &jsonResp, fmt.Errorf("received an error from the server: %s", jsonResp.Error)
 	}
 
 	return &jsonResp, nil

--- a/cmd/migration-manager/main_source.go
+++ b/cmd/migration-manager/main_source.go
@@ -99,7 +99,7 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 	// Set variables.
 	if len(args) == 3 {
 		if !slices.Contains(supportedTypes, strings.ToLower(args[0])) {
-			return fmt.Errorf("Unsupported source type '%s'; must be one of %q", args[0], supportedTypes)
+			return fmt.Errorf("unsupported source type '%s'; must be one of %q", args[0], supportedTypes)
 		}
 		sourceType = strings.ToLower(args[0])
 		sourceName = args[1]
@@ -256,7 +256,7 @@ func parseReturnedSource(source any) (any, error) {
 
 		return source, nil
 	default:
-		return nil, fmt.Errorf("Unsupported source type %f", rawSource["type"].(float64))
+		return nil, fmt.Errorf("unsupported source type %f", rawSource["type"].(float64))
 	}
 }
 
@@ -393,7 +393,7 @@ func (c *cmdSourceUpdate) Run(cmd *cobra.Command, args []string) error {
 		newSourceName = specificSource.Name
 		s = internalSource
 	default:
-		return fmt.Errorf("Unsupported source type %T; must be one of %q", s, supportedTypes)
+		return fmt.Errorf("unsupported source type %T; must be one of %q", s, supportedTypes)
 	}
 
 	// Update the source.

--- a/cmd/migration-managerd/api_batch.go
+++ b/cmd/migration-managerd/api_batch.go
@@ -146,7 +146,7 @@ func batchesPost(d *Daemon, r *http.Request) response.Response {
 		return d.db.AddBatch(tx, &b)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed creating batch %q: %w", b.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed creating batch %q: %w", b.GetName(), err))
 	}
 
 	// Add any instances to this batch that match selection criteria.
@@ -154,7 +154,7 @@ func batchesPost(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateInstancesAssignedToBatch(tx, &b)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed to assign instances to batch %q: %w", b.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed to assign instances to batch %q: %w", b.GetName(), err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/batches/"+b.GetName())
@@ -185,14 +185,14 @@ func batchDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return d.db.DeleteBatch(tx, name)
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to delete batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to delete batch '%s': %w", name, err))
 	}
 
 	return response.EmptySyncResponse
@@ -239,7 +239,7 @@ func batchGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	var b batch.Batch
@@ -253,7 +253,7 @@ func batchGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get batch '%s': %w", name, err))
 	}
 
 	return response.SyncResponseETag(true, b, b)
@@ -295,7 +295,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	// Get the existing batch.
@@ -310,7 +310,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get batch '%s': %w", name, err))
 	}
 
 	// Validate ETag
@@ -330,7 +330,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateBatch(tx, b)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating batch %q: %w", b.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed updating batch %q: %w", b.GetName(), err))
 	}
 
 	// Update any instances for this batch that match selection criteria.
@@ -338,7 +338,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateInstancesAssignedToBatch(tx, b)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed to update instances for batch %q: %w", b.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed to update instances for batch %q: %w", b.GetName(), err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/batches/"+b.GetName())
@@ -388,7 +388,7 @@ func batchInstancesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	var b batch.Batch
@@ -402,7 +402,7 @@ func batchInstancesGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get batch '%s': %w", name, err))
 	}
 
 	result := []instance.Instance{}
@@ -450,7 +450,7 @@ func batchStartPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -462,7 +462,7 @@ func batchStartPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to start batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to start batch '%s': %w", name, err))
 	}
 
 	return response.SyncResponse(true, nil)
@@ -493,7 +493,7 @@ func batchStopPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Batch name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("batch name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -505,7 +505,7 @@ func batchStopPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to stop batch '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to stop batch '%s': %w", name, err))
 	}
 
 	return response.SyncResponse(true, nil)

--- a/cmd/migration-managerd/api_instance.go
+++ b/cmd/migration-managerd/api_instance.go
@@ -141,7 +141,7 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get instance '%s': %w", UUID, err))
+		return response.BadRequest(fmt.Errorf("failed to get instance '%s': %w", UUID, err))
 	}
 
 	return response.SyncResponseETag(true, i, i)
@@ -199,7 +199,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get instance '%s': %w", UUID, err))
+		return response.BadRequest(fmt.Errorf("failed to get instance '%s': %w", UUID, err))
 	}
 
 	// Validate ETag
@@ -219,7 +219,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateInstance(tx, i)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating instance '%s': %w", i.GetUUID(), err))
+		return response.SmartError(fmt.Errorf("failed updating instance '%s': %w", i.GetUUID(), err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/instances/"+i.GetUUID().String())

--- a/cmd/migration-managerd/api_network.go
+++ b/cmd/migration-managerd/api_network.go
@@ -126,7 +126,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return d.db.AddNetwork(tx, &n)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed creating network %q: %w", n.Name, err))
+		return response.SmartError(fmt.Errorf("failed creating network %q: %w", n.Name, err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/networks/"+n.Name)
@@ -157,14 +157,14 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Network name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("network name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return d.db.DeleteNetwork(tx, name)
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to delete network '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to delete network '%s': %w", name, err))
 	}
 
 	return response.EmptySyncResponse
@@ -211,7 +211,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Network name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("network name cannot be empty"))
 	}
 
 	var n api.Network
@@ -225,7 +225,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get network '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get network '%s': %w", name, err))
 	}
 
 	return response.SyncResponseETag(true, n, n)
@@ -267,7 +267,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Network name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("network name cannot be empty"))
 	}
 
 	// Get the existing network.
@@ -282,7 +282,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get network '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get network '%s': %w", name, err))
 	}
 
 	// Validate ETag
@@ -302,7 +302,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateNetwork(tx, n)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating network %q: %w", n.Name, err))
+		return response.SmartError(fmt.Errorf("failed updating network %q: %w", n.Name, err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/networks/"+n.Name)

--- a/cmd/migration-managerd/api_queue.go
+++ b/cmd/migration-managerd/api_queue.go
@@ -83,7 +83,7 @@ func queueRootGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get batches: %w", err))
+		return response.BadRequest(fmt.Errorf("failed to get batches: %w", err))
 	}
 
 	// For each batch that has entered the "queued" state or later, add its instances.
@@ -94,7 +94,7 @@ func queueRootGet(d *Daemon, r *http.Request) response.Response {
 
 		id, err := b.GetDatabaseID()
 		if err != nil {
-			return response.BadRequest(fmt.Errorf("Failed to get database ID for batch '%s': %w", b.GetName(), err))
+			return response.BadRequest(fmt.Errorf("failed to get database ID for batch '%s': %w", b.GetName(), err))
 		}
 
 		var instances []instance.Instance
@@ -108,7 +108,7 @@ func queueRootGet(d *Daemon, r *http.Request) response.Response {
 			return nil
 		})
 		if err != nil {
-			return response.BadRequest(fmt.Errorf("Failed to get instances for batch '%s': %w", b.GetName(), err))
+			return response.BadRequest(fmt.Errorf("failed to get instances for batch '%s': %w", b.GetName(), err))
 		}
 
 		for _, i := range instances {
@@ -181,23 +181,23 @@ func queueGet(d *Daemon, r *http.Request) response.Response {
 
 		internalInstance, ok := dbInstance.(*instance.InternalInstance)
 		if !ok {
-			return fmt.Errorf("Wasn't given an InternalInstance?")
+			return fmt.Errorf("wasn't given an InternalInstance?")
 		}
 		i = internalInstance
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get instance '%s': %w", UUID, err))
+		return response.BadRequest(fmt.Errorf("failed to get instance '%s': %w", UUID, err))
 	}
 
 	// Don't return info for instances that aren't in the migration queue.
 	if i.GetBatchID() == internal.INVALID_DATABASE_ID || !i.IsMigrating() {
-		return response.BadRequest(fmt.Errorf("Instance '%s' isn't in the migration queue", i.GetName()))
+		return response.BadRequest(fmt.Errorf("instance '%s' isn't in the migration queue", i.GetName()))
 	}
 
 	// If the instance is already doing something, don't start something else.
 	if i.MigrationStatus != api.MIGRATIONSTATUS_IDLE {
-		return response.BadRequest(fmt.Errorf("Instance '%s' isn't idle: %s (%s)", i.Name, i.MigrationStatus.String(), i.MigrationStatusString))
+		return response.BadRequest(fmt.Errorf("instance '%s' isn't idle: %s (%s)", i.Name, i.MigrationStatus.String(), i.MigrationStatusString))
 	}
 
 	// Setup the default "idle" command
@@ -225,7 +225,7 @@ func queueGet(d *Daemon, r *http.Request) response.Response {
 		return json.Unmarshal(encodedSource, &s)
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get source '%s': %w", UUID, err))
+		return response.BadRequest(fmt.Errorf("failed to get source '%s': %w", UUID, err))
 	}
 
 	// If we can do a background disk sync, kick it off if needed
@@ -249,7 +249,7 @@ func queueGet(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateInstanceStatus(tx, UUID, i.MigrationStatus, i.MigrationStatusString, i.NeedsDiskImport)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating instance '%s': %w", i.GetUUID(), err))
+		return response.SmartError(fmt.Errorf("failed updating instance '%s': %w", i.GetUUID(), err))
 	}
 
 	return response.SyncResponseETag(true, cmd, cmd)
@@ -305,18 +305,18 @@ func queuePut(d *Daemon, r *http.Request) response.Response {
 
 		internalInstance, ok := dbInstance.(*instance.InternalInstance)
 		if !ok {
-			return fmt.Errorf("Wasn't given an InternalInstance?")
+			return fmt.Errorf("wasn't given an InternalInstance?")
 		}
 		i = internalInstance
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get instance '%s': %w", UUID, err))
+		return response.BadRequest(fmt.Errorf("failed to get instance '%s': %w", UUID, err))
 	}
 
 	// Don't update instances that aren't in the migration queue.
 	if i.GetBatchID() == internal.INVALID_DATABASE_ID || !i.IsMigrating() {
-		return response.BadRequest(fmt.Errorf("Instance '%s' isn't in the migration queue", i.GetName()))
+		return response.BadRequest(fmt.Errorf("instance '%s' isn't in the migration queue", i.GetName()))
 	}
 
 	// Decode the command response.
@@ -350,7 +350,7 @@ func queuePut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateInstanceStatus(tx, UUID, i.MigrationStatus, i.MigrationStatusString, i.NeedsDiskImport)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating instance '%s': %w", i.GetUUID(), err))
+		return response.SmartError(fmt.Errorf("failed updating instance '%s': %w", i.GetUUID(), err))
 	}
 
 	return response.SyncResponse(true, nil)

--- a/cmd/migration-managerd/api_source.go
+++ b/cmd/migration-managerd/api_source.go
@@ -90,7 +90,7 @@ func sourcesGet(d *Daemon, r *http.Request) response.Response {
 			case *source.InternalVMwareSource:
 				result = append(result, sourcesResult{Type: api.SOURCETYPE_VMWARE, Source: s})
 			default:
-				return fmt.Errorf("Unsupported source type %T", s)
+				return fmt.Errorf("unsupported source type %T", s)
 			}
 		}
 
@@ -143,7 +143,7 @@ func sourcesPost(d *Daemon, r *http.Request) response.Response {
 	// Get source type parameter.
 	sourceType, err := strconv.Atoi(r.FormValue("type"))
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Source type must be an integer"))
+		return response.BadRequest(fmt.Errorf("source type must be an integer"))
 	}
 
 	// Setup the correct source type for unmarshaling.
@@ -153,7 +153,7 @@ func sourcesPost(d *Daemon, r *http.Request) response.Response {
 	case api.SOURCETYPE_VMWARE:
 		s = &source.InternalVMwareSource{}
 	default:
-		return response.BadRequest(fmt.Errorf("Unsupported source type %d", sourceType))
+		return response.BadRequest(fmt.Errorf("unsupported source type %d", sourceType))
 	}
 
 	// Decode into the new source.
@@ -167,7 +167,7 @@ func sourcesPost(d *Daemon, r *http.Request) response.Response {
 		return d.db.AddSource(tx, s)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed creating source %q: %w", s.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed creating source %q: %w", s.GetName(), err))
 	}
 
 	// Trigger a scan of this new source for instances.
@@ -201,14 +201,14 @@ func sourceDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Source name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("source name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return d.db.DeleteSource(tx, name)
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to delete source '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to delete source '%s': %w", name, err))
 	}
 
 	return response.EmptySyncResponse
@@ -256,7 +256,7 @@ func sourceGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Source name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("source name cannot be empty"))
 	}
 
 	var s source.Source
@@ -270,7 +270,7 @@ func sourceGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get source '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get source '%s': %w", name, err))
 	}
 
 	var ret sourcesResult
@@ -280,7 +280,7 @@ func sourceGet(d *Daemon, r *http.Request) response.Response {
 	case *source.InternalVMwareSource:
 		ret = sourcesResult{Type: api.SOURCETYPE_VMWARE, Source: s}
 	default:
-		return response.BadRequest(fmt.Errorf("Unsupported source type %T", s))
+		return response.BadRequest(fmt.Errorf("unsupported source type %T", s))
 	}
 
 	return response.SyncResponseETag(true, ret, s)
@@ -323,7 +323,7 @@ func sourcePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Source name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("source name cannot be empty"))
 	}
 
 	// Get the existing source.
@@ -338,7 +338,7 @@ func sourcePut(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get source '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get source '%s': %w", name, err))
 	}
 
 	// Validate ETag
@@ -358,7 +358,7 @@ func sourcePut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateSource(tx, s)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating source %q: %w", s.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed updating source %q: %w", s.GetName(), err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/sources/"+s.GetName())

--- a/cmd/migration-managerd/api_target.go
+++ b/cmd/migration-managerd/api_target.go
@@ -127,7 +127,7 @@ func targetsPost(d *Daemon, r *http.Request) response.Response {
 		return d.db.AddTarget(tx, &t)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed creating target %q: %w", t.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed creating target %q: %w", t.GetName(), err))
 	}
 
 	// Trigger a scan for new instances.
@@ -161,14 +161,14 @@ func targetDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Target name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("target name cannot be empty"))
 	}
 
 	err = d.db.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return d.db.DeleteTarget(tx, name)
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to delete target '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to delete target '%s': %w", name, err))
 	}
 
 	return response.EmptySyncResponse
@@ -215,7 +215,7 @@ func targetGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Target name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("target name cannot be empty"))
 	}
 
 	var t target.Target
@@ -229,7 +229,7 @@ func targetGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get target '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get target '%s': %w", name, err))
 	}
 
 	return response.SyncResponseETag(true, t, t)
@@ -271,7 +271,7 @@ func targetPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if name == "" {
-		return response.BadRequest(fmt.Errorf("Target name cannot be empty"))
+		return response.BadRequest(fmt.Errorf("target name cannot be empty"))
 	}
 
 	// Get the existing target.
@@ -286,7 +286,7 @@ func targetPut(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Failed to get target '%s': %w", name, err))
+		return response.BadRequest(fmt.Errorf("failed to get target '%s': %w", name, err))
 	}
 
 	// Validate ETag
@@ -306,7 +306,7 @@ func targetPut(d *Daemon, r *http.Request) response.Response {
 		return d.db.UpdateTarget(tx, t)
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating target %q: %w", t.GetName(), err))
+		return response.SmartError(fmt.Errorf("failed updating target %q: %w", t.GetName(), err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/targets/"+t.GetName())

--- a/cmd/migration-managerd/daemon.go
+++ b/cmd/migration-managerd/daemon.go
@@ -160,7 +160,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		}
 
 		if d.shutdownCtx.Err() == context.Canceled && !allowedDuringShutdown() {
-			_ = response.Unavailable(fmt.Errorf("Shutting down")).Render(w)
+			_ = response.Unavailable(fmt.Errorf("shutting down")).Render(w)
 			return
 		}
 
@@ -171,12 +171,12 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 
 			// All APIEndpointActions should have an access handler or should allow untrusted requests.
 			if action.AccessHandler == nil && !action.AllowUntrusted {
-				return response.InternalError(fmt.Errorf("Access handler not defined for %s %s", r.Method, r.URL.RequestURI()))
+				return response.InternalError(fmt.Errorf("access handler not defined for %s %s", r.Method, r.URL.RequestURI()))
 			}
 
 			// If the request is not trusted, only call the handler if the action allows it.
 			if !trusted && !action.AllowUntrusted {
-				return response.Forbidden(fmt.Errorf("You must be authenticated"))
+				return response.Forbidden(fmt.Errorf("you must be authenticated"))
 			}
 
 			// Call the access handler if there is one.
@@ -204,7 +204,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		case "PATCH":
 			resp = handleRequest(c.Patch)
 		default:
-			resp = response.NotFound(fmt.Errorf("Method %q not found", r.Method))
+			resp = response.NotFound(fmt.Errorf("method %q not found", r.Method))
 		}
 
 		// Handle errors

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -37,7 +37,7 @@ func (b *InternalBatch) GetName() string {
 
 func (b *InternalBatch) GetDatabaseID() (int, error) {
 	if b.DatabaseID == internal.INVALID_DATABASE_ID {
-		return internal.INVALID_DATABASE_ID, fmt.Errorf("Batch has not been added to database, so it doesn't have an ID")
+		return internal.INVALID_DATABASE_ID, fmt.Errorf("batch has not been added to database, so it doesn't have an ID")
 	}
 
 	return b.DatabaseID, nil

--- a/internal/db/batch.go
+++ b/internal/db/batch.go
@@ -15,7 +15,7 @@ import (
 func (n *Node) AddBatch(tx *sql.Tx, b batch.Batch) error {
 	internalBatch, ok := b.(*batch.InternalBatch)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalBatch?")
+		return fmt.Errorf("wasn't given an InternalBatch?")
 	}
 
 	// Add batch to the database.
@@ -51,7 +51,7 @@ func (n *Node) GetBatch(tx *sql.Tx, name string) (batch.Batch, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No batch exists with name '%s'", name)
+		return nil, fmt.Errorf("no batch exists with name '%s'", name)
 	}
 
 	return ret[0], nil
@@ -64,7 +64,7 @@ func (n *Node) GetBatchByID(tx *sql.Tx, id int) (batch.Batch, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No batch exists with ID '%d'", id)
+		return nil, fmt.Errorf("no batch exists with ID '%d'", id)
 	}
 
 	return ret[0], nil
@@ -81,7 +81,7 @@ func (n *Node) DeleteBatch(tx *sql.Tx, name string) error {
 		return err
 	}
 	if !dbBatch.CanBeModified() {
-		return fmt.Errorf("Cannot delete batch '%s': Currently in a migration phase", name)
+		return fmt.Errorf("cannot delete batch '%s': Currently in a migration phase", name)
 	}
 
 	// Get a list of any instances currently assigned to this batch.
@@ -97,7 +97,7 @@ func (n *Node) DeleteBatch(tx *sql.Tx, name string) error {
 	// Verify all instances for this batch aren't in a migration phase and remove their association with this batch.
 	for _, instance := range instances {
 		if instance.IsMigrating() {
-			return fmt.Errorf("Cannot delete batch '%s': At least one assigned instance is in a migration phase", name)
+			return fmt.Errorf("cannot delete batch '%s': At least one assigned instance is in a migration phase", name)
 		}
 
 		q := `UPDATE instances SET batchid=?,migrationstatus=?,migrationstatusstring=? WHERE uuid=?`
@@ -119,7 +119,7 @@ func (n *Node) DeleteBatch(tx *sql.Tx, name string) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Batch with name '%s' doesn't exist, can't delete", name)
+		return fmt.Errorf("batch with name '%s' doesn't exist, can't delete", name)
 	}
 
 	return nil
@@ -145,7 +145,7 @@ func (n *Node) UpdateBatch(tx *sql.Tx, b batch.Batch) error {
 		return err
 	}
 	if !dbBatch.CanBeModified() {
-		return fmt.Errorf("Cannot update batch '%s': Currently in a migration phase", b.GetName())
+		return fmt.Errorf("cannot update batch '%s': Currently in a migration phase", b.GetName())
 	}
 
 	// Update batch in the database.
@@ -153,7 +153,7 @@ func (n *Node) UpdateBatch(tx *sql.Tx, b batch.Batch) error {
 
 	internalBatch, ok := b.(*batch.InternalBatch)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalBatch?")
+		return fmt.Errorf("wasn't given an InternalBatch?")
 	}
 
 	marshalledMigrationWindowStart, err := internalBatch.MigrationWindowStart.MarshalText()
@@ -174,7 +174,7 @@ func (n *Node) UpdateBatch(tx *sql.Tx, b batch.Batch) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Batch with ID %d doesn't exist, can't update", internalBatch.DatabaseID)
+		return fmt.Errorf("batch with ID %d doesn't exist, can't update", internalBatch.DatabaseID)
 	}
 
 	return nil
@@ -310,12 +310,12 @@ func (n *Node) StartBatch(tx *sql.Tx, name string) error {
 
 	internalBatch, ok := b.(*batch.InternalBatch)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalBatch?")
+		return fmt.Errorf("wasn't given an InternalBatch?")
 	}
 
 	// Ensure batch is in a state that is ready to start.
 	if internalBatch.Status != api.BATCHSTATUS_DEFINED && internalBatch.Status != api.BATCHSTATUS_STOPPED && internalBatch.Status != api.BATCHSTATUS_ERROR {
-		return fmt.Errorf("Cannot start batch '%s' in its current state '%s'", internalBatch.Name, internalBatch.Status)
+		return fmt.Errorf("cannot start batch '%s' in its current state '%s'", internalBatch.Name, internalBatch.Status)
 	}
 
 	// Move batch status to "ready".
@@ -331,12 +331,12 @@ func (n *Node) StopBatch(tx *sql.Tx, name string) error {
 
 	internalBatch, ok := b.(*batch.InternalBatch)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalBatch?")
+		return fmt.Errorf("wasn't given an InternalBatch?")
 	}
 
 	// Ensure batch is in a state that is ready to stop.
 	if internalBatch.Status != api.BATCHSTATUS_READY && internalBatch.Status != api.BATCHSTATUS_QUEUED && internalBatch.Status != api.BATCHSTATUS_RUNNING {
-		return fmt.Errorf("Cannot stop batch '%s' in its current state '%s'", internalBatch.Name, internalBatch.Status)
+		return fmt.Errorf("cannot stop batch '%s' in its current state '%s'", internalBatch.Name, internalBatch.Status)
 	}
 
 	// Move batch status to "stopped".

--- a/internal/db/instance.go
+++ b/internal/db/instance.go
@@ -15,7 +15,7 @@ import (
 func (n *Node) AddInstance(tx *sql.Tx, i instance.Instance) error {
 	internalInstance, ok := i.(*instance.InternalInstance)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalInstance?")
+		return fmt.Errorf("wasn't given an InternalInstance?")
 	}
 
 	// Add instance to the database.
@@ -49,7 +49,7 @@ func (n *Node) GetInstance(tx *sql.Tx, UUID uuid.UUID) (instance.Instance, error
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No instance exists with UUID '%s'", UUID)
+		return nil, fmt.Errorf("no instance exists with UUID '%s'", UUID)
 	}
 
 	return ret[0], nil
@@ -66,7 +66,7 @@ func (n *Node) DeleteInstance(tx *sql.Tx, UUID uuid.UUID) error {
 		return err
 	}
 	if i.GetBatchID() != internal.INVALID_DATABASE_ID || i.IsMigrating() {
-		return fmt.Errorf("Cannot delete instance '%s': Either assigned to a batch or currently migrating", i.GetName())
+		return fmt.Errorf("cannot delete instance '%s': Either assigned to a batch or currently migrating", i.GetName())
 	}
 
 	// Delete the instance from the database.
@@ -81,7 +81,7 @@ func (n *Node) DeleteInstance(tx *sql.Tx, UUID uuid.UUID) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Instance with UUID '%s' doesn't exist, can't delete", UUID)
+		return fmt.Errorf("instance with UUID '%s' doesn't exist, can't delete", UUID)
 	}
 
 	return nil
@@ -107,7 +107,7 @@ func (n *Node) UpdateInstance(tx *sql.Tx, i instance.Instance) error {
 			return err
 		}
 
-		return fmt.Errorf("Cannot update instance '%s' while assigned to batch '%s'", i.GetName(), batchName)
+		return fmt.Errorf("cannot update instance '%s' while assigned to batch '%s'", i.GetName(), batchName)
 	}
 
 	// Update instance in the database.
@@ -115,7 +115,7 @@ func (n *Node) UpdateInstance(tx *sql.Tx, i instance.Instance) error {
 
 	internalInstance, ok := i.(*instance.InternalInstance)
 	if !ok {
-		return fmt.Errorf("Wasn't given an InternalInstance?")
+		return fmt.Errorf("wasn't given an InternalInstance?")
 	}
 
 	marshalledLastUpdateFromSource, err := internalInstance.LastUpdateFromSource.MarshalText()
@@ -144,7 +144,7 @@ func (n *Node) UpdateInstance(tx *sql.Tx, i instance.Instance) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Instance with UUID '%s' doesn't exist, can't update", internalInstance.UUID.String())
+		return fmt.Errorf("instance with UUID '%s' doesn't exist, can't update", internalInstance.UUID.String())
 	}
 
 	return nil

--- a/internal/db/network.go
+++ b/internal/db/network.go
@@ -38,7 +38,7 @@ func (n *Node) GetNetwork(tx *sql.Tx, name string) (api.Network, error) {
 	}
 
 	if len(ret) != 1 {
-		return api.Network{}, fmt.Errorf("No network '%s'", name)
+		return api.Network{}, fmt.Errorf("no network '%s'", name)
 	}
 
 	return ret[0], nil
@@ -61,7 +61,7 @@ func (n *Node) DeleteNetwork(tx *sql.Tx, name string) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("No network '%s' exists, can't delete", name)
+		return fmt.Errorf("no network '%s' exists, can't delete", name)
 	}
 
 	return nil
@@ -85,7 +85,7 @@ func (n *Node) UpdateNetwork(tx *sql.Tx, net api.Network) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("No network '%s' exists, can't update", net.Name)
+		return fmt.Errorf("no network '%s' exists, can't update", net.Name)
 	}
 
 	return nil

--- a/internal/db/query/transation.go
+++ b/internal/db/query/transation.go
@@ -23,7 +23,7 @@ func Transaction(ctx context.Context, db *sql.DB, f func(context.Context, *sql.T
 			_, _ = db.Exec("ROLLBACK")
 		}
 
-		return fmt.Errorf("Failed to begin transaction: %w", err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
 	err = f(ctx, tx)

--- a/internal/db/schema/schema.go
+++ b/internal/db/schema/schema.go
@@ -249,7 +249,7 @@ func checkSchemaVersionsHaveNoHoles(versions []int) error {
 	// Ensure that there are no "holes" in the recorded versions.
 	for i := range versions[:len(versions)-1] {
 		if versions[i+1] != versions[i]+1 {
-			return fmt.Errorf("Missing updates: %d to %d", versions[i], versions[i+1])
+			return fmt.Errorf("missing updates: %d to %d", versions[i], versions[i+1])
 		}
 	}
 	return nil

--- a/internal/db/source.go
+++ b/internal/db/source.go
@@ -31,7 +31,7 @@ func (n *Node) AddSource(tx *sql.Tx, s source.Source) error {
 		configString = string(marshalled)
 		isInsecure = specificSource.Insecure
 	default:
-		return fmt.Errorf("Can only add a Common or VMware source")
+		return fmt.Errorf("can only add a Common or VMware source")
 	}
 
 	result, err := tx.Exec(q, s.GetName(), sourceType, isInsecure, configString)
@@ -61,7 +61,7 @@ func (n *Node) GetSource(tx *sql.Tx, name string) (source.Source, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No source exists with name '%s'", name)
+		return nil, fmt.Errorf("no source exists with name '%s'", name)
 	}
 
 	return ret[0], nil
@@ -74,7 +74,7 @@ func (n *Node) GetSourceByID(tx *sql.Tx, id int) (source.Source, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No source exists with ID '%d'", id)
+		return nil, fmt.Errorf("no source exists with ID '%d'", id)
 	}
 
 	return ret[0], nil
@@ -118,7 +118,7 @@ func (n *Node) DeleteSource(tx *sql.Tx, name string) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Source with name '%s' doesn't exist, can't delete", name)
+		return fmt.Errorf("source with name '%s' doesn't exist, can't delete", name)
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func (n *Node) UpdateSource(tx *sql.Tx, s source.Source) error {
 		configString = string(marshalled)
 		isInsecure = specificSource.Insecure
 	default:
-		return fmt.Errorf("Can only update a Common or VMware source")
+		return fmt.Errorf("can only update a Common or VMware source")
 	}
 
 	id, err := s.GetDatabaseID()
@@ -159,7 +159,7 @@ func (n *Node) UpdateSource(tx *sql.Tx, s source.Source) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Source with ID %d doesn't exist, can't update", id)
+		return fmt.Errorf("source with ID %d doesn't exist, can't update", id)
 	}
 
 	return nil
@@ -215,7 +215,7 @@ func (n *Node) getSourcesHelper(tx *sql.Tx, name string, id int) ([]source.Sourc
 			newSource.Insecure = sourceInsecure
 			ret = append(ret, newSource)
 		default:
-			return nil, fmt.Errorf("Unknown source type %d", sourceType)
+			return nil, fmt.Errorf("unknown source type %d", sourceType)
 		}
 	}
 

--- a/internal/db/target.go
+++ b/internal/db/target.go
@@ -12,7 +12,7 @@ import (
 func (n *Node) AddTarget(tx *sql.Tx, t target.Target) error {
 	incusTarget, ok := t.(*target.InternalIncusTarget)
 	if !ok {
-		return fmt.Errorf("Only Incus targets are supported")
+		return fmt.Errorf("only Incus targets are supported")
 	}
 
 	// Add target to the database.
@@ -44,7 +44,7 @@ func (n *Node) GetTarget(tx *sql.Tx, name string) (target.Target, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No target exists with name '%s'", name)
+		return nil, fmt.Errorf("no target exists with name '%s'", name)
 	}
 
 	return ret[0], nil
@@ -57,7 +57,7 @@ func (n *Node) GetTargetByID(tx *sql.Tx, id int) (target.Target, error) {
 	}
 
 	if len(ret) != 1 {
-		return nil, fmt.Errorf("No target exists with ID '%d'", id)
+		return nil, fmt.Errorf("no target exists with ID '%d'", id)
 	}
 
 	return ret[0], nil
@@ -101,7 +101,7 @@ func (n *Node) DeleteTarget(tx *sql.Tx, name string) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Target with name '%s' doesn't exist, can't delete", name)
+		return fmt.Errorf("target with name '%s' doesn't exist, can't delete", name)
 	}
 
 	return nil
@@ -113,7 +113,7 @@ func (n *Node) UpdateTarget(tx *sql.Tx, t target.Target) error {
 
 	incusTarget, ok := t.(*target.InternalIncusTarget)
 	if !ok {
-		return fmt.Errorf("Only Incus targets are supported")
+		return fmt.Errorf("only Incus targets are supported")
 	}
 
 	id, err := t.GetDatabaseID()
@@ -134,7 +134,7 @@ func (n *Node) UpdateTarget(tx *sql.Tx, t target.Target) error {
 		return err
 	}
 	if affectedRows == 0 {
-		return fmt.Errorf("Target with ID %d doesn't exist, can't update", id)
+		return fmt.Errorf("target with ID %d doesn't exist, can't update", id)
 	}
 
 	return nil

--- a/internal/server/endpoint/endpoint.go
+++ b/internal/server/endpoint/endpoint.go
@@ -36,7 +36,7 @@ type Endpoint struct {
 
 func Up(config *Config) (*Endpoint, error) {
 	if config.RestServer == nil {
-		return nil, fmt.Errorf("No REST server configured")
+		return nil, fmt.Errorf("no REST server configured")
 	}
 
 	if config.Config == nil {
@@ -64,7 +64,7 @@ func (e *Endpoint) up(config *Config) error {
 
 	e.listener, err = networkCreateListener(config.NetworkAddress, config.NetworkPort, e.tlsConfig)
 	if err != nil {
-		return fmt.Errorf("Failed to create listener: %s", err)
+		return fmt.Errorf("failed to create listener: %s", err)
 	}
 
 	logger.Info("Binding socket", logger.Ctx{"socket": e.listener.Addr()})

--- a/internal/source/common.go
+++ b/internal/source/common.go
@@ -28,16 +28,16 @@ func NewCommonSource(name string) *InternalCommonSource {
 }
 
 func (s *InternalCommonSource) Connect(ctx context.Context) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("not implemented by CommonSource")
 }
 
 func (s *InternalCommonSource) Disconnect(ctx context.Context) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("not implemented by CommonSource")
 }
 
 func (s *InternalCommonSource) SetInsecureTLS(insecure bool) error {
 	if s.isConnected {
-		return fmt.Errorf("Cannot change insecure TLS setting after connecting")
+		return fmt.Errorf("cannot change insecure TLS setting after connecting")
 	}
 
 	s.Insecure = insecure
@@ -54,24 +54,24 @@ func (s *InternalCommonSource) GetName() string {
 
 func (s *InternalCommonSource) GetDatabaseID() (int, error) {
 	if s.DatabaseID == internal.INVALID_DATABASE_ID {
-		return internal.INVALID_DATABASE_ID, fmt.Errorf("Source has not been added to database, so it doesn't have an ID")
+		return internal.INVALID_DATABASE_ID, fmt.Errorf("source has not been added to database, so it doesn't have an ID")
 	}
 
 	return s.DatabaseID, nil
 }
 
 func (s *InternalCommonSource) GetAllVMs(ctx context.Context) ([]instance.InternalInstance, error) {
-	return nil, fmt.Errorf("Not implemented by CommonSource")
+	return nil, fmt.Errorf("not implemented by CommonSource")
 }
 
 func (s *InternalCommonSource) GetAllNetworks(ctx context.Context) ([]api.Network, error) {
-	return nil, fmt.Errorf("Not implemented by CommonSource")
+	return nil, fmt.Errorf("not implemented by CommonSource")
 }
 
 func (s *InternalCommonSource) DeleteVMSnapshot(ctx context.Context, vmName string, snapshotName string) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("not implemented by CommonSource")
 }
 
 func (s *InternalCommonSource) ImportDisks(ctx context.Context, vmName string, statusCallback func(string)) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("not implemented by CommonSource")
 }

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -60,7 +60,7 @@ func NewVMwareSource(name string, endpoint string, username string, password str
 
 func (s *InternalVMwareSource) Connect(ctx context.Context) error {
 	if s.isConnected {
-		return fmt.Errorf("Already connected to endpoint '%s'", s.Endpoint)
+		return fmt.Errorf("already connected to endpoint '%s'", s.Endpoint)
 	}
 
 	endpointURL, err := soap.ParseURL(s.Endpoint)
@@ -93,7 +93,7 @@ func (s *InternalVMwareSource) Connect(ctx context.Context) error {
 
 func (s *InternalVMwareSource) Disconnect(ctx context.Context) error {
 	if !s.isConnected {
-		return fmt.Errorf("Not connected to endpoint '%s'", s.Endpoint)
+		return fmt.Errorf("not connected to endpoint '%s'", s.Endpoint)
 	}
 
 	err := s.govmomiClient.Logout(ctx)

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lxc/incus/v6/client"
+	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/revert"
 
@@ -47,7 +47,7 @@ func NewIncusTarget(name string, endpoint string, storagePool string, bootISOIma
 
 func (t *InternalIncusTarget) Connect(ctx context.Context) error {
 	if t.isConnected {
-		return fmt.Errorf("Already connected to endpoint '%s'", t.Endpoint)
+		return fmt.Errorf("already connected to endpoint '%s'", t.Endpoint)
 	}
 
 	authType := api.AuthenticationMethodTLS
@@ -65,7 +65,7 @@ func (t *InternalIncusTarget) Connect(ctx context.Context) error {
 	client, err := incus.ConnectIncusWithContext(ctx, t.Endpoint, t.incusConnectionArgs)
 	if err != nil {
 		t.incusConnectionArgs = nil
-		return fmt.Errorf("Failed to connect to endpoint '%s': %s", t.Endpoint, err)
+		return fmt.Errorf("failed to connect to endpoint '%s': %s", t.Endpoint, err)
 	}
 	t.incusClient = client.UseProject(t.IncusProject)
 
@@ -74,14 +74,14 @@ func (t *InternalIncusTarget) Connect(ctx context.Context) error {
 	if srv.Auth != "trusted" {
 		t.incusConnectionArgs = nil
 		t.incusClient = nil
-		return fmt.Errorf("Failed to connect to endpoint '%s': not authorized", t.Endpoint)
+		return fmt.Errorf("failed to connect to endpoint '%s': not authorized", t.Endpoint)
 	}
 
 	// Save the OIDC tokens.
 	if authType == api.AuthenticationMethodOIDC {
 		pi, ok := t.incusClient.(*incus.ProtocolIncus)
 		if !ok {
-			return fmt.Errorf("Server != ProtocolIncus")
+			return fmt.Errorf("server != ProtocolIncus")
 		}
 
 		t.OIDCTokens = pi.GetOIDCTokens()
@@ -93,7 +93,7 @@ func (t *InternalIncusTarget) Connect(ctx context.Context) error {
 
 func (t *InternalIncusTarget) Disconnect(ctx context.Context) error {
 	if !t.isConnected {
-		return fmt.Errorf("Not connected to endpoint '%s'", t.Endpoint)
+		return fmt.Errorf("not connected to endpoint '%s'", t.Endpoint)
 	}
 
 	t.incusClient.Disconnect()
@@ -106,7 +106,7 @@ func (t *InternalIncusTarget) Disconnect(ctx context.Context) error {
 
 func (t *InternalIncusTarget) SetInsecureTLS(insecure bool) error {
 	if t.isConnected {
-		return fmt.Errorf("Cannot change insecure TLS setting after connecting")
+		return fmt.Errorf("cannot change insecure TLS setting after connecting")
 	}
 
 	t.Insecure = insecure
@@ -115,7 +115,7 @@ func (t *InternalIncusTarget) SetInsecureTLS(insecure bool) error {
 
 func (t *InternalIncusTarget) SetClientTLSCredentials(key string, cert string) error {
 	if t.isConnected {
-		return fmt.Errorf("Cannot change client TLS key/cert after connecting")
+		return fmt.Errorf("cannot change client TLS key/cert after connecting")
 	}
 
 	t.TLSClientKey = key
@@ -133,7 +133,7 @@ func (t *InternalIncusTarget) GetName() string {
 
 func (t *InternalIncusTarget) GetDatabaseID() (int, error) {
 	if t.DatabaseID == internal.INVALID_DATABASE_ID {
-		return internal.INVALID_DATABASE_ID, fmt.Errorf("Target has not been added to database, so it doesn't have an ID")
+		return internal.INVALID_DATABASE_ID, fmt.Errorf("target has not been added to database, so it doesn't have an ID")
 	}
 
 	return t.DatabaseID, nil
@@ -141,7 +141,7 @@ func (t *InternalIncusTarget) GetDatabaseID() (int, error) {
 
 func (t *InternalIncusTarget) SetProject(project string) error {
 	if !t.isConnected {
-		return fmt.Errorf("Cannot change project before connecting")
+		return fmt.Errorf("cannot change project before connecting")
 	}
 
 	t.IncusProject = project

--- a/internal/util/table.go
+++ b/internal/util/table.go
@@ -79,7 +79,7 @@ func RenderTable(format string, header []string, data [][]string, raw any) error
 
 		fmt.Printf("%s", out)
 	default:
-		return fmt.Errorf("Invalid format %q", format)
+		return fmt.Errorf("invalid format %q", format)
 	}
 
 	return nil

--- a/internal/worker/linux.go
+++ b/internal/worker/linux.go
@@ -166,7 +166,7 @@ func determineRootPartition() (string, int, []string, error) {
 		}
 	}
 
-	return "", PARTITION_TYPE_UNKNOWN, nil, fmt.Errorf("Failed to determine the root partition")
+	return "", PARTITION_TYPE_UNKNOWN, nil, fmt.Errorf("failed to determine the root partition")
 }
 
 func runScriptInChroot(scriptName string) error {
@@ -274,5 +274,5 @@ func getBTRFSTopSubvol(partition string) (string, error) {
 		return submatch[1], nil
 	}
 
-	return "", fmt.Errorf("Unable to determine top level subvolume for partition %s", partition)
+	return "", fmt.Errorf("unable to determine top level subvolume for partition %s", partition)
 }

--- a/internal/worker/util.go
+++ b/internal/worker/util.go
@@ -15,7 +15,7 @@ func DoMount(device string, path string, options []string) error {
 	if !util.PathExists(path) {
 		err := os.MkdirAll(path, 0o755)
 		if err != nil {
-			return fmt.Errorf("Failed to create mount target %q", path)
+			return fmt.Errorf("failed to create mount target %q", path)
 		}
 	}
 
@@ -36,7 +36,7 @@ func DoMount(device string, path string, options []string) error {
 		// Attempt to fix the NTFS partition.
 		_, err = subprocess.RunCommand("ntfsfix", device)
 		if err != nil {
-			return fmt.Errorf("NTFS partition %s contains an unclean file system; running `ntfsfix` failed. Please cleanly shutdown the source VM, then re-try migration.", device)
+			return fmt.Errorf("detected NTFS partition %s contains an unclean file system; running `ntfsfix` failed. Please cleanly shutdown the source VM, then re-try migration", device)
 		}
 
 		// Mount the clean NTFS partition.


### PR DESCRIPTION
@gibmat let us discuss this. Capitalized error messages are not a best practice in go, see: https://go.dev/wiki/CodeReviewComments#error-strings

But I understand, that the errors in some situations are returned to the user through the API and there the error should be capitalized for the user. Maybe we can add a capitalize call before we use the message of an error as the error message, that is returned in the API, to compensate for this.