### PR TITLE
Set 'LastUpdate' field for instance overrides in daemon logic

### DIFF
--- a/cmd/migration-manager/cmds/instance_override.go
+++ b/cmd/migration-manager/cmds/instance_override.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/lxc/incus/v6/shared/units"
@@ -115,8 +114,6 @@ func (c *cmdInstanceOverrideAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	override.MemoryInBytes, _ = units.ParseByteSizeString(memoryString)
-
-	override.LastUpdate = time.Now().UTC()
 
 	// Insert into database.
 	content, err := json.Marshal(override)
@@ -319,8 +316,6 @@ func (c *cmdInstanceOverrideUpdate) Run(cmd *cobra.Command, args []string) error
 	if override.MemoryInBytes != val {
 		override.MemoryInBytes = val
 	}
-
-	override.LastUpdate = time.Now().UTC()
 
 	content, err := json.Marshal(override)
 	if err != nil {

--- a/cmd/migration-managerd/api/api_instance.go
+++ b/cmd/migration-managerd/api/api_instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -371,7 +372,7 @@ func instanceOverridePost(d *Daemon, r *http.Request) response.Response {
 
 	_, err = d.instance.CreateOverrides(r.Context(), migration.Overrides{
 		UUID:             override.UUID,
-		LastUpdate:       override.LastUpdate,
+		LastUpdate:       time.Now().UTC(),
 		Comment:          override.Comment,
 		NumberCPUs:       override.NumberCPUs,
 		MemoryInBytes:    override.MemoryInBytes,
@@ -450,7 +451,7 @@ func instanceOverridePut(d *Daemon, r *http.Request) response.Response {
 
 	_, err = d.instance.UpdateOverridesByID(ctx, migration.Overrides{
 		UUID:             override.UUID,
-		LastUpdate:       override.LastUpdate,
+		LastUpdate:       time.Now().UTC(),
 		Comment:          override.Comment,
 		NumberCPUs:       override.NumberCPUs,
 		MemoryInBytes:    override.MemoryInBytes,


### PR DESCRIPTION
Similar to #65. Updating the `LastUpdate` field should be the responsibility of the daemon.