### PR TITLE
ui: Wrap tables in a scroll view

### DIFF
--- a/ui/src/pages/Batch.tsx
+++ b/ui/src/pages/Batch.tsx
@@ -72,7 +72,11 @@ const Batch = () => {
           </div>
         </div>
       </div>
-      <DataTable headers={headers} rows={rows} />
+      <div className="d-flex flex-column">
+        <div className="scroll-container flex-grow-1 p-3">
+          <DataTable headers={headers} rows={rows} />
+        </div>
+      </div>
     </>
   );
 };

--- a/ui/src/pages/Instance.tsx
+++ b/ui/src/pages/Instance.tsx
@@ -21,7 +21,13 @@ const Instance = () => {
     );
   }
 
-  return <InstanceDataTable instances={instances} />;
+  return (
+    <div className="d-flex flex-column">
+      <div className="scroll-container flex-grow-1 p-3">
+        <InstanceDataTable instances={instances} />
+      </div>
+    </div>
+  );
 };
 
 export default Instance;

--- a/ui/src/pages/Queue.tsx
+++ b/ui/src/pages/Queue.tsx
@@ -43,7 +43,13 @@ const Queue = () => {
     );
   }
 
-  return <DataTable headers={headers} rows={rows} />;
+  return (
+    <div className="d-flex flex-column">
+      <div className="scroll-container flex-grow-1 p-3">
+        <DataTable headers={headers} rows={rows} />
+      </div>
+    </div>
+  );
 };
 
 export default Queue

--- a/ui/src/pages/Source.tsx
+++ b/ui/src/pages/Source.tsx
@@ -54,7 +54,13 @@ const Source = () => {
     );
   }
 
-  return <DataTable headers={headers} rows={rows} />;
+  return (
+    <div className="d-flex flex-column">
+      <div className="scroll-container flex-grow-1 p-3">
+        <DataTable headers={headers} rows={rows} />
+      </div>
+    </div>
+  );
 };
 
 export default Source;

--- a/ui/src/pages/Target.tsx
+++ b/ui/src/pages/Target.tsx
@@ -43,7 +43,13 @@ const Target = () => {
     );
   }
 
-  return <DataTable headers={headers} rows={rows} />;
+  return (
+    <div className="d-flex flex-column">
+      <div className="scroll-container flex-grow-1 p-3">
+        <DataTable headers={headers} rows={rows} />
+      </div>
+    </div>
+  );
 };
 
 export default Target;


### PR DESCRIPTION
This change wraps tables in a scroll view to ensure they remain confined within the viewport. By doing so, we avoid tables extending beyond the visible area, improving layout consistency and usability, especially for large tables.