### PR TITLE
Move most Source and Target properties into type-specific structs

### DIFF
--- a/cmd/migration-manager/internal/cmds/instance.go
+++ b/cmd/migration-manager/internal/cmds/instance.go
@@ -106,7 +106,7 @@ func (c *cmdInstanceList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get nice names for the targets.
-	targets := []api.IncusTarget{}
+	targets := []api.Target{}
 	targetsMap := make(map[int]string)
 	resp, err = c.global.doHTTPRequestV1("/targets", http.MethodGet, "recursion=1", nil)
 	if err != nil {

--- a/cmd/migration-managerd/internal/api/api_queue.go
+++ b/cmd/migration-managerd/internal/api/api_queue.go
@@ -306,7 +306,6 @@ func queueWorkerGet(d *Daemon, r *http.Request) response.Response {
 	apiSource := api.Source{
 		DatabaseID: workerCommand.Source.ID,
 		Name:       workerCommand.Source.Name,
-		Insecure:   workerCommand.Source.Insecure,
 		SourceType: workerCommand.Source.SourceType,
 		Properties: workerCommand.Source.Properties,
 	}

--- a/cmd/migration-managerd/internal/api/api_source.go
+++ b/cmd/migration-managerd/internal/api/api_source.go
@@ -127,7 +127,6 @@ func sourcesGet(d *Daemon, r *http.Request) response.Response {
 			result = append(result, api.Source{
 				DatabaseID: source.ID,
 				Name:       source.Name,
-				Insecure:   source.Insecure,
 				SourceType: source.SourceType,
 				Properties: source.Properties,
 			})
@@ -186,7 +185,6 @@ func sourcesPost(d *Daemon, r *http.Request) response.Response {
 
 	_, err = d.source.Create(r.Context(), migration.Source{
 		Name:       source.Name,
-		Insecure:   source.Insecure,
 		SourceType: source.SourceType,
 		Properties: source.Properties,
 	})
@@ -276,7 +274,6 @@ func sourceGet(d *Daemon, r *http.Request) response.Response {
 		api.Source{
 			DatabaseID: source.ID,
 			Name:       source.Name,
-			Insecure:   source.Insecure,
 			SourceType: source.SourceType,
 			Properties: source.Properties,
 		},
@@ -345,7 +342,6 @@ func sourcePut(d *Daemon, r *http.Request) response.Response {
 	_, err = d.source.UpdateByID(ctx, migration.Source{
 		ID:         currentSource.ID,
 		Name:       source.Name,
-		Insecure:   source.Insecure,
 		SourceType: source.SourceType,
 		Properties: source.Properties,
 	})

--- a/cmd/migration-managerd/internal/api/api_target.go
+++ b/cmd/migration-managerd/internal/api/api_target.go
@@ -122,16 +122,13 @@ func targetsGet(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		result := make([]api.IncusTarget, 0, len(targets))
+		result := make([]api.Target, 0, len(targets))
 		for _, target := range targets {
-			result = append(result, api.IncusTarget{
-				DatabaseID:    target.ID,
-				Name:          target.Name,
-				Endpoint:      target.Endpoint,
-				TLSClientKey:  target.TLSClientKey,
-				TLSClientCert: target.TLSClientCert,
-				OIDCTokens:    target.OIDCTokens,
-				Insecure:      target.Insecure,
+			result = append(result, api.Target{
+				DatabaseID: target.ID,
+				Name:       target.Name,
+				TargetType: target.TargetType,
+				Properties: target.Properties,
 			})
 		}
 
@@ -179,7 +176,7 @@ func targetsGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func targetsPost(d *Daemon, r *http.Request) response.Response {
-	var target api.IncusTarget
+	var target api.Target
 
 	// Decode into the new target.
 	err := json.NewDecoder(r.Body).Decode(&target)
@@ -188,12 +185,9 @@ func targetsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	_, err = d.target.Create(r.Context(), migration.Target{
-		Name:          target.Name,
-		Endpoint:      target.Endpoint,
-		TLSClientKey:  target.TLSClientKey,
-		TLSClientCert: target.TLSClientCert,
-		OIDCTokens:    target.OIDCTokens,
-		Insecure:      target.Insecure,
+		Name:       target.Name,
+		TargetType: target.TargetType,
+		Properties: target.Properties,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed creating target %q: %w", target.Name, err))
@@ -275,14 +269,11 @@ func targetGet(d *Daemon, r *http.Request) response.Response {
 
 	return response.SyncResponseETag(
 		true,
-		api.IncusTarget{
-			DatabaseID:    target.ID,
-			Name:          target.Name,
-			Endpoint:      target.Endpoint,
-			TLSClientKey:  target.TLSClientKey,
-			TLSClientCert: target.TLSClientCert,
-			OIDCTokens:    target.OIDCTokens,
-			Insecure:      target.Insecure,
+		api.Target{
+			DatabaseID: target.ID,
+			Name:       target.Name,
+			TargetType: target.TargetType,
+			Properties: target.Properties,
 		},
 		target,
 	)
@@ -320,7 +311,7 @@ func targetGet(d *Daemon, r *http.Request) response.Response {
 func targetPut(d *Daemon, r *http.Request) response.Response {
 	name := r.PathValue("name")
 
-	var target api.IncusTarget
+	var target api.Target
 
 	err := json.NewDecoder(r.Body).Decode(&target)
 	if err != nil {
@@ -347,13 +338,10 @@ func targetPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	_, err = d.target.UpdateByID(ctx, migration.Target{
-		ID:            currentTarget.ID,
-		Name:          target.Name,
-		Endpoint:      target.Endpoint,
-		TLSClientKey:  target.TLSClientKey,
-		TLSClientCert: target.TLSClientCert,
-		OIDCTokens:    target.OIDCTokens,
-		Insecure:      target.Insecure,
+		ID:         currentTarget.ID,
+		Name:       target.Name,
+		TargetType: target.TargetType,
+		Properties: target.Properties,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating target %q: %w", target.Name, err))

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -77,7 +77,6 @@ CREATE TABLE sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     source_type INTEGER NOT NULL,
-    insecure BOOLEAN,
     properties TEXT NOT NULL,
     UNIQUE (name)
 );
@@ -85,11 +84,8 @@ CREATE TABLE sources (
 CREATE TABLE targets (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    endpoint VARCHAR(255) NOT NULL,
-    tls_client_key TEXT NOT NULL,
-    tls_client_cert TEXT NOT NULL,
-    oidc_tokens TEXT NOT NULL,
-    insecure BOOLEAN,
+    target_type INTEGER NOT NULL,
+    properties TEXT NOT NULL,
     UNIQUE (name)
 );
 
@@ -194,7 +190,6 @@ CREATE TABLE sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     source_type INTEGER NOT NULL,
-    insecure BOOLEAN,
     properties TEXT NOT NULL,
     UNIQUE (name)
 );
@@ -202,11 +197,8 @@ CREATE TABLE sources (
 CREATE TABLE targets (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    endpoint VARCHAR(255) NOT NULL,
-    tls_client_key TEXT NOT NULL,
-    tls_client_cert TEXT NOT NULL,
-    oidc_tokens TEXT NOT NULL,
-    insecure BOOLEAN,
+    target_type INTEGER NOT NULL,
+    properties TEXT NOT NULL,
     UNIQUE (name)
 );
 `

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -76,9 +76,9 @@ CREATE TABLE networks (
 CREATE TABLE sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    type INTEGER NOT NULL,
+    source_type INTEGER NOT NULL,
     insecure BOOLEAN,
-    config TEXT NOT NULL,
+    properties TEXT NOT NULL,
     UNIQUE (name)
 );
 
@@ -193,9 +193,9 @@ CREATE TABLE networks (
 CREATE TABLE sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
-    type INTEGER NOT NULL,
+    source_type INTEGER NOT NULL,
     insecure BOOLEAN,
-    config TEXT NOT NULL,
+    properties TEXT NOT NULL,
     UNIQUE (name)
 );
 

--- a/internal/migration/repo/sqlite/instance_test.go
+++ b/internal/migration/repo/sqlite/instance_test.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	testSource    = migration.Source{Name: "TestSource", SourceType: api.SOURCETYPE_COMMON, Properties: []byte(`{}`)}
-	testTarget    = migration.Target{Name: "TestTarget", Endpoint: "https://localhost:6443"}
+	testTarget    = migration.Target{Name: "TestTarget", TargetType: api.TARGETTYPE_INCUS, Properties: []byte(`{"endpoint": "https://localhost:6443"}`)}
 	testBatch     = migration.Batch{ID: 1, Name: "TestBatch", TargetID: 1, StoragePool: "", IncludeExpression: "true", MigrationWindowStart: time.Time{}, MigrationWindowEnd: time.Time{}}
 	instanceAUUID = uuid.Must(uuid.NewRandom())
 

--- a/internal/migration/repo/sqlite/source.go
+++ b/internal/migration/repo/sqlite/source.go
@@ -22,16 +22,16 @@ func NewSource(db repo.DBTX) *source {
 
 func (s source) Create(ctx context.Context, in migration.Source) (migration.Source, error) {
 	const sqlInsert = `
-INSERT INTO sources (name, type, insecure, config)
-VALUES(:name, :type, :insecure, :config)
-RETURNING id, name, type, insecure, config;
+INSERT INTO sources (name, source_type, insecure, properties)
+VALUES(:name, :source_type, :insecure, :properties)
+RETURNING id, name, source_type, insecure, properties;
 `
 
 	row := s.db.QueryRowContext(ctx, sqlInsert,
 		sql.Named("name", in.Name),
-		sql.Named("type", in.SourceType),
+		sql.Named("source_type", in.SourceType),
 		sql.Named("insecure", in.Insecure),
-		sql.Named("config", in.Properties),
+		sql.Named("properties", in.Properties),
 	)
 	if row.Err() != nil {
 		return migration.Source{}, mapErr(row.Err())
@@ -41,7 +41,7 @@ RETURNING id, name, type, insecure, config;
 }
 
 func (s source) GetAll(ctx context.Context) (migration.Sources, error) {
-	const sqlGetAll = `SELECT id, name, type, insecure, config FROM sources ORDER BY name;`
+	const sqlGetAll = `SELECT id, name, source_type, insecure, properties FROM sources ORDER BY name;`
 
 	rows, err := s.db.QueryContext(ctx, sqlGetAll)
 	if err != nil {
@@ -96,7 +96,7 @@ func (s source) GetAllNames(ctx context.Context) ([]string, error) {
 }
 
 func (s source) GetByID(ctx context.Context, id int) (migration.Source, error) {
-	const sqlGetByID = `SELECT id, name, type, insecure, config FROM sources WHERE id=:id;`
+	const sqlGetByID = `SELECT id, name, source_type, insecure, properties FROM sources WHERE id=:id;`
 
 	row := s.db.QueryRowContext(ctx, sqlGetByID, sql.Named("id", id))
 	if row.Err() != nil {
@@ -107,7 +107,7 @@ func (s source) GetByID(ctx context.Context, id int) (migration.Source, error) {
 }
 
 func (s source) GetByName(ctx context.Context, name string) (migration.Source, error) {
-	const sqlGetByName = `SELECT id, name, type, insecure, config FROM sources WHERE name=:name;`
+	const sqlGetByName = `SELECT id, name, source_type, insecure, properties FROM sources WHERE name=:name;`
 
 	row := s.db.QueryRowContext(ctx, sqlGetByName, sql.Named("name", name))
 	if row.Err() != nil {
@@ -119,16 +119,16 @@ func (s source) GetByName(ctx context.Context, name string) (migration.Source, e
 
 func (s source) UpdateByID(ctx context.Context, in migration.Source) (migration.Source, error) {
 	const sqlUpdate = `
-UPDATE sources SET name=:name, insecure=:insecure, type=:type, config=:config
+UPDATE sources SET name=:name, insecure=:insecure, source_type=:source_type, properties=:properties
 WHERE id=:id
-RETURNING id, name, type, insecure, config;
+RETURNING id, name, source_type, insecure, properties;
 `
 
 	row := s.db.QueryRowContext(ctx, sqlUpdate,
 		sql.Named("name", in.Name),
-		sql.Named("type", in.SourceType),
+		sql.Named("source_type", in.SourceType),
 		sql.Named("insecure", in.Insecure),
-		sql.Named("config", in.Properties),
+		sql.Named("properties", in.Properties),
 		sql.Named("id", in.ID),
 	)
 	if row.Err() != nil {

--- a/internal/migration/repo/sqlite/source.go
+++ b/internal/migration/repo/sqlite/source.go
@@ -22,15 +22,14 @@ func NewSource(db repo.DBTX) *source {
 
 func (s source) Create(ctx context.Context, in migration.Source) (migration.Source, error) {
 	const sqlInsert = `
-INSERT INTO sources (name, source_type, insecure, properties)
-VALUES(:name, :source_type, :insecure, :properties)
-RETURNING id, name, source_type, insecure, properties;
+INSERT INTO sources (name, source_type, properties)
+VALUES(:name, :source_type, :properties)
+RETURNING id, name, source_type, properties;
 `
 
 	row := s.db.QueryRowContext(ctx, sqlInsert,
 		sql.Named("name", in.Name),
 		sql.Named("source_type", in.SourceType),
-		sql.Named("insecure", in.Insecure),
 		sql.Named("properties", in.Properties),
 	)
 	if row.Err() != nil {
@@ -41,7 +40,7 @@ RETURNING id, name, source_type, insecure, properties;
 }
 
 func (s source) GetAll(ctx context.Context) (migration.Sources, error) {
-	const sqlGetAll = `SELECT id, name, source_type, insecure, properties FROM sources ORDER BY name;`
+	const sqlGetAll = `SELECT id, name, source_type, properties FROM sources ORDER BY name;`
 
 	rows, err := s.db.QueryContext(ctx, sqlGetAll)
 	if err != nil {
@@ -96,7 +95,7 @@ func (s source) GetAllNames(ctx context.Context) ([]string, error) {
 }
 
 func (s source) GetByID(ctx context.Context, id int) (migration.Source, error) {
-	const sqlGetByID = `SELECT id, name, source_type, insecure, properties FROM sources WHERE id=:id;`
+	const sqlGetByID = `SELECT id, name, source_type, properties FROM sources WHERE id=:id;`
 
 	row := s.db.QueryRowContext(ctx, sqlGetByID, sql.Named("id", id))
 	if row.Err() != nil {
@@ -107,7 +106,7 @@ func (s source) GetByID(ctx context.Context, id int) (migration.Source, error) {
 }
 
 func (s source) GetByName(ctx context.Context, name string) (migration.Source, error) {
-	const sqlGetByName = `SELECT id, name, source_type, insecure, properties FROM sources WHERE name=:name;`
+	const sqlGetByName = `SELECT id, name, source_type, properties FROM sources WHERE name=:name;`
 
 	row := s.db.QueryRowContext(ctx, sqlGetByName, sql.Named("name", name))
 	if row.Err() != nil {
@@ -119,15 +118,14 @@ func (s source) GetByName(ctx context.Context, name string) (migration.Source, e
 
 func (s source) UpdateByID(ctx context.Context, in migration.Source) (migration.Source, error) {
 	const sqlUpdate = `
-UPDATE sources SET name=:name, insecure=:insecure, source_type=:source_type, properties=:properties
+UPDATE sources SET name=:name, source_type=:source_type, properties=:properties
 WHERE id=:id
-RETURNING id, name, source_type, insecure, properties;
+RETURNING id, name, source_type, properties;
 `
 
 	row := s.db.QueryRowContext(ctx, sqlUpdate,
 		sql.Named("name", in.Name),
 		sql.Named("source_type", in.SourceType),
-		sql.Named("insecure", in.Insecure),
 		sql.Named("properties", in.Properties),
 		sql.Named("id", in.ID),
 	)
@@ -144,7 +142,6 @@ func scanSource(row interface{ Scan(dest ...any) error }) (migration.Source, err
 		&source.ID,
 		&source.Name,
 		&source.SourceType,
-		&source.Insecure,
 		&source.Properties,
 	)
 	if err != nil {

--- a/internal/migration/repo/sqlite/source_test.go
+++ b/internal/migration/repo/sqlite/source_test.go
@@ -119,13 +119,13 @@ func TestSourceDatabaseActions(t *testing.T) {
 func newVMwareSource(name string, insecure bool, endpoint string, user string, password string) migration.Source {
 	vmwareProperties := api.VMwareProperties{
 		Endpoint: endpoint,
+		Insecure: insecure,
 		Username: user,
 		Password: password,
 	}
 
 	src := migration.Source{
 		Name:       name,
-		Insecure:   insecure,
 		SourceType: api.SOURCETYPE_VMWARE,
 	}
 

--- a/internal/migration/source_model.go
+++ b/internal/migration/source_model.go
@@ -10,7 +10,6 @@ import (
 type Source struct {
 	ID         int
 	Name       string
-	Insecure   bool
 	SourceType api.SourceType
 
 	Properties json.RawMessage

--- a/internal/migration/source_service_test.go
+++ b/internal/migration/source_service_test.go
@@ -27,16 +27,14 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 			repoCreateSource: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: require.NoError,
@@ -46,24 +44,24 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "endpoint.url",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
 			repoCreateSource: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "endpoint.url",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -75,9 +73,8 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         -1, // invalid
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -90,9 +87,8 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "", // empty
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -105,9 +101,8 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SourceType(-1), // invalid
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -120,7 +115,6 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
 				Properties: nil, // nil
 			},
@@ -135,7 +129,6 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
 				Properties: json.RawMessage(`{`), // invalid json
 			},
@@ -150,7 +143,6 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{`), // invalid json
 			},
@@ -165,12 +157,12 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": ":|\\",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -185,12 +177,12 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "enpoint.url",
   "username": "",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -205,12 +197,12 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "enpoint.url",
   "username": "user",
-  "password": ""
+  "password": "",
+  "insecure": false
 }
 `),
 			},
@@ -225,9 +217,8 @@ func TestSourceService_Create(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 			repoCreateErr: boom.Error,
 
@@ -476,16 +467,14 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 			repoUpdateSource: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: require.NoError,
@@ -495,24 +484,24 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "endpoint.url",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
 			repoUpdateSource: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "endpoint.url",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -524,9 +513,8 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         -1, // invalid
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -539,9 +527,8 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "", // empty
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -554,9 +541,8 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SourceType(-1), // invalid
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -569,7 +555,6 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
 				Properties: nil, // nil
 			},
@@ -584,7 +569,6 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
 				Properties: json.RawMessage(`{`), // invalid json
 			},
@@ -599,7 +583,6 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{`), // invalid json
 			},
@@ -614,12 +597,12 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": ":|\\",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -634,12 +617,12 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "enpoint.url",
   "username": "",
-  "password": "pass"
+  "password": "pass",
+  "insecure": false
 }
 `),
 			},
@@ -654,12 +637,12 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_VMWARE,
 				Properties: json.RawMessage(`{
   "endpoint": "enpoint.url",
   "username": "user",
-  "password": ""
+  "password": "",
+  "insecure": false
 }
 `),
 			},
@@ -674,9 +657,8 @@ func TestSourceService_UpdateByID(t *testing.T) {
 			source: migration.Source{
 				ID:         1,
 				Name:       "one",
-				Insecure:   false,
 				SourceType: api.SOURCETYPE_COMMON,
-				Properties: json.RawMessage(`{}`),
+				Properties: json.RawMessage(`{"insecure": false}`),
 			},
 			repoUpdateErr: boom.Error,
 

--- a/internal/migration/target_model.go
+++ b/internal/migration/target_model.go
@@ -1,19 +1,18 @@
 package migration
 
 import (
+	"encoding/json"
 	"net/url"
 
-	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 type Target struct {
-	ID            int
-	Name          string
-	Endpoint      string
-	TLSClientKey  string
-	TLSClientCert string
-	OIDCTokens    *oidc.Tokens[*oidc.IDTokenClaims]
-	Insecure      bool
+	ID         int
+	Name       string
+	TargetType api.TargetType
+
+	Properties json.RawMessage
 }
 
 func (t Target) Validate() error {
@@ -25,9 +24,38 @@ func (t Target) Validate() error {
 		return NewValidationErrf("Invalid target, name can not be empty")
 	}
 
-	_, err := url.Parse(t.Endpoint)
+	if t.TargetType < api.TARGETTYPE_INCUS || t.TargetType > api.TARGETTYPE_INCUS {
+		return NewValidationErrf("Invalid target, %d is not a valid target type", t.TargetType)
+	}
+
+	if t.Properties == nil {
+		return NewValidationErrf("Invalid target, properties can not be null")
+	}
+
+	var err error
+	switch t.TargetType {
+	case api.TARGETTYPE_INCUS:
+		err = t.validateTargetTypeIncus()
+	}
+
 	if err != nil {
-		return NewValidationErrf("Invalid target, endpoint %q is not a valid URL: %v", t.Endpoint, err)
+		return err
+	}
+
+	return nil
+}
+
+func (t Target) validateTargetTypeIncus() error {
+	var properties api.IncusProperties
+
+	err := json.Unmarshal(t.Properties, &properties)
+	if err != nil {
+		return NewValidationErrf("Invalid properties for Incus type: %v", err)
+	}
+
+	_, err = url.Parse(properties.Endpoint)
+	if err != nil {
+		return NewValidationErrf("Invalid target, endpoint %q is not a valid URL: %v", properties.Endpoint, err)
 	}
 
 	return nil

--- a/internal/migration/target_service_test.go
+++ b/internal/migration/target_service_test.go
@@ -2,6 +2,7 @@ package migration_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/migration"
 	"github.com/FuturFusion/migration-manager/internal/migration/repo/mock"
 	"github.com/FuturFusion/migration-manager/internal/testing/boom"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 func TestTargetService_Create(t *testing.T) {
@@ -23,20 +25,16 @@ func TestTargetService_Create(t *testing.T) {
 		{
 			name: "success",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 			repoCreateTarget: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: require.NoError,
@@ -44,12 +42,10 @@ func TestTargetService_Create(t *testing.T) {
 		{
 			name: "error - invalid id",
 			target: migration.Target{
-				ID:            -1, // invalid
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         -1, // invalid
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -60,12 +56,10 @@ func TestTargetService_Create(t *testing.T) {
 		{
 			name: "error - name empty",
 			target: migration.Target{
-				ID:            1,
-				Name:          "", // empty
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "", // empty
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -76,12 +70,10 @@ func TestTargetService_Create(t *testing.T) {
 		{
 			name: "error - invalid endpoint url",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      ":|\\", // invalid
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": ":|\\", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -92,12 +84,10 @@ func TestTargetService_Create(t *testing.T) {
 		{
 			name: "error - repo",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 			repoCreateErr: boom.Error,
 
@@ -347,20 +337,16 @@ func TestTargetService_UpdateByID(t *testing.T) {
 		{
 			name: "success",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 			repoUpdateTarget: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: require.NoError,
@@ -368,12 +354,10 @@ func TestTargetService_UpdateByID(t *testing.T) {
 		{
 			name: "error - invalid id",
 			target: migration.Target{
-				ID:            -1, // invalid
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         -1, // invalid
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -384,12 +368,10 @@ func TestTargetService_UpdateByID(t *testing.T) {
 		{
 			name: "error - name empty",
 			target: migration.Target{
-				ID:            1,
-				Name:          "", // empty
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "", // empty
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -400,12 +382,10 @@ func TestTargetService_UpdateByID(t *testing.T) {
 		{
 			name: "error - invalid endpoint url",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      ":|\\", // invalid
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": ":|\\", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -416,12 +396,10 @@ func TestTargetService_UpdateByID(t *testing.T) {
 		{
 			name: "error - repo",
 			target: migration.Target{
-				ID:            1,
-				Name:          "one",
-				Endpoint:      "endpoint.url",
-				TLSClientKey:  "key",
-				TLSClientCert: "cert",
-				Insecure:      false,
+				ID:         1,
+				Name:       "one",
+				TargetType: api.TARGETTYPE_INCUS,
+				Properties: json.RawMessage(`{"endpoint": "endpoint.url", "tls_client_key": "key", "tls_client_cert": "cert", "insecure": false}`),
 			},
 			repoUpdateErr: boom.Error,
 

--- a/internal/source/common.go
+++ b/internal/source/common.go
@@ -19,11 +19,11 @@ type InternalSource struct {
 }
 
 func (s *InternalSource) Connect(ctx context.Context) error {
-	return fmt.Errorf("Not implemented by Source")
+	return fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) Disconnect(ctx context.Context) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) SetInsecureTLS(insecure bool) error {
@@ -51,21 +51,21 @@ func (s *InternalSource) GetDatabaseID() (int, error) {
 }
 
 func (s *InternalSource) GetAllVMs(ctx context.Context) ([]instance.InternalInstance, error) {
-	return nil, fmt.Errorf("Not implemented by CommonSource")
+	return nil, fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) GetAllNetworks(ctx context.Context) ([]api.Network, error) {
-	return nil, fmt.Errorf("Not implemented by CommonSource")
+	return nil, fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) DeleteVMSnapshot(ctx context.Context, vmName string, snapshotName string) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) ImportDisks(ctx context.Context, vmName string, statusCallback func(string, bool)) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) PowerOffVM(ctx context.Context, vmName string) error {
-	return fmt.Errorf("Not implemented by CommonSource")
+	return fmt.Errorf("Not implemented by InternalSource")
 }

--- a/internal/source/common.go
+++ b/internal/source/common.go
@@ -27,12 +27,7 @@ func (s *InternalSource) Disconnect(ctx context.Context) error {
 }
 
 func (s *InternalSource) SetInsecureTLS(insecure bool) error {
-	if s.isConnected {
-		return fmt.Errorf("Cannot change insecure TLS setting after connecting")
-	}
-
-	s.Insecure = insecure
-	return nil
+	return fmt.Errorf("Not implemented by InternalSource")
 }
 
 func (s *InternalSource) WithAdditionalRootCertificate(rootCert *tls.Certificate) {

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -103,6 +103,15 @@ func (s *InternalVMwareSource) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+func (s *InternalVMwareSource) SetInsecureTLS(insecure bool) error {
+	if s.isConnected {
+		return fmt.Errorf("Cannot change insecure TLS setting after connecting")
+	}
+
+	s.Insecure = insecure
+	return nil
+}
+
 func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instances, error) {
 	ret := migration.Instances{}
 

--- a/internal/target/common.go
+++ b/internal/target/common.go
@@ -1,0 +1,106 @@
+package target
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	incus "github.com/lxc/incus/v6/client"
+	incusAPI "github.com/lxc/incus/v6/shared/api"
+
+	"github.com/FuturFusion/migration-manager/internal"
+	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+type InternalTarget struct {
+	api.Target `yaml:",inline"`
+
+	isConnected bool
+
+	additionalRootCertificate *tls.Certificate
+}
+
+func (t *InternalTarget) Connect(ctx context.Context) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) Disconnect(ctx context.Context) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) SetInsecureTLS(insecure bool) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) WithAdditionalRootCertificate(rootCert *tls.Certificate) {
+	t.additionalRootCertificate = rootCert
+}
+
+func (t *InternalTarget) SetClientTLSCredentials(key string, cert string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) IsConnected() bool {
+	return t.isConnected
+}
+
+func (t *InternalTarget) GetName() string {
+	return t.Name
+}
+
+func (t *InternalTarget) GetDatabaseID() (int, error) {
+	if t.DatabaseID == internal.INVALID_DATABASE_ID {
+		return internal.INVALID_DATABASE_ID, fmt.Errorf("Target has not been added to database, so it doesn't have an ID")
+	}
+
+	return t.DatabaseID, nil
+}
+
+func (t *InternalTarget) SetProject(project string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) CreateVMDefinition(instanceDef migration.Instance, sourceName string, storagePool string) incusAPI.InstancesPost {
+	return incusAPI.InstancesPost{}
+}
+
+func (t *InternalTarget) CreateNewVM(apiDef incusAPI.InstancesPost, storagePool string, bootISOImage string, driversISOImage string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) DeleteVM(name string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) StartVM(name string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) StopVM(name string, force bool) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) PushFile(instanceName string, file string, destDir string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) ExecWithoutWaiting(instanceName string, cmd []string) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) GetInstance(name string) (*api.Instance, string, error) {
+	return nil, "", fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) UpdateInstance(name string, instanceDef incusAPI.InstancePut, ETag string) (incus.Operation, error) {
+	return nil, fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error) {
+	return nil, "", fmt.Errorf("Not implemented by InternalTarget")
+}
+
+func (t *InternalTarget) CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) (incus.Operation, error) {
+	return nil, fmt.Errorf("Not implemented by InternalTarget")
+}

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -2,11 +2,12 @@ package target
 
 import (
 	"context"
+	"crypto/tls"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
 
-	"github.com/FuturFusion/migration-manager/internal/instance"
+	"github.com/FuturFusion/migration-manager/internal/migration"
 )
 
 // Interface definition for all migration manager targets.
@@ -30,6 +31,11 @@ type Target interface {
 	//
 	// Returns an error if called while connected to a target.
 	SetInsecureTLS(insecure bool) error
+
+	// WithAdditionalRootCertificate accepts an additional certificate, which
+	// is added to the default CertPool used to validate server certificates
+	// while connecting to the Target using TLS.
+	WithAdditionalRootCertificate(rootCert *tls.Certificate)
 
 	// Sets the client TLS key and certificate to be used to authenticate with the target. Leave unset to
 	// default to OIDC authentication.
@@ -64,7 +70,7 @@ type Target interface {
 	SetProject(project string) error
 
 	// Creates a VM definition for use with the Incus REST API.
-	CreateVMDefinition(instanceDef instance.InternalInstance, sourceName string, storagePool string) api.InstancesPost
+	CreateVMDefinition(instanceDef migration.Instance, sourceName string, storagePool string) api.InstancesPost
 
 	// Creates a new VM from the pre-populated API definition.
 	CreateNewVM(apiDef api.InstancesPost, storagePool string, bootISOImage string, driversISOImage string) error

--- a/shared/api/source.go
+++ b/shared/api/source.go
@@ -39,10 +39,6 @@ type Source struct {
 	// Example: 123
 	DatabaseID int `json:"database_id" yaml:"database_id"`
 
-	// If true, disable TLS certificate validation
-	// Example: false
-	Insecure bool `json:"insecure" yaml:"insecure"`
-
 	// SourceType defines the type of the source
 	SourceType SourceType `json:"source_type" yaml:"source_type"`
 
@@ -57,6 +53,10 @@ type VMwareProperties struct {
 	// Hostname or IP address of the source endpoint
 	// Example: vsphere.local
 	Endpoint string `json:"endpoint" yaml:"endpoint"`
+
+	// If true, disable TLS certificate validation
+	// Example: false
+	Insecure bool `json:"insecure" yaml:"insecure"`
 
 	// Username to authenticate against the endpoint
 	// Example: admin

--- a/shared/api/target.go
+++ b/shared/api/target.go
@@ -1,13 +1,35 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
-// IncusTarget defines an Incus target for use by the migration manager.
+type TargetType int
+
+const (
+	TARGETTYPE_UNKNOWN TargetType = iota
+	TARGETTYPE_INCUS
+)
+
+// Implement the stringer interface.
+func (t TargetType) String() string {
+	switch t {
+	case TARGETTYPE_UNKNOWN:
+		return "Unknown"
+	case TARGETTYPE_INCUS:
+		return "Incus"
+	default:
+		return fmt.Sprintf("TargetType(%d)", t)
+	}
+}
+
+// Target defines properties common to all targets.
 //
 // swagger:model
-type IncusTarget struct {
+type Target struct {
 	// A human-friendly name for this target
 	// Example: MyTarget
 	Name string `json:"name" yaml:"name"`
@@ -16,6 +38,17 @@ type IncusTarget struct {
 	// Example: 123
 	DatabaseID int `json:"database_id" yaml:"database_id"`
 
+	// TargetType defines the type of the target
+	TargetType TargetType `json:"target_type" yaml:"target_type"`
+
+	// Properties contains target type specific properties
+	Properties json.RawMessage `json:"properties" yaml:"properties"`
+}
+
+// IncusProperties defines the set of Incus specific properties of a target that the migration manager can connect to.
+//
+// swagger:model
+type IncusProperties struct {
 	// Hostname or IP address of the target endpoint
 	// Example: https://incus.local:6443
 	Endpoint string `json:"endpoint" yaml:"endpoint"`


### PR DESCRIPTION
This moves most properties for source and targets into json objects that can contain type-specific values without needing to then also worry about future database schema updates.