### PR TITLE
Fix worker authentication

### DIFF
--- a/cmd/migration-manager-worker/internal/worker/worker.go
+++ b/cmd/migration-manager-worker/internal/worker/worker.go
@@ -97,7 +97,7 @@ func (w *Worker) Run(ctx context.Context) {
 
 	for {
 		done := func() (done bool) {
-			resp, err := w.doHTTPRequestV1("/queue/"+w.uuid+"/worker/command", http.MethodPost, "", nil)
+			resp, err := w.doHTTPRequestV1("/queue/"+w.uuid+"/worker/command", http.MethodPost, "secret="+w.token, nil)
 			if err != nil {
 				slog.Error("HTTP request failed", logger.Err(err))
 				return false

--- a/cmd/migration-manager-worker/worker_test.go
+++ b/cmd/migration-manager-worker/worker_test.go
@@ -286,7 +286,7 @@ func TestRun(t *testing.T) {
 					}
 
 					fallthrough
-				case fmt.Sprintf("/1.0/queue/%s/worker/command", uuid):
+				case fmt.Sprintf("/1.0/queue/%s/worker/command?secret=", uuid):
 					if r.RequestURI != "/1.0" {
 						if r.Method != http.MethodPost {
 							cancel(fmt.Errorf("Unsupported method %q", r.Method))

--- a/cmd/migration-managerd/internal/api/api_queue.go
+++ b/cmd/migration-managerd/internal/api/api_queue.go
@@ -40,9 +40,9 @@ var queueWorkerCommandCmd = APIEndpoint{
 }
 
 // Authenticate a migration worker. Allow a GET for an existing instance so the worker can get its instructions,
-// and for PUT require the secret token to be valid when the worker reports back.
+// and for POST require the secret token to be valid when the worker reports back.
 func (d *Daemon) workerAccessTokenValid(r *http.Request) bool {
-	// Only allow GET and PUT methods.
+	// Only allow GET and POST methods.
 	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		return false
 	}

--- a/cmd/migration-managerd/internal/api/daemon.go
+++ b/cmd/migration-managerd/internal/api/daemon.go
@@ -388,7 +388,7 @@ func (d *Daemon) createCmd(restAPI *http.ServeMux, apiVersion string, c APIEndpo
 				_ = d.oidcVerifier.WriteHeaders(w)
 			}
 
-			slog.Warn("Rejecting request from untrusted client", slog.String("ip", r.RemoteAddr))
+			slog.Warn("Rejecting request from untrusted client", slog.String("ip", r.RemoteAddr), slog.String("path", r.RequestURI), slog.String("method", r.Method))
 			_ = response.Forbidden(nil).Render(w)
 			return
 		}


### PR DESCRIPTION
Since the request is a `POST` now, it should have the secret included. Currently requests from the worker fail authentication because we only allow `GET`s through without a secret.