### PR TITLE
Build migration backup volume

### DIFF
--- a/cmd/migration-managerd/internal/api/daemon.go
+++ b/cmd/migration-managerd/internal/api/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/server/sys"
 	tlsutil "github.com/FuturFusion/migration-manager/internal/server/util"
 	"github.com/FuturFusion/migration-manager/internal/transaction"
+	"github.com/FuturFusion/migration-manager/internal/util"
 	"github.com/FuturFusion/migration-manager/internal/version"
 )
 
@@ -66,6 +67,8 @@ type Daemon struct {
 	errgroup *errgroup.Group
 	config   *config.DaemonConfig
 
+	batchLock util.IDLock[string]
+
 	ShutdownCtx    context.Context    // Canceled when shutdown starts.
 	ShutdownCancel context.CancelFunc // Cancels the shutdownCtx to indicate shutdown starting.
 	ShutdownDoneCh chan error         // Receives the result of the d.Stop() function and tells the daemon to end.
@@ -78,6 +81,7 @@ func NewDaemon(cfg *config.DaemonConfig) *Daemon {
 		db:             &db.Node{},
 		os:             sys.DefaultOS(),
 		config:         cfg,
+		batchLock:      util.NewIDLock[string](),
 		ShutdownCtx:    shutdownCtx,
 		ShutdownCancel: shutdownCancel,
 		ShutdownDoneCh: make(chan error),

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -1014,7 +1014,7 @@ func (d *Daemon) configureMigratedInstances(ctx context.Context, instances migra
 		}
 
 		// Remove the migration ISO image.
-		delete(apiDef.Devices, "migration-iso")
+		delete(apiDef.Devices, util.WorkerVolume())
 
 		// Don't set any profiles by default.
 		apiDef.Profiles = []string{}

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -793,12 +793,6 @@ func (d *Daemon) createTargetVMs(ctx context.Context, b migration.Batch, instanc
 			return fmt.Errorf("Failed to set project %q for target %q: %w", b.TargetProject, it.GetName(), err)
 		}
 
-		// Create the instance.
-		workerISOName, err := d.os.GetMigrationManagerISOName()
-		if err != nil {
-			return fmt.Errorf("Failed to get worker ISO path: %w", err)
-		}
-
 		var driverISOName string
 		if inst.GetOSType() == api.OSTYPE_WINDOWS {
 			driverISOName, err = d.os.GetVirtioDriversISOName()
@@ -819,7 +813,7 @@ func (d *Daemon) createTargetVMs(ctx context.Context, b migration.Batch, instanc
 			})
 		}
 
-		err = it.CreateNewVM(instanceDef, b.StoragePool, workerISOName, driverISOName)
+		err = it.CreateNewVM(instanceDef, b.StoragePool, util.WorkerVolume(), driverISOName)
 		if err != nil {
 			return fmt.Errorf("Failed to create new instance %q on migration target %q: %w", instanceDef.Name, it.GetName(), err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/expr-lang/expr v1.16.9
 	github.com/flosch/pongo2/v4 v4.0.2
 	github.com/fvbommel/sortorder v1.1.0
+	github.com/google/go-github/v69 v69.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.14.0
 	github.com/hexdigest/gowrap v1.4.1
@@ -54,6 +55,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 // indirect
 	github.com/google/cel-go v0.22.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,13 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/cel-go v0.22.1 h1:AfVXx3chM2qwoSbM7Da8g8hX8OVSkBFwX+rz2+PcK40=
 github.com/google/cel-go v0.22.1/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
+github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/migratekit/nbdkit/builder.go
+++ b/internal/migratekit/nbdkit/builder.go
@@ -79,7 +79,6 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 	socket := fmt.Sprintf("%s/nbdkit.sock", tmp)
 	pidFile := fmt.Sprintf("%s/nbdkit.pid", tmp)
 
-	os.Setenv("LD_LIBRARY_PATH", "/usr/lib64/vmware-vix-disklib/lib64")
 	cmd := exec.Command(
 		"nbdkit",
 		"--exit-with-parent",
@@ -95,6 +94,7 @@ func (b *NbdkitBuilder) Build() (*NbdkitServer, error) {
 		fmt.Sprintf("compression=%s", b.compression),
 		fmt.Sprintf("vm=moref=%s", b.vm),
 		fmt.Sprintf("snapshot=%s", b.snapshot),
+		"libdir=/opt/vmware-vix-disklib-distrib",
 		"transports=file:nbdssl:nbd",
 		b.filename,
 	)

--- a/internal/server/sys/os.go
+++ b/internal/server/sys/os.go
@@ -46,20 +46,6 @@ func (s *OS) LocalDatabaseDir() string {
 	return filepath.Join(s.VarDir, "database")
 }
 
-// Returns the name of the migration manger worker ISO image.
-func (s *OS) GetMigrationManagerISOName() (string, error) {
-	files, err := filepath.Glob(fmt.Sprintf("%s/migration-manager-minimal-boot*.iso", s.CacheDir))
-	if err != nil {
-		return "", err
-	}
-
-	if len(files) != 1 {
-		return "", fmt.Errorf("Unable to determine migration manager ISO name")
-	}
-
-	return filepath.Base(files[0]), nil
-}
-
 // Returns the name of the virtio drivers ISO image.
 func (s *OS) GetVirtioDriversISOName() (string, error) {
 	files, err := filepath.Glob(fmt.Sprintf("%s/virtio-win-*.iso", s.CacheDir))

--- a/internal/source/vmware_linux.go
+++ b/internal/source/vmware_linux.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi"
 
 	"github.com/FuturFusion/migration-manager/internal/migratekit/nbdkit"
@@ -36,6 +37,9 @@ func (s *InternalVMwareSource) ImportDisks(ctx context.Context, vmName string, s
 		if err == nil {
 			break
 		}
+
+		logger := log.WithFields(log.Fields{"error": err, "attempt": i + 1})
+		logger.Error("Disk import attempt failed")
 
 		time.Sleep(time.Second * 1)
 	}

--- a/internal/target/common.go
+++ b/internal/target/common.go
@@ -106,6 +106,10 @@ func (t *InternalTarget) GetStoragePoolVolume(pool string, volType string, name 
 	return nil, "", fmt.Errorf("Not implemented by InternalTarget")
 }
 
+func (t *InternalTarget) CreateStoragePoolVolumeFromBackup(pool string, isoFilePath string) (incus.Operation, error) {
+	return nil, fmt.Errorf("Not implemented by InternalTarget")
+}
+
 func (t *InternalTarget) CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) (incus.Operation, error) {
 	return nil, fmt.Errorf("Not implemented by InternalTarget")
 }

--- a/internal/target/common.go
+++ b/internal/target/common.go
@@ -106,7 +106,7 @@ func (t *InternalTarget) GetStoragePoolVolume(pool string, volType string, name 
 	return nil, "", fmt.Errorf("Not implemented by InternalTarget")
 }
 
-func (t *InternalTarget) CreateStoragePoolVolumeFromBackup(pool string, isoFilePath string) (incus.Operation, error) {
+func (t *InternalTarget) CreateStoragePoolVolumeFromBackup(pool string, isoFilePath string) ([]incus.Operation, error) {
 	return nil, fmt.Errorf("Not implemented by InternalTarget")
 }
 

--- a/internal/target/common.go
+++ b/internal/target/common.go
@@ -102,8 +102,8 @@ func (t *InternalTarget) UpdateInstance(name string, instanceDef incusAPI.Instan
 	return nil, fmt.Errorf("Not implemented by InternalTarget")
 }
 
-func (t *InternalTarget) GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error) {
-	return nil, "", fmt.Errorf("Not implemented by InternalTarget")
+func (t *InternalTarget) GetStoragePoolVolumeNames(pool string) ([]string, error) {
+	return nil, fmt.Errorf("Not implemented by InternalTarget")
 }
 
 func (t *InternalTarget) CreateStoragePoolVolumeFromBackup(pool string, isoFilePath string) ([]incus.Operation, error) {

--- a/internal/target/common.go
+++ b/internal/target/common.go
@@ -66,6 +66,10 @@ func (t *InternalTarget) SetProject(project string) error {
 	return fmt.Errorf("Not implemented by InternalTarget")
 }
 
+func (t *InternalTarget) SetPostMigrationVMConfig(i migration.Instance, allNetworks map[string]migration.Network) error {
+	return fmt.Errorf("Not implemented by InternalTarget")
+}
+
 func (t *InternalTarget) CreateVMDefinition(instanceDef migration.Instance, sourceName string, storagePool string) incusAPI.InstancesPost {
 	return incusAPI.InstancesPost{}
 }

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -395,6 +395,8 @@ func (t *InternalIncusTarget) CreateNewVM(apiDef incusAPI.InstancesPost, storage
 		"pool":          storagePool,
 		"source":        bootISOImage,
 		"boot.priority": "10",
+		"readonly":      "true",
+		"io.bus":        "virtio-blk",
 	}
 
 	// If this is a Windows VM, attach the virtio drivers ISO.

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -448,8 +448,8 @@ func (t *InternalIncusTarget) UpdateInstance(name string, instanceDef incusAPI.I
 	return t.incusClient.UpdateInstance(name, instanceDef, ETag)
 }
 
-func (t *InternalIncusTarget) GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error) {
-	return t.incusClient.GetStoragePoolVolume(pool, volType, name)
+func (t *InternalIncusTarget) GetStoragePoolVolumeNames(pool string) ([]string, error) {
+	return t.incusClient.GetStoragePoolVolumeNames(pool)
 }
 
 func (t *InternalIncusTarget) CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) ([]incus.Operation, error) {

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -301,7 +301,7 @@ func (t *InternalIncusTarget) CreateNewVM(apiDef incusAPI.InstancesPost, storage
 	defer reverter.Fail()
 
 	// Attach bootable ISO to run migration of this VM.
-	apiDef.Devices["migration-iso"] = map[string]string{
+	apiDef.Devices[util.WorkerVolume()] = map[string]string{
 		"type":          "disk",
 		"pool":          storagePool,
 		"source":        bootISOImage,

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -105,6 +105,9 @@ type Target interface {
 	// Wrapper around Incus' GetStoragePoolVolume method.
 	GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error)
 
+	// Wrapper around Incus' CreateStoragePoolVolumeFromBackup.
+	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) (incus.Operation, error)
+
 	// Wrapper around Incus' CreateStoragePoolVolumeFromISO.
 	CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) (incus.Operation, error)
 }

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -75,6 +75,9 @@ type Target interface {
 	// Returns an error if called while disconnected from a target.
 	SetProject(project string) error
 
+	// SetPostMigrationVMConfig stops the target instance and applies post-migration configuration before restarting it.
+	SetPostMigrationVMConfig(i migration.Instance, allNetworks map[string]migration.Network) error
+
 	// Creates a VM definition for use with the Incus REST API.
 	CreateVMDefinition(instanceDef migration.Instance, sourceName string, storagePool string) incusAPI.InstancesPost
 

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -102,8 +102,8 @@ type Target interface {
 	// Wrapper around Incus' UpdateInstance method.
 	UpdateInstance(name string, instanceDef incusAPI.InstancePut, ETag string) (incus.Operation, error)
 
-	// Wrapper around Incus' GetStoragePoolVolume method.
-	GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error)
+	// Wrapper around Incus' GetStoragePoolVolumeNames method.
+	GetStoragePoolVolumeNames(pool string) ([]string, error)
 
 	// Wrapper around Incus' CreateStoragePoolVolumeFromBackup.
 	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) ([]incus.Operation, error)

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -106,7 +106,7 @@ type Target interface {
 	GetStoragePoolVolume(pool string, volType string, name string) (*incusAPI.StorageVolume, string, error)
 
 	// Wrapper around Incus' CreateStoragePoolVolumeFromBackup.
-	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) (incus.Operation, error)
+	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) ([]incus.Operation, error)
 
 	// Wrapper around Incus' CreateStoragePoolVolumeFromISO.
 	CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) (incus.Operation, error)

--- a/internal/util/archive.go
+++ b/internal/util/archive.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// CreateTarballFromDir creates a tarball from a given directory, inclusive of the containing directory.
+func CreateTarballFromDir(target string, contentDir string) error {
+	f, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = f.Close() }()
+
+	gzipWriter := gzip.NewWriter(f)
+	defer func() { _ = gzipWriter.Close() }()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer func() { _ = tarWriter.Close() }()
+
+	return filepath.Walk(contentDir, archiveDir(tarWriter, contentDir))
+}
+
+func archiveDir(tarWriter *tar.Writer, contentDir string) filepath.WalkFunc {
+	return func(path string, info fs.FileInfo, err error) error {
+		if err != nil || path == contentDir {
+			return err
+		}
+
+		// Recurse through directories.
+		if info.IsDir() {
+			return filepath.Walk(path, archiveDir(tarWriter, path))
+		}
+
+		relPath, err := filepath.Rel(filepath.Dir(contentDir), path)
+		if err != nil {
+			return err
+		}
+
+		err = tarWriter.WriteHeader(&tar.Header{
+			Name:    relPath,
+			Size:    info.Size(),
+			Mode:    int64(info.Mode()),
+			ModTime: info.ModTime(),
+		})
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = f.Close() }()
+
+		_, err = io.Copy(tarWriter, f)
+
+		return err
+	}
+}

--- a/internal/util/github.go
+++ b/internal/util/github.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/google/go-github/v69/github"
+
+	"github.com/FuturFusion/migration-manager/internal/version"
+)
+
+type githubRepo struct {
+	owner string
+	repo  string
+	tag   string
+
+	client        *github.Client
+	releaseAssets map[string]int64
+}
+
+// GetProjectRepo returns a GitHub repository client for the project at the current tag, and populates release assets.
+// If latest is true, release assets will be populated from the latest release instead of the tag.
+func GetProjectRepo(ctx context.Context, latest bool) (*githubRepo, error) {
+	g := &githubRepo{
+		owner: "futurfusion",
+		repo:  "migration-manager",
+		tag:   version.GoVersion(),
+
+		client: github.NewClient(nil),
+	}
+
+	var err error
+	var release *github.RepositoryRelease
+	if latest {
+		release, _, err = g.client.Repositories.GetLatestRelease(ctx, g.owner, g.repo)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get latest GitHub release: %w", err)
+		}
+	} else {
+		release, _, err = g.client.Repositories.GetReleaseByTag(ctx, g.owner, g.repo, g.tag)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get GitHub release for tag %q: %w", g.tag, err)
+		}
+	}
+
+	g.releaseAssets = make(map[string]int64, len(release.Assets))
+	for _, r := range release.Assets {
+		g.releaseAssets[r.GetName()] = r.GetID()
+	}
+
+	return g, nil
+}
+
+// DownloadAsset downloads the given release asset to the given target location.
+func (g *githubRepo) DownloadAsset(ctx context.Context, target string, asset string) error {
+	assetID, ok := g.releaseAssets[asset]
+	if !ok {
+		return fmt.Errorf("No GitHub release asset found with name %q", asset)
+	}
+
+	rc, _, err := g.client.Repositories.DownloadReleaseAsset(ctx, g.owner, g.repo, assetID, http.DefaultClient)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch GitHub release asset with name %q: %w", asset, err)
+	}
+
+	defer func() { _ = rc.Close() }()
+	f, err := os.Create(target)
+	if err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("Failed to create file at %q: %w", target, err)
+		}
+
+		f, err = os.OpenFile(target, os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("Failed to open file at %q: %w", target, err)
+		}
+	}
+
+	defer func() { _ = f.Close() }()
+
+	// Setup a gzip reader to decompress during streaming.
+	body, err := gzip.NewReader(rc)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = body.Close() }()
+
+	// Read from the decompressor in chunks to avoid excessive memory consumption.
+	for {
+		_, err = io.CopyN(f, body, 4*1024*1024)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return fmt.Errorf("Failed to copy GitHub release asset to %q: %w", target, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -3,7 +3,19 @@ package util
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/FuturFusion/migration-manager/internal/version"
 )
+
+// WorkerVolume represents the name of the storage volume containing the migration worker.
+func WorkerVolume() string {
+	return "migration-worker-" + version.GoVersion()
+}
+
+// RawWorkerImage represents the raw worker image supplied to an Incus target.
+func RawWorkerImage() string {
+	return WorkerVolume() + ".img"
+}
 
 // CachePath returns the directory that migration manager should use for caching assets. If MIGRATION_MANAGER_DIR is
 // set, this path is $MIGRATION_MANAGER_DIR/cache, otherwise it is /var/cache/migration-manager.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,8 @@
 package version
 
-const Version string = "0.0.1"
+const Version string = "0.0.0-pre.2"
+
+// GoVersion returns the project version formatted as a Go semantic version string.
+func GoVersion() string {
+	return "v" + Version
+}

--- a/internal/worker/linux.go
+++ b/internal/worker/linux.go
@@ -45,7 +45,7 @@ type LVSOutput struct {
 	} `json:"report"`
 }
 
-const chrootMountPath string = "/mnt/target/"
+const chrootMountPath string = "/run/mount/target/"
 
 func LinuxDoPostMigrationConfig(distro string, majorVersion int) error {
 	slog.Info("Preparing to perform post-migration configuration of VM")

--- a/internal/worker/windows.go
+++ b/internal/worker/windows.go
@@ -30,11 +30,11 @@ const (
 )
 
 const (
-	bitLockerMountPath       string = "/mnt/dislocker/"
+	bitLockerMountPath       string = "/run/mount/dislocker/"
 	driversMountDevice       string = "/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_incus_drivers"
-	driversMountPath         string = "/mnt/drivers/"
-	windowsMainMountPath     string = "/mnt/win_main/"
-	windowsRecoveryMountPath string = "/mnt/win_recovery/"
+	driversMountPath         string = "/run/mount/drivers/"
+	windowsMainMountPath     string = "/run/mount/win_main/"
+	windowsRecoveryMountPath string = "/run/mount/win_recovery/"
 )
 
 func init() {


### PR DESCRIPTION
Closes #126
Closes #87 

On batch start, creates `<target>_<pool>_<version>_worker.tar.gz` for each newly encountered target & storage pool combo, and imports it as a storage pool volume backup on the Incus target, if it doesn't exist already.
* If the volume already exists, it will be re-used, without creating a new tarball to import.
* If the tarball for the current migration-manager version already exists for the given pool in the given target, it will be re-used, without creating a new image with the VMware VIX tarball.
* If the raw image for the current migration-manager already exists, it will not be re-fetched from github.