### PR TITLE
Misc improvements

### DIFF
--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -682,11 +682,11 @@ func (d *Daemon) beginImports(ctx context.Context, cleanupInstances bool) error 
 		return err
 	}
 
-	for bID, instances := range instancesByBatch {
-		err := d.createTargetVMs(ctx, batchesByID[bID], instances, targetsByBatch[bID], sourcesByInstance, cleanupInstances)
-		if err != nil {
-			log.Error("Failed to initialize migration workers", slog.String("target", targetsByBatch[bID].Name), slog.String("batch", batchesByID[bID].Name), logger.Err(err))
-		}
+	err = util.RunConcurrentMap(instancesByBatch, func(bID int, instances migration.Instances) error {
+		return d.createTargetVMs(ctx, batchesByID[bID], instances, targetsByBatch[bID], sourcesByInstance, cleanupInstances)
+	})
+	if err != nil {
+		log.Error("Failed to initialize migration workers", logger.Err(err))
 	}
 
 	return nil

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -217,6 +217,11 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(i migration.Instance, all
 			apiDef.Devices[nicDeviceName][k] = v
 		}
 
+		// If no network is given, set "default" as the default.
+		if apiDef.Devices[nicDeviceName]["network"] == "" {
+			apiDef.Devices[nicDeviceName]["network"] = "default"
+		}
+
 		// Set a few forced overrides.
 		apiDef.Devices[nicDeviceName]["type"] = "nic"
 		apiDef.Devices[nicDeviceName]["name"] = nicDeviceName


### PR DESCRIPTION
* Run instance creation for multiple batches concurrently. Previously, only instances within 1 batch were created concurrently.

* Fallback to the `default` network if no additional network configuration is defined. This avoids the need to set a JSON config on the network before starting a batch. Obviously instance creation will still fail if the `default` network doesn't exist. 