### PR TITLE
Explicitly support http/2

### DIFF
--- a/cmd/migration-managerd/internal/api/api.go
+++ b/cmd/migration-managerd/internal/api/api.go
@@ -114,6 +114,7 @@ func restServer(d *Daemon) *http.Server {
 		ConnContext: request.SaveConnectionInContext,
 		IdleTimeout: 30 * time.Second,
 		TLSConfig: &tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
 			ClientAuth: tls.RequestClientCert,
 		},
 	}


### PR DESCRIPTION
As of go `1.24`, `http.Serve` with TLS requires explicit declaration of supported protocols, and will not implicitly fallback to `http/1.1`. Since we're always using TLS, we might as well support both http/2 and http/1.1. 