### PR TITLE
Set status message if downloads are needed

### DIFF
--- a/internal/server/sys/os.go
+++ b/internal/server/sys/os.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/FuturFusion/migration-manager/internal/util"
 )
@@ -49,7 +50,7 @@ func (s *OS) LocalDatabaseDir() string {
 
 // Returns the name of the virtio drivers ISO image.
 func (s *OS) GetVirtioDriversISOName() (string, error) {
-	files, err := filepath.Glob(fmt.Sprintf("%s/virtio-win*.iso", s.CacheDir))
+	files, err := filepath.Glob(fmt.Sprintf("%s/virtio-win-*.iso", s.CacheDir))
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +157,12 @@ func (s *OS) LoadVirtioWinISO() (string, error) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	isoPath := filepath.Join(s.CacheDir, "virtio-win.iso")
+	versionedName := filepath.Base(resp.Request.URL.Path)
+	if !strings.HasPrefix(versionedName, "virtio-win-") || !strings.HasSuffix(versionedName, ".iso") {
+		return "", fmt.Errorf("VirtIO drivers ISO is not available. Found artifact: %q", versionedName)
+	}
+
+	isoPath := filepath.Join(s.CacheDir, versionedName)
 	isoFile, err := os.Create(isoPath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Sets a `QUEUED` batch message to `Downloading Artifacts` if we need to download (or upload to the target) any resources prior to instance creation.

Happens under the following conditions:
* No base image volume corresponding to the migration manager version exists on the target
* A windows VM is part of the batch, and no virtio drivers ISO can be found
  * In this case, we first need to check for existence of the actual ISO in `/var/cache/migration-manager` because we don't actually know the full name of the ISO including its version to check against storage volumes. 