### PR TITLE
Add distributed port group support

### DIFF
--- a/cmd/migration-manager/internal/cmds/network.go
+++ b/cmd/migration-manager/internal/cmds/network.go
@@ -154,7 +154,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the table.
-	header := []string{"Name", "Config"}
+	header := []string{"Name", "Location", "Config"}
 	data := [][]string{}
 
 	for _, n := range networks {
@@ -163,7 +163,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 			configString, _ = json.Marshal(n.Config)
 		}
 
-		data = append(data, []string{n.Name, string(configString)})
+		data = append(data, []string{n.Name, n.Location, string(configString)})
 	}
 
 	sort.Sort(util.SortColumnsNaturally(data))

--- a/cmd/migration-manager/internal/cmds/network.go
+++ b/cmd/migration-manager/internal/cmds/network.go
@@ -258,11 +258,6 @@ func (c *cmdNetworkUpdate) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	network.Name, err = c.global.Asker.AskString("Network name [default="+network.Name+"]: ", network.Name, nil)
-	if err != nil {
-		return err
-	}
-
 	defaultConfig := "(empty to skip): "
 	if len(configString) > 0 {
 		defaultConfig = "[default=" + string(configString) + "]: "
@@ -282,7 +277,7 @@ func (c *cmdNetworkUpdate) Run(cmd *cobra.Command, args []string) error {
 	newNetworkName := network.Name
 
 	// Update the network.
-	content, err := json.Marshal(network)
+	content, err := json.Marshal(network.NetworkPut)
 	if err != nil {
 		return err
 	}

--- a/cmd/migration-managerd/internal/api/api_network.go
+++ b/cmd/migration-managerd/internal/api/api_network.go
@@ -124,10 +124,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 
 		result := make([]api.Network, 0, len(networks))
 		for _, network := range networks {
-			result = append(result, api.Network{
-				Name:   network.Name,
-				Config: network.Config,
-			})
+			result = append(result, network.ToAPI())
 		}
 
 		return response.SyncResponse(true, result)
@@ -183,8 +180,9 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	_, err = d.network.Create(r.Context(), migration.Network{
-		Name:   network.Name,
-		Config: network.Config,
+		Name:     network.Name,
+		Location: network.Location,
+		Config:   network.Config,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed creating network %q: %w", network.Name, err))
@@ -266,10 +264,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 
 	return response.SyncResponseETag(
 		true,
-		api.Network{
-			Name:   network.Name,
-			Config: network.Config,
-		},
+		network.ToAPI(),
 		network,
 	)
 }

--- a/cmd/migration-managerd/internal/api/api_network.go
+++ b/cmd/migration-managerd/internal/api/api_network.go
@@ -301,7 +301,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 func networkPut(d *Daemon, r *http.Request) response.Response {
 	name := r.PathValue("name")
 
-	var network api.Network
+	var network api.NetworkPut
 
 	err := json.NewDecoder(r.Body).Decode(&network)
 	if err != nil {
@@ -328,12 +328,13 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = d.network.Update(ctx, &migration.Network{
-		ID:     currentNetwork.ID,
-		Name:   network.Name,
-		Config: network.Config,
+		ID:       currentNetwork.ID,
+		Name:     currentNetwork.Name,
+		Location: currentNetwork.Location,
+		Config:   network.Config,
 	})
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed updating network %q: %w", network.Name, err))
+		return response.SmartError(fmt.Errorf("Failed updating network %q: %w", currentNetwork.Name, err))
 	}
 
 	err = trans.Commit()
@@ -341,5 +342,5 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed commit transaction: %w", err))
 	}
 
-	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/networks/"+network.Name)
+	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/networks/"+currentNetwork.Name)
 }

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -175,7 +175,7 @@ func syncNetworksFromSource(ctx context.Context, sourceName string, n migration.
 		if !ok {
 			log := log.With(slog.String("network", network.Name))
 			log.Info("Recording new network detected on source")
-			_, err := n.Create(ctx, migration.Network{Name: network.Name, Config: network.Config})
+			_, err := n.Create(ctx, migration.Network{Name: network.Name, Config: network.Config, Location: network.Location})
 			if err != nil {
 				return err
 			}

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -166,8 +166,28 @@ func syncNetworksFromSource(ctx context.Context, sourceName string, n migration.
 		slog.String("source", sourceName),
 	)
 
-	// TODO: Do more than pick up new networks, also delete removed networks and update existing networks with any changes.
-	// Currently, the entire network list is given in existingNetworks for each source, so we will need to be smarter about filtering that as well.
+	for name, network := range existingNetworks {
+		srcNet, ok := srcNetworks[name]
+		if !ok {
+			// TODO: Do more than pick up new networks, also delete removed networks and update existing networks with any changes.
+			// Currently, the entire network list is given in existingNetworks for each source, so we will need to be smarter about filtering that as well.
+			continue
+		}
+
+		networkUpdated := false
+		if network.Location != srcNet.Location {
+			network.Location = srcNet.Location
+			networkUpdated = true
+		}
+
+		if networkUpdated {
+			log.Info("Syncing changes to network from source")
+			err := n.Update(ctx, &network)
+			if err != nil {
+				return fmt.Errorf("Failed to update network: %w", err)
+			}
+		}
+	}
 
 	// Create any missing networks.
 	for name, network := range srcNetworks {

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -104,6 +104,26 @@ func Schema() *schema.Schema {
 
 var updates = map[int]schema.Update{
 	1: updateFromV0,
+	2: updateFromV1,
+}
+
+func updateFromV1(ctx context.Context, tx *sql.Tx) error {
+	stmt := `
+CREATE TABLE networks_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+	  location TEXT NOT NULL,
+    config INTEGER NOT NULL,
+    UNIQUE (name)
+);
+
+INSERT INTO networks_new (id, name, location, config) SELECT id, name, '', config from networks;
+DROP TABLE networks;
+ALTER TABLE networks_new RENAME TO networks;
+	`
+
+	_, err := tx.ExecContext(ctx, stmt)
+	return err
 }
 
 func updateFromV0(ctx context.Context, tx *sql.Tx) error {

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -80,7 +80,6 @@ CREATE TABLE targets (
 // Schema for the local database.
 func Schema() *schema.Schema {
 	dbSchema := schema.NewFromMap(updates)
-	dbSchema.Fresh(freshSchema + `INSERT INTO schema (version, updated_at) VALUES (1, strftime("%s"));`)
 
 	return dbSchema
 }

--- a/internal/migration/network_model.go
+++ b/internal/migration/network_model.go
@@ -35,6 +35,8 @@ func (n Network) ToAPI() api.Network {
 	return api.Network{
 		Name:     n.Name,
 		Location: n.Location,
-		Config:   n.Config,
+		NetworkPut: api.NetworkPut{
+			Config: n.Config,
+		},
 	}
 }

--- a/internal/migration/network_model.go
+++ b/internal/migration/network_model.go
@@ -1,8 +1,9 @@
 package migration
 
 type Network struct {
-	ID   int64
-	Name string `db:"primary=yes"`
+	ID       int64
+	Name     string `db:"primary=yes"`
+	Location string
 
 	Config map[string]string `db:"marshal=json"`
 }
@@ -14,6 +15,10 @@ func (n Network) Validate() error {
 
 	if n.Name == "" {
 		return NewValidationErrf("Invalid network, name can not be empty")
+	}
+
+	if n.Location == "" {
+		return NewValidationErrf("Invalid network, location can not be empty")
 	}
 
 	return nil

--- a/internal/migration/network_model.go
+++ b/internal/migration/network_model.go
@@ -1,5 +1,9 @@
 package migration
 
+import (
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
 type Network struct {
 	ID       int64
 	Name     string `db:"primary=yes"`
@@ -25,3 +29,12 @@ func (n Network) Validate() error {
 }
 
 type Networks []Network
+
+// ToAPI returns the API representation of a network.
+func (n Network) ToAPI() api.Network {
+	return api.Network{
+		Name:     n.Name,
+		Location: n.Location,
+		Config:   n.Config,
+	}
+}

--- a/internal/migration/network_service_test.go
+++ b/internal/migration/network_service_test.go
@@ -23,14 +23,16 @@ func TestNetworkService_Create(t *testing.T) {
 		{
 			name: "success",
 			network: migration.Network{
-				ID:     1,
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 			repoCreateNetwork: migration.Network{
-				ID:     1,
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 
 			assertErr: require.NoError,
@@ -38,9 +40,10 @@ func TestNetworkService_Create(t *testing.T) {
 		{
 			name: "error - invalid id",
 			network: migration.Network{
-				ID:     -1, // invalid
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       -1, // invalid
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -51,9 +54,24 @@ func TestNetworkService_Create(t *testing.T) {
 		{
 			name: "error - name empty",
 			network: migration.Network{
-				ID:     1,
-				Name:   "", // empty
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "", // empty
+				Location: "/path/to/one",
+				Config:   map[string]string{},
+			},
+
+			assertErr: func(tt require.TestingT, err error, a ...any) {
+				var verr migration.ErrValidation
+				require.ErrorAs(tt, err, &verr, a...)
+			},
+		},
+		{
+			name: "error - location empty",
+			network: migration.Network{
+				ID:       1,
+				Name:     "one",
+				Location: "", // empty
+				Config:   map[string]string{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -64,9 +82,10 @@ func TestNetworkService_Create(t *testing.T) {
 		{
 			name: "error - repo",
 			network: migration.Network{
-				ID:     1,
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 			repoCreateErr: boom.Error,
 
@@ -266,9 +285,10 @@ func TestNetworkService_UpdateByID(t *testing.T) {
 		{
 			name: "success",
 			network: migration.Network{
-				ID:     1,
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 
 			assertErr: require.NoError,
@@ -276,9 +296,10 @@ func TestNetworkService_UpdateByID(t *testing.T) {
 		{
 			name: "error - invalid id",
 			network: migration.Network{
-				ID:     -1, // invalid
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       -1, // invalid
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -289,9 +310,10 @@ func TestNetworkService_UpdateByID(t *testing.T) {
 		{
 			name: "error - name empty",
 			network: migration.Network{
-				ID:     1,
-				Name:   "", // empty
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "", // empty
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -302,9 +324,10 @@ func TestNetworkService_UpdateByID(t *testing.T) {
 		{
 			name: "error - repo",
 			network: migration.Network{
-				ID:     1,
-				Name:   "one",
-				Config: map[string]string{},
+				ID:       1,
+				Name:     "one",
+				Location: "/path/to/one",
+				Config:   map[string]string{},
 			},
 			repoUpdateErr: boom.Error,
 

--- a/internal/properties/definitions.go
+++ b/internal/properties/definitions.go
@@ -149,6 +149,20 @@ func (p RawPropertySet[T]) Get(n Name) (PropertyInfo, error) {
 	return info, nil
 }
 
+// GetValue returns the stored value for the property, if one exists. Cannot be used to fetch a group of sub-properties.
+func (p RawPropertySet[T]) GetValue(n Name) (any, error) {
+	if HasSubProperties(n) {
+		return nil, fmt.Errorf("Cannot fetch value of property %q with sub-properties", n.String())
+	}
+
+	val, ok := p.propValues[n]
+	if !ok {
+		return nil, fmt.Errorf("No value assigned to property %q", n.String())
+	}
+
+	return val, nil
+}
+
 // GetSubProperties returns the RawPropertySet for the sub-properties of the named property, if supported by this target or source.
 func (p RawPropertySet[T]) GetSubProperties(n Name) (RawPropertySet[T], error) {
 	if !HasSubProperties(n) {

--- a/internal/properties/instance_properties.yaml
+++ b/internal/properties/instance_properties.yaml
@@ -220,7 +220,8 @@
           source:
               vmware:
                   8.0:
-                    key: backing.deviceName
+                    # InventoryPath is a special field from the global network properties client.
+                    key: InventoryPath
       id:
           source:
               vmware:

--- a/internal/properties/instance_properties.yaml
+++ b/internal/properties/instance_properties.yaml
@@ -225,7 +225,9 @@
           source:
               vmware:
                   8.0:
-                    key: backing.network.value
+                    # For networks, there are many possible objects holding the ID.
+                    # Each set is delimited by commas.
+                    key: backing.network.value,backing.port.portgroupKey
 
 - name: snapshots
   description: instance snapshots

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -206,7 +206,7 @@ func (s *InternalVMwareSource) GetAllNetworks(ctx context.Context) ([]api.Networ
 	}
 
 	for _, n := range networks {
-		ret = append(ret, api.Network{Name: n.Reference().Value})
+		ret = append(ret, api.Network{Name: n.Reference().Value, Location: n.GetInventoryPath()})
 	}
 
 	return ret, nil

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -163,7 +163,7 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 
 		vmProps, err := s.getVMProperties(vm, vmProperties)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to record properties for %q: %w", vm.InventoryPath, err)
 		}
 
 		secretToken, _ := uuid.NewRandom()
@@ -328,7 +328,7 @@ func (s *InternalVMwareSource) getVMProperties(vm *object.VirtualMachine, vmProp
 			for _, snap := range vmProperties.Snapshot.RootSnapshotList {
 				err = s.getDeviceProperties(snap, &props, defName)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("Failed to get %q properties: %w", defName.String(), err)
 				}
 			}
 
@@ -341,7 +341,7 @@ func (s *InternalVMwareSource) getVMProperties(vm *object.VirtualMachine, vmProp
 
 				err = s.getDeviceProperties(eth, &props, defName)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("Failed to get %q properties: %w", defName.String(), err)
 				}
 			}
 
@@ -354,7 +354,7 @@ func (s *InternalVMwareSource) getVMProperties(vm *object.VirtualMachine, vmProp
 
 				err = s.getDeviceProperties(disk, &props, defName)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("Failed to get %q properties: %w", defName.String(), err)
 				}
 			}
 

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -163,6 +165,13 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 
 		vmProps, err := s.getVMProperties(vm, vmProperties)
 		if err != nil {
+			b, marshalErr := json.Marshal(vmProperties)
+			if marshalErr == nil {
+				// Dump the VM properties to the cache dir on errors.
+				fileName := filepath.Join(util.CachePath(), strings.ReplaceAll(vm.InventoryPath, "/", "_"))
+				_ = os.WriteFile(fileName, b, 0o644)
+			}
+
 			return nil, fmt.Errorf("Failed to record properties for %q: %w", vm.InventoryPath, err)
 		}
 

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -4,6 +4,8 @@ package api
 //
 // swagger:model
 type Network struct {
+	NetworkPut
+
 	// The name of the network
 	// Example: network-23
 	Name string `json:"name" yaml:"name"`
@@ -11,7 +13,12 @@ type Network struct {
 	// The location of the network
 	// Example: /path/to/network
 	Location string `json:"location" yaml:"location"`
+}
 
+// NetworkPut defines the configurable properties of Network.
+//
+// swagger:model
+type NetworkPut struct {
 	// Any network-specific config options
 	// Example: {"network": "vmware", "ipv6.address": "none"}
 	Config map[string]string `json:"config" yaml:"config"`

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -8,6 +8,10 @@ type Network struct {
 	// Example: network-23
 	Name string `json:"name" yaml:"name"`
 
+	// The location of the network
+	// Example: /path/to/network
+	Location string `json:"location" yaml:"location"`
+
 	// Any network-specific config options
 	// Example: {"network": "vmware", "ipv6.address": "none"}
 	Config map[string]string `json:"config" yaml:"config"`


### PR DESCRIPTION
This allows us to parse distributed port groups from VMware. 

* The keys in the instance properties now support comma-delimited alternatives to the first key. The first matching key set will be used.
  * For now, this is used for the network ID, which lives in different places according to the NIC type.


* The NIC network is now the full inventory path of the network

* The NIC inventory path (as `Location`) is now included in the networks API and CLI

* Modifying the network name is no longer supported. This didn't make sense anyway as the periodic sync could overwrite it.

I wanted to try replacing the network ID with the UUID from the vCenter URL, but I can't seem to find the actual UUID  on either the VM or global network API, so I kept it as is for now.

There's also the added issue of ESXI overloading the network ID field with the port group UUID split up with spaces. So I had to add a parser to take only the last element, which is the actual network ID. I've also replaced any remaining spaces with "_" because we use these values as API paths. 

