### PR TITLE
ui: Minor layout fixes

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/src/assets/favicon.png">
-    <title>Migration manager</title>
+    <title>Migration Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/DataTable.tsx
+++ b/ui/src/components/DataTable.tsx
@@ -142,7 +142,7 @@ const DataTable: FC<Props> = ({ headers, rows}) => {
   }
 
   return (
-    <div className="container mt-4">
+    <div className="mx-2 mx-md-4 mt-4">
       <Row className="justify-content-end">
         <Col xs="auto">
           <Form.Control

--- a/ui/src/components/InstanceDataTable.tsx
+++ b/ui/src/components/InstanceDataTable.tsx
@@ -15,24 +15,19 @@ interface Props {
 
 const InstanceDataTable: FC<Props> = ({instances}) => {
 
-  const headers = ["UUID", "Source", "Location", "OS version", "CPU", "Memory", "Migration status", ""];
+  const headers = ["Source", "Location", "OS version", "CPU", "Memory", "Migration status", ""];
   const rows = instances.map((item) => {
     const className = item.overrides?.disable_migration === true ? 'item-deleted' : '';
     const isOverrideDefined = hasOverride(item);
 
     return [
       {
-        content: <Link to={`/ui/instances/${item.properties.uuid}`} className="data-table-link">{item.properties.uuid}</Link>,
-        sortKey: item.properties.uuid,
-        class: className,
-      },
-      {
-        content: item.source,
+        content: <Link to={`/ui/sources/${item.source}`} className="data-table-link">{item.source}</Link>,
         sortKey: item.source,
         class: className,
       },
       {
-        content: item.properties.location,
+        content: <Link to={`/ui/instances/${item.properties.uuid}`} className="data-table-link">{item.properties.location}</Link>,
         sortKey: item.properties.location,
         class: className,
       },

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ const Sidebar = () => {
       {/* Sidebar Navbar */}
       <Navbar bg="dark" variant="dark" className="flex-column vh-100">
         <Navbar.Brand href="/ui/" style={{ margin: '5px 15px' }}>
-          Migration manager
+          Migration Manager
         </Navbar.Brand>
 
         {/* Sidebar content */}

--- a/ui/src/pages/Batch.tsx
+++ b/ui/src/pages/Batch.tsx
@@ -73,15 +73,15 @@ const Batch = () => {
 
   return (
     <>
-      <div className="container">
-        <div className="row">
-          <div className="col-12">
-          <Button variant="success" className="float-end" onClick={() => navigate('/ui/batches/create')}>Create batch</Button>
+      <div className="d-flex flex-column">
+        <div className="mx-2 mx-md-4">
+          <div className="row">
+            <div className="col-12">
+            <Button variant="success" className="float-end" onClick={() => navigate('/ui/batches/create')}>Create batch</Button>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="d-flex flex-column">
-        <div className="scroll-container flex-grow-1 p-3">
+        <div className="scroll-container flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>

--- a/ui/src/pages/Source.tsx
+++ b/ui/src/pages/Source.tsx
@@ -20,7 +20,7 @@ const Source = () => {
     refetchInterval: refetchInterval,
   })
 
-  const headers = ["Name", "Type", "Endpoint", "Connectivity status", "Username", "Cert fingerprint"];
+  const headers = ["Name", "Type", "Endpoint", "Connectivity status", "Username"];
   const rows = sources.map((item) => {
     if (item.source_type == SourceType.VMware) {
       const props = item.properties as VMwareProperties;
@@ -44,10 +44,6 @@ const Source = () => {
           content: props.username,
           sortKey: props.username
         },
-        {
-          content: props.trusted_server_certificate_fingerprint,
-          sortKey: props.trusted_server_certificate_fingerprint,
-        },
       ];
     }
 
@@ -68,15 +64,15 @@ const Source = () => {
 
   return (
     <>
-      <div className="container">
-        <div className="row">
-          <div className="col-12">
-          <Button variant="success" className="float-end" onClick={() => navigate('/ui/sources/create')}>Create source</Button>
-          </div>
-        </div>
-      </div>
       <div className="d-flex flex-column">
-        <div className="scroll-container flex-grow-1 p-3">
+        <div className="mx-2 mx-md-4">
+          <div className="row">
+            <div className="col-12">
+              <Button variant="success" className="float-end" onClick={() => navigate('/ui/sources/create')}>Create source</Button>
+            </div>
+          </div>
+	</div>
+        <div className="scroll-container flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>

--- a/ui/src/pages/Target.tsx
+++ b/ui/src/pages/Target.tsx
@@ -19,7 +19,7 @@ const Target = () => {
     refetchInterval: refetchInterval,
   })
 
-  const headers = ["Name", "Type", "Endpoint", "Connectivity status", "Auth Type", "Cert fingerprint"];
+  const headers = ["Name", "Type", "Endpoint", "Connectivity status", "Auth Type"];
   const rows = targets.map((item) => {
     const props = item.properties as IncusProperties;
     let authType = "OIDC";
@@ -48,10 +48,6 @@ const Target = () => {
         content: authType,
         sortKey: authType,
       },
-      {
-        content: props.trusted_server_certificate_fingerprint,
-        sortKey: props.trusted_server_certificate_fingerprint,
-      },
     ];
   });
 
@@ -69,15 +65,15 @@ const Target = () => {
 
   return (
     <>
-      <div className="container">
-        <div className="row">
-          <div className="col-12">
-          <Button variant="success" className="float-end" onClick={() => navigate('/ui/targets/create')}>Create target</Button>
+      <div className="d-flex flex-column">
+        <div className="mx-2 mx-md-4">
+          <div className="row">
+            <div className="col-12">
+            <Button variant="success" className="float-end" onClick={() => navigate('/ui/targets/create')}>Create target</Button>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="d-flex flex-column">
-        <div className="scroll-container flex-grow-1 p-3">
+        <div className="scroll-container flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>


### PR DESCRIPTION
- Title change: "Migration manager" → "Migration Manager"
- General UI
  - Stretch tables horizontally when space is available
- Sources and Targets view
  - Hide the fingerprint from the list
- Instances view
  - Hide the UUID column
  - Make the source a link to the source detail page
  - Make the location a link to the instance detail page