### PR TITLE
Add tags, attributes, and config overrides

### DIFF
--- a/internal/migration/batch_service_test.go
+++ b/internal/migration/batch_service_test.go
@@ -581,7 +581,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A"`,
+				IncludeExpression: `location matches "^/inventory/path/A"`,
 			},
 			instanceSvcGetAllByBatchIDInstances: migration.Instances{
 				{
@@ -703,7 +703,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A"`,
+				IncludeExpression: `location matches "^/inventory/path/A"`,
 			},
 			instanceSvcGetAllByBatchIDInstances: migration.Instances{
 				{
@@ -724,7 +724,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A`, // invalid expression, missing " at the end
+				IncludeExpression: `location matches "^/inventory/path/A`, // invalid expression, missing " at the end
 			},
 			instanceSvcGetAllByBatchIDInstances: migration.Instances{
 				{
@@ -753,7 +753,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A`, // invalid expression, missing " at the end
+				IncludeExpression: `location matches "^/inventory/path/A`, // invalid expression, missing " at the end
 			},
 			instanceSvcGetAllByBatchIDInstances: migration.Instances{
 				{
@@ -782,7 +782,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A"`,
+				IncludeExpression: `location matches "^/inventory/path/A"`,
 			},
 			instanceSvcGetAllByBatchIDInstances: migration.Instances{
 				{
@@ -828,7 +828,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A"`,
+				IncludeExpression: `location matches "^/inventory/path/A"`,
 			},
 			instanceSvcGetAllUnassignedInstances: migration.Instances{
 				{
@@ -849,7 +849,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A`, // invalid expression, missing " at the end
+				IncludeExpression: `location matches "^/inventory/path/A`, // invalid expression, missing " at the end
 			},
 			instanceSvcGetAllUnassignedInstances: migration.Instances{
 				{
@@ -878,7 +878,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A`, // invalid expression, missing " at the end
+				IncludeExpression: `location matches "^/inventory/path/A`, // invalid expression, missing " at the end
 			},
 			instanceSvcGetAllUnassignedInstances: migration.Instances{
 				{
@@ -907,7 +907,7 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			batch: migration.Batch{
 				ID:                1,
 				Name:              "one",
-				IncludeExpression: `Location matches "^/inventory/path/A"`,
+				IncludeExpression: `location matches "^/inventory/path/A"`,
 			},
 			instanceSvcGetAllUnassignedInstances: migration.Instances{
 				{
@@ -1426,49 +1426,49 @@ func TestInternalBatch_InstanceMatchesCriteria(t *testing.T) {
 		},
 		{
 			name:       "Inventory path exact match",
-			expression: `Location == "/a/b/c"`,
+			expression: `location == "/a/b/c"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "Inventory path regex match",
-			expression: `Location matches "^/a/[^/]+/c*"`,
+			expression: `location matches "^/a/[^/]+/c*"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "Name exact match",
-			expression: `Name == "c"`,
+			expression: `name == "c"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "boolean or expression",
-			expression: `Location matches "^/e/f/.*" || Name == "c"`,
+			expression: `location matches "^/e/f/.*" || name == "c"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "boolean and expression",
-			expression: `Location == "/a/b/c" && TPM`,
+			expression: `location == "/a/b/c" && tpm`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "exclude regex",
-			expression: `!(Location matches "^/a/e/.*$")`,
+			expression: `!(location matches "^/a/e/.*$")`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
 		},
 		{
 			name:       "custom path_base function exact match",
-			expression: `path_base(Location) == "c"`,
+			expression: `path_base(location) == "c"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
@@ -1489,7 +1489,7 @@ func TestInternalBatch_InstanceMatchesCriteria(t *testing.T) {
 		},
 		{
 			name:       "custom path_dir function exact match",
-			expression: `path_dir(Location) == "/a/b"`,
+			expression: `path_dir(location) == "/a/b"`,
 
 			assertErr:  require.NoError,
 			wantResult: true,
@@ -1517,7 +1517,7 @@ func TestInternalBatch_InstanceMatchesCriteria(t *testing.T) {
 		},
 		{
 			name:       "complex expression",
-			expression: `Source in ["vcenter01", "vcenter02", "vcenter03"] && (Location startsWith "/a/b" || Location startsWith "/e/f") && CPUs <= 4 && Memory <= 1024*1024*1024*8 && len(Disks) == 1 && !Disks[0].Shared && OS in ["Ubuntu 22.04", "Ubuntu 24.04"]`,
+			expression: `source in ["vcenter01", "vcenter02", "vcenter03"] && (location startsWith "/a/b" || location startsWith "/e/f") && cpus <= 4 && memory <= 1024*1024*1024*8 && len(disks) == 1 && !disks[0].shared && os in ["Ubuntu 22.04", "Ubuntu 24.04"]`,
 
 			assertErr:  require.NoError,
 			wantResult: true,

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -43,12 +43,12 @@ type InstanceOverride struct {
 type InstanceFilterable struct {
 	api.InstanceProperties
 
-	MigrationStatus        api.MigrationStatusType
-	MigrationStatusMessage string
-	LastUpdateFromSource   time.Time
+	MigrationStatus        api.MigrationStatusType `json:"migration_status" expr:"migration_status"`
+	MigrationStatusMessage string                  `json:"migration_status_message" expr:"migration_status_message"`
+	LastUpdateFromSource   time.Time               `json:"last_update_from_source" expr:"last_update_from_source"`
 
-	Source     string
-	SourceType api.SourceType
+	Source     string         `json:"source" expr:"source"`
+	SourceType api.SourceType `json:"source_type" expr:"source_type"`
 }
 
 func (i Instance) Validate() error {

--- a/internal/properties/definitions.go
+++ b/internal/properties/definitions.go
@@ -224,6 +224,12 @@ func (p *RawPropertySet[T]) Add(key Name, val any) error {
 				return fmt.Errorf("Invalid disk capacity %d", flt)
 			}
 
+		case InstanceConfig:
+			_, ok := val.(map[string]string)
+			if !ok {
+				return fmt.Errorf("Cannot convert %q property %v to map", key.String(), val)
+			}
+
 		case InstanceDiskName:
 			fallthrough
 		case InstanceNICHardwareAddress:
@@ -310,6 +316,10 @@ func (p RawPropertySet[T]) ToAPI() (*api.InstanceProperties, error) {
 	err = json.Unmarshal(b, &detectedProperties)
 	if err != nil {
 		return nil, err
+	}
+
+	if detectedProperties.Config == nil {
+		detectedProperties.Config = map[string]string{}
 	}
 
 	return &detectedProperties, nil

--- a/internal/properties/instance_properties.yaml
+++ b/internal/properties/instance_properties.yaml
@@ -252,3 +252,12 @@
           8.0:
               type: property
               key: config.changeTrackingEnabled
+
+- name: config
+  description: generic instance config
+  source:
+      vmware:
+          8.0:
+              type: property
+              # This stores an object with a key ID and a value. The associated key name to ID mapping is in .availableField.
+              key: summary.customValue

--- a/internal/properties/names.go
+++ b/internal/properties/names.go
@@ -38,6 +38,8 @@ const (
 	InstanceBackgroundImport
 	// InstanceArchitecture is the property name for the architecture of the instance.
 	InstanceArchitecture
+	// InstanceConfig is the property name for generic instance config.
+	InstanceConfig
 	// InstanceNICHardwareAddress is the property name for an instance nic's hardware address.
 	InstanceNICHardwareAddress
 	// InstanceNICNetwork is the property name for the name of the network entity used by the instance.
@@ -63,6 +65,8 @@ func (n Name) String() string {
 		return "background_import"
 	case InstanceCPUs:
 		return "cpus"
+	case InstanceConfig:
+		return "config"
 	case InstanceDescription:
 		return "description"
 	case InstanceLegacyBoot:
@@ -117,6 +121,8 @@ func ParseInstanceProperty(s string) (Name, error) {
 		return InstanceBackgroundImport, nil
 	case InstanceCPUs.String():
 		return InstanceCPUs, nil
+	case InstanceConfig.String():
+		return InstanceConfig, nil
 	case InstanceDescription.String():
 		return InstanceDescription, nil
 	case InstanceDisks.String():
@@ -204,6 +210,7 @@ func allInstanceProperties() []Name {
 		InstanceDescription,
 		InstanceBackgroundImport,
 		InstanceArchitecture,
+		InstanceConfig,
 	}
 }
 

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -8,47 +8,47 @@ import (
 type InstanceProperties struct {
 	InstancePropertiesConfigurable
 
-	UUID             uuid.UUID `json:"uuid"              yaml:"uuid"`
-	Name             string    `json:"name"              yaml:"name"`
-	Location         string    `json:"location"          yaml:"location"`
-	OS               string    `json:"os"                yaml:"os"`
-	OSVersion        string    `json:"os_version"        yaml:"os_version"`
-	SecureBoot       bool      `json:"secure_boot"       yaml:"secure_boot"`
-	LegacyBoot       bool      `json:"legacy_boot"       yaml:"legacy_boot"`
-	TPM              bool      `json:"tpm"               yaml:"tpm"`
-	BackgroundImport bool      `json:"background_import" yaml:"background_import"`
-	Architecture     string    `json:"architecture"      yaml:"architecture"`
+	UUID             uuid.UUID `json:"uuid"              yaml:"uuid"              expr:"uuid"`
+	Name             string    `json:"name"              yaml:"name"              expr:"name"`
+	Location         string    `json:"location"          yaml:"location"          expr:"location"`
+	OS               string    `json:"os"                yaml:"os"                expr:"os"`
+	OSVersion        string    `json:"os_version"        yaml:"os_version"        expr:"os_version"`
+	SecureBoot       bool      `json:"secure_boot"       yaml:"secure_boot"       expr:"secure_boot"`
+	LegacyBoot       bool      `json:"legacy_boot"       yaml:"legacy_boot"       expr:"legacy_boot"`
+	TPM              bool      `json:"tpm"               yaml:"tpm"               expr:"tpm"`
+	BackgroundImport bool      `json:"background_import" yaml:"background_import" expr:"background_import"`
+	Architecture     string    `json:"architecture"      yaml:"architecture"      expr:"architecture"`
 
-	NICs      []InstancePropertiesNIC      `json:"nics"      yaml:"nics"`
-	Disks     []InstancePropertiesDisk     `json:"disks"     yaml:"disks"`
-	Snapshots []InstancePropertiesSnapshot `json:"snapshots" yaml:"snapshots"`
+	NICs      []InstancePropertiesNIC      `json:"nics"      yaml:"nics"      expr:"nics"`
+	Disks     []InstancePropertiesDisk     `json:"disks"     yaml:"disks"     expr:"disks"`
+	Snapshots []InstancePropertiesSnapshot `json:"snapshots" yaml:"snapshots" expr:"snapshots"`
 }
 
 // InstancePropertiesConfigurable are the configurable properties of an instance.
 type InstancePropertiesConfigurable struct {
-	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
-	CPUs        int64             `json:"cpus"                  yaml:"cpus"`
-	Memory      int64             `json:"memory"                yaml:"memory"`
-	Config      map[string]string `json:"config"          yaml:"config"`
+	Description string            `json:"description,omitempty" yaml:"description,omitempty" expr:"description"`
+	CPUs        int64             `json:"cpus"                  yaml:"cpus"                  expr:"cpus"`
+	Memory      int64             `json:"memory"                yaml:"memory"                expr:"memory"`
+	Config      map[string]string `json:"config"                yaml:"config"                expr:"config"`
 }
 
 // InstancePropertiesNIC are all properties supported by instance NICs.
 type InstancePropertiesNIC struct {
-	ID              string `json:"id"               yaml:"id"`
-	HardwareAddress string `json:"hardware_address" yaml:"hardware_address"`
-	Network         string `json:"network"          yaml:"network"`
+	ID              string `json:"id"               yaml:"id"               expr:"id"`
+	HardwareAddress string `json:"hardware_address" yaml:"hardware_address" expr:"hardware_address"`
+	Network         string `json:"network"          yaml:"network"          expr:"network"`
 }
 
 // InstancePropertiesDisk are all properties supported by instance disks.
 type InstancePropertiesDisk struct {
-	Capacity int64  `json:"capacity" yaml:"capacity"`
-	Name     string `json:"name"     yaml:"name"`
-	Shared   bool   `json:"shared"   yaml:"shared"`
+	Capacity int64  `json:"capacity" yaml:"capacity" expr:"capacity"`
+	Name     string `json:"name"     yaml:"name"     expr:"name"`
+	Shared   bool   `json:"shared"   yaml:"shared"   expr:"shared"`
 }
 
 // InstancePropertiesSnapshot are all properties supported by snapshots.
 type InstancePropertiesSnapshot struct {
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name" expr:"name"`
 }
 
 // Apply updates the properties with the given set of configurable properties.

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -26,9 +26,10 @@ type InstanceProperties struct {
 
 // InstancePropertiesConfigurable are the configurable properties of an instance.
 type InstancePropertiesConfigurable struct {
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	CPUs        int64  `json:"cpus"                  yaml:"cpus"`
-	Memory      int64  `json:"memory"                yaml:"memory"`
+	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
+	CPUs        int64             `json:"cpus"                  yaml:"cpus"`
+	Memory      int64             `json:"memory"                yaml:"memory"`
+	Config      map[string]string `json:"config"          yaml:"config"`
 }
 
 // InstancePropertiesNIC are all properties supported by instance NICs.

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -65,4 +65,8 @@ func (i *InstanceProperties) Apply(cfg InstancePropertiesConfigurable) {
 	if cfg.Memory != 0 {
 		i.Memory = cfg.Memory
 	}
+
+	for k, v := range cfg.Config {
+		i.Config[k] = v
+	}
 }


### PR DESCRIPTION
Closes #159 

So I feel a bit silly now, I spent a bunch of time last week (and today) digging into the weeds of `expr-lang`, only to realize that there's built-in support for struct tags 🤦‍♂️

So this PR is now way smaller and cleaner!

* Uses struct tag names instead of Go field names in the batch include expression.

* Adds a `config` key/value map to instance properties, which can be overridden through the overrides API as well.
* Adds support for VMware tags and attributes on instances.
  * Tags are added to config as`tag.<category> = <tag1>,<tag2>,<tag3>` 
    * Example: `tag.cat1=tag1,tag2,tag3`
  * Attributes are added to config as `attribute.<scope>.<key> = <value>` 
    * Example: `attribute.global.key1 = val1`

