### PR TITLE
Add Batch Constraints

### DIFF
--- a/cmd/migration-manager/internal/cmds/batch.go
+++ b/cmd/migration-manager/internal/cmds/batch.go
@@ -107,7 +107,8 @@ func (c *cmdBatchAdd) Run(cmd *cobra.Command, args []string) error {
 	// Add the batch.
 	b := api.Batch{
 		BatchPut: api.BatchPut{
-			Name: args[0],
+			Name:        args[0],
+			Constraints: []api.BatchConstraint{},
 		},
 	}
 
@@ -174,6 +175,56 @@ func (c *cmdBatchAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		addWindows, err = c.global.Asker.AskBool("Add more migration windows? (yes/no) [default=no]: ", "no")
+		if err != nil {
+			return err
+		}
+	}
+
+	addConstraints, err := c.global.Asker.AskBool("Add constraints? (yes/no) [default=no]: ", "no")
+	if err != nil {
+		return err
+	}
+
+	for addConstraints {
+		var constraint api.BatchConstraint
+		constraint.Name, err = c.global.Asker.AskString("Constraint name: ", "", nil)
+		if err != nil {
+			return err
+		}
+
+		constraint.Description, err = c.global.Asker.AskString("Constraint description (empty to skip): ", "", validate.IsAny)
+		if err != nil {
+			return err
+		}
+
+		constraint.IncludeExpression, err = c.global.Asker.AskString("Expression to include instances: ", "", validate.IsAny)
+		if err != nil {
+			return err
+		}
+
+		maxConcurrent, err := c.global.Asker.AskString("Maximum concurrent instance (empty to skip): ", "0", validate.IsInt64)
+		if err != nil {
+			return err
+		}
+
+		constraint.MaxConcurrentInstances, err = strconv.Atoi(maxConcurrent)
+		if err != nil {
+			return err
+		}
+
+		constraint.MinInstanceBootTime, err = c.global.Asker.AskString("Minimum instance boot time (empty to skip): ", "", func(s string) error {
+			if s != "" {
+				return validate.IsMinimumDuration(0)(s)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		b.Constraints = append(b.Constraints, constraint)
+		addConstraints, err = c.global.Asker.AskBool("Add more constraints? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}
@@ -616,6 +667,60 @@ func (c *cmdBatchUpdate) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		addWindows, err = c.global.Asker.AskBool("Add more migration windows? (yes/no) [default=no]: ", "no")
+		if err != nil {
+			return err
+		}
+	}
+
+	addConstraints, err := c.global.Asker.AskBool("Replace constraints? (yes/no) [default=no]: ", "no")
+	if err != nil {
+		return err
+	}
+
+	if addConstraints {
+		b.Constraints = []api.BatchConstraint{}
+	}
+
+	for addConstraints {
+		var constraint api.BatchConstraint
+		constraint.Name, err = c.global.Asker.AskString("Constraint name: ", "", nil)
+		if err != nil {
+			return err
+		}
+
+		constraint.Description, err = c.global.Asker.AskString("Constraint description (empty to skip): ", "", validate.IsAny)
+		if err != nil {
+			return err
+		}
+
+		constraint.IncludeExpression, err = c.global.Asker.AskString("Expression to include instances: ", "", validate.IsAny)
+		if err != nil {
+			return err
+		}
+
+		maxConcurrent, err := c.global.Asker.AskString("Maximum concurrent instance (empty to skip): ", "0", validate.IsInt64)
+		if err != nil {
+			return err
+		}
+
+		constraint.MaxConcurrentInstances, err = strconv.Atoi(maxConcurrent)
+		if err != nil {
+			return err
+		}
+
+		constraint.MinInstanceBootTime, err = c.global.Asker.AskString("Minimum instance boot time (empty to skip): ", "", func(s string) error {
+			if s != "" {
+				return validate.IsMinimumDuration(0)(s)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		b.Constraints = append(b.Constraints, constraint)
+		addConstraints, err = c.global.Asker.AskBool("Add more constraints? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -108,6 +108,32 @@ var updates = map[int]schema.Update{
 	1: updateFromV0,
 	2: updateFromV1,
 	3: updateFromV2,
+	4: updateFromV3,
+}
+
+func updateFromV3(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE batches_new (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name               TEXT NOT NULL,
+    target_id          INTEGER NOT NULL,
+    target_project     TEXT NOT NULL,
+    status             TEXT NOT NULL,
+    status_message     TEXT NOT NULL,
+    storage_pool       TEXT NOT NULL,
+    include_expression TEXT NOT NULL,
+    constraints        TEXT NOT NULL,
+    UNIQUE (name),
+    FOREIGN KEY(target_id) REFERENCES targets(id)
+);
+
+INSERT INTO batches_new (id, name, target_id, target_project, status, status_message, storage_pool, include_expression, constraints) SELECT id, name, target_id, target_project, status, status_message, storage_pool, include_expression, '[]' FROM batches;
+
+DROP TABLE batches;
+ALTER TABLE batches_new RENAME TO batches;
+`)
+
+	return err
 }
 
 func updateFromV2(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -107,6 +107,10 @@ func (b BatchConstraint) Validate() error {
 // GetEarliest returns the earliest valid migration window, or an error if none are found.
 func (ws MigrationWindows) GetEarliest() (*MigrationWindow, error) {
 	var earliestWindow *MigrationWindow
+	if len(ws) == 0 {
+		return &MigrationWindow{}, nil
+	}
+
 	for _, w := range ws {
 		if w.Validate() != nil {
 			continue

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -2,11 +2,8 @@ package migration
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
-	"github.com/expr-lang/expr"
-	"github.com/expr-lang/expr/vm"
 	"github.com/lxc/incus/v6/shared/validate"
 
 	"github.com/FuturFusion/migration-manager/shared/api"
@@ -70,7 +67,7 @@ func (b Batch) Validate() error {
 		return NewValidationErrf("Invalid status: %v", err)
 	}
 
-	_, err = b.CompileIncludeExpression(InstanceFilterable{})
+	_, err = InstanceFilterable{}.CompileIncludeExpression(b.IncludeExpression)
 	if err != nil {
 		return NewValidationErrf("Invalid batch %q is not a valid include expression: %v", b.IncludeExpression, err)
 	}
@@ -193,60 +190,6 @@ func (b Batch) CanBeModified() bool {
 	default:
 		return false
 	}
-}
-
-func (b Batch) InstanceMatchesCriteria(instance Instance) (bool, error) {
-	filterable := instance.ToFilterable()
-	includeExpr, err := b.CompileIncludeExpression(filterable)
-	if err != nil {
-		return false, fmt.Errorf("Failed to compile include expression %q: %v", b.IncludeExpression, err)
-	}
-
-	output, err := expr.Run(includeExpr, filterable)
-	if err != nil {
-		return false, fmt.Errorf("Failed to run include expression %q with instance %v: %v", b.IncludeExpression, filterable, err)
-	}
-
-	result, ok := output.(bool)
-	if !ok {
-		return false, fmt.Errorf("Include expression %q does not evaluate to boolean result: %v", b.IncludeExpression, output)
-	}
-
-	return result, nil
-}
-
-func (b Batch) CompileIncludeExpression(i InstanceFilterable) (*vm.Program, error) {
-	customFunctions := []expr.Option{
-		expr.Function("path_base", func(params ...any) (any, error) {
-			if len(params) != 1 {
-				return nil, fmt.Errorf("invalid number of arguments, expected 1, got: %d", len(params))
-			}
-
-			path, ok := params[0].(string)
-			if !ok {
-				return nil, fmt.Errorf("invalid argument type, expected string, got: %T", params[0])
-			}
-
-			return filepath.Base(path), nil
-		}),
-
-		expr.Function("path_dir", func(params ...any) (any, error) {
-			if len(params) != 1 {
-				return nil, fmt.Errorf("invalid number of arguments, expected 1, got: %d", len(params))
-			}
-
-			path, ok := params[0].(string)
-			if !ok {
-				return nil, fmt.Errorf("invalid argument type, expected string, got: %T", params[0])
-			}
-
-			return filepath.Dir(path), nil
-		}),
-	}
-
-	options := append([]expr.Option{expr.Env(i)}, customFunctions...)
-
-	return expr.Compile(b.IncludeExpression, options...)
 }
 
 type Batches []Batch

--- a/internal/migration/batch_service.go
+++ b/internal/migration/batch_service.go
@@ -136,7 +136,7 @@ func (s batchService) UpdateInstancesAssignedToBatch(ctx context.Context, batch 
 
 		// Update each instance for this batch.
 		for _, instance := range instances {
-			isMatch, err := batch.InstanceMatchesCriteria(instance)
+			isMatch, err := instance.MatchesCriteria(batch.IncludeExpression)
 			if err != nil {
 				return err
 			}
@@ -158,7 +158,7 @@ func (s batchService) UpdateInstancesAssignedToBatch(ctx context.Context, batch 
 
 		// Check if any unassigned instances should be assigned to this batch.
 		for _, instance := range instances {
-			isMatch, err := batch.InstanceMatchesCriteria(instance)
+			isMatch, err := instance.MatchesCriteria(batch.IncludeExpression)
 			if err != nil {
 				return err
 			}

--- a/internal/migration/batch_service.go
+++ b/internal/migration/batch_service.go
@@ -217,6 +217,11 @@ func (s batchService) DeleteByName(ctx context.Context, name string) error {
 			}
 		}
 
+		err = s.repo.UnassignMigrationWindows(ctx, name)
+		if err != nil {
+			return err
+		}
+
 		return s.repo.DeleteByName(ctx, name)
 	})
 }

--- a/internal/migration/queue_ports.go
+++ b/internal/migration/queue_ports.go
@@ -15,7 +15,7 @@ type QueueService interface {
 	GetAll(ctx context.Context) (QueueEntries, error)
 	GetAllByState(ctx context.Context, status ...api.MigrationStatusType) (QueueEntries, error)
 	GetAllByBatch(ctx context.Context, batch string) (QueueEntries, error)
-	GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (QueueEntries, error)
+	GetAllByBatchAndState(ctx context.Context, batch string, status ...api.MigrationStatusType) (QueueEntries, error)
 	GetAllNeedingImport(ctx context.Context, batch string, needsDiskImport bool) (QueueEntries, error)
 	GetByInstanceUUID(ctx context.Context, id uuid.UUID) (*QueueEntry, error)
 	Update(ctx context.Context, entry *QueueEntry) error
@@ -37,7 +37,7 @@ type QueueRepo interface {
 	GetAll(ctx context.Context) (QueueEntries, error)
 	GetAllByState(ctx context.Context, status ...api.MigrationStatusType) (QueueEntries, error)
 	GetAllByBatch(ctx context.Context, batch string) (QueueEntries, error)
-	GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (QueueEntries, error)
+	GetAllByBatchAndState(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (QueueEntries, error)
 	GetAllNeedingImport(ctx context.Context, batch string, needsDiskImport bool) (QueueEntries, error)
 	GetByInstanceUUID(ctx context.Context, id uuid.UUID) (*QueueEntry, error)
 	Update(ctx context.Context, entry QueueEntry) error

--- a/internal/migration/queue_service.go
+++ b/internal/migration/queue_service.go
@@ -57,8 +57,8 @@ func (s queueService) GetAllByBatch(ctx context.Context, batch string) (QueueEnt
 	return s.repo.GetAllByBatch(ctx, batch)
 }
 
-func (s queueService) GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (QueueEntries, error) {
-	return s.repo.GetAllByBatchAndState(ctx, batch, status)
+func (s queueService) GetAllByBatchAndState(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (QueueEntries, error) {
+	return s.repo.GetAllByBatchAndState(ctx, batch, statuses...)
 }
 
 func (s queueService) GetAllNeedingImport(ctx context.Context, batch string, needsDiskImport bool) (QueueEntries, error) {

--- a/internal/migration/queue_service.go
+++ b/internal/migration/queue_service.go
@@ -3,8 +3,13 @@ package migration
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"sort"
 
 	"github.com/google/uuid"
+	incusAPI "github.com/lxc/incus/v6/shared/api"
 
 	"github.com/FuturFusion/migration-manager/internal/transaction"
 	"github.com/FuturFusion/migration-manager/shared/api"
@@ -109,6 +114,144 @@ func (s queueService) DeleteAllByBatch(ctx context.Context, batch string) error 
 	return s.repo.DeleteAllByBatch(ctx, batch)
 }
 
+// GetNextWindow returns the next valid migration window for the instance in the batch.
+// - If the instance does not match any constraint, the earliest valid migration window is used.
+// - The earliest migration window valid for the the first matching constraint will be used otherwise.
+// - Returns a 404 if no migration window can be found, but the instance matched a constraint.
+func (s queueService) GetNextWindow(ctx context.Context, batchName string, instanceUUID uuid.UUID) (*MigrationWindow, error) {
+	var entries QueueEntries
+	var instances Instances
+	var windows MigrationWindows
+	var batch *Batch
+	err := transaction.Do(ctx, func(ctx context.Context) error {
+		var err error
+		entries, err = s.GetAllByBatchAndState(ctx, batchName, api.MIGRATIONSTATUS_IDLE, api.MIGRATIONSTATUS_FINAL_IMPORT, api.MIGRATIONSTATUS_IMPORT_COMPLETE)
+		if err != nil {
+			return fmt.Errorf("Failed to get idle queue entries for batch %q: %w", batchName, err)
+		}
+
+		windows, err = s.batch.GetMigrationWindows(ctx, batchName)
+		if err != nil {
+			return fmt.Errorf("Failed to get migration windows for batch %q: %w", batchName, err)
+		}
+
+		instances, err = s.instance.GetAllQueued(ctx, entries)
+		if err != nil {
+			return fmt.Errorf("Failed to get idle instances for batch %q: %w", batchName, err)
+		}
+
+		batch, err = s.batch.GetByName(ctx, batchName)
+		if err != nil {
+			return fmt.Errorf("Failed to get batch %q: %w", batchName, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	matchedAny := false
+	for _, c := range batch.Constraints {
+		if matchedAny {
+			break
+		}
+
+		for _, inst := range instances {
+			match, err := inst.MatchesCriteria(c.IncludeExpression)
+			if err != nil {
+				return nil, err
+			}
+
+			// Record if this instance in particular matched any constraint.
+			if inst.UUID == instanceUUID && match {
+				matchedAny = true
+				break
+			}
+		}
+	}
+
+	// If there are no constraints on the batch, or if the instance matches none of them, just return the earliest migration window.
+	if !matchedAny || len(batch.Constraints) == 0 {
+		return windows.GetEarliest()
+	}
+
+	statusMap := make(map[uuid.UUID]api.MigrationStatusType, len(entries))
+	for _, e := range entries {
+		statusMap[e.InstanceUUID] = e.MigrationStatus
+	}
+
+	// Sort instances according to their status in the queue.
+	sort.Slice(instances, func(i, j int) bool {
+		aFinal := statusMap[instances[i].UUID] == api.MIGRATIONSTATUS_FINAL_IMPORT
+		bFinal := statusMap[instances[j].UUID] == api.MIGRATIONSTATUS_FINAL_IMPORT
+
+		if aFinal != bFinal {
+			return aFinal
+		}
+
+		aFinal = statusMap[instances[i].UUID] == api.MIGRATIONSTATUS_IMPORT_COMPLETE
+		bFinal = statusMap[instances[j].UUID] == api.MIGRATIONSTATUS_IMPORT_COMPLETE
+
+		if aFinal != bFinal {
+			return aFinal
+		}
+
+		return instances[i].UUID.String() < instances[j].UUID.String()
+	})
+
+	for _, c := range batch.Constraints {
+		var numMatches int
+		matches := map[uuid.UUID]bool{}
+		for _, inst := range instances {
+			// If we hit the limit, then stop and check the list of matches.
+			if c.MaxConcurrentInstances > 0 && numMatches == c.MaxConcurrentInstances {
+				break
+			}
+
+			match, err := inst.MatchesCriteria(c.IncludeExpression)
+			if err != nil {
+				return nil, err
+			}
+
+			if !match {
+				continue
+			}
+
+			// Record that we got a match.
+			numMatches++
+
+			// Keep track of IDLE instances that match.
+			if statusMap[inst.UUID] == api.MIGRATIONSTATUS_IDLE {
+				matches[inst.UUID] = true
+			}
+		}
+
+		// Consider the next constraint if this instance does not match, or does not fit within the max concurrent count.
+		if !matches[instanceUUID] {
+			continue
+		}
+
+		// If there is no minimum migration time, we just use the earliest valid migration window.
+		if c.MinInstanceBootTime == 0 {
+			return windows.GetEarliest()
+		}
+
+		// Get the earliest window that fits the constraint duration.
+		index := slices.IndexFunc(windows, func(w MigrationWindow) bool {
+			return w.FitsDuration(c.MinInstanceBootTime)
+		})
+
+		// If we found a matching window, then stop checking constraints and return.
+		if index != -1 {
+			return &windows[index], nil
+		}
+	}
+
+	// Return a 404 if this instance matched a constraint, but no valid migration window could be found.
+	return nil, incusAPI.StatusErrorf(http.StatusNotFound, "No valid migration window found for instance %q", instanceUUID)
+}
+
 // NewWorkerCommandByInstanceID gets the next worker command for the instance with the given UUID, and updates the instance state accordingly.
 // An instance must be IDLE to have a next worker command.
 func (s queueService) NewWorkerCommandByInstanceUUID(ctx context.Context, id uuid.UUID) (WorkerCommand, error) {
@@ -146,28 +289,35 @@ func (s queueService) NewWorkerCommandByInstanceUUID(ctx context.Context, id uui
 			OSVersion:  instance.Properties.OSVersion,
 		}
 
-		window, err := s.batch.GetEarliestWindow(ctx, queueEntry.BatchName)
-		if err != nil {
-			return fmt.Errorf("Failed to get earliest migration window for batch %q: %w", queueEntry.BatchName, err)
-		}
-
 		// Determine what action, if any, the worker should start.
 		newStatus := queueEntry.MigrationStatus
 		newStatusMessage := queueEntry.MigrationStatusMessage
-		switch {
-		case queueEntry.NeedsDiskImport && instance.Properties.BackgroundImport:
+		if queueEntry.NeedsDiskImport && instance.Properties.BackgroundImport {
 			// If we can do a background disk sync, kick it off.
 			workerCommand.Command = api.WORKERCOMMAND_IMPORT_DISKS
 
 			newStatus = api.MIGRATIONSTATUS_BACKGROUND_IMPORT
 			newStatusMessage = string(api.MIGRATIONSTATUS_BACKGROUND_IMPORT)
+		} else {
+			window, err := s.GetNextWindow(ctx, queueEntry.BatchName, queueEntry.InstanceUUID)
+			if err != nil && !incusAPI.StatusErrorCheck(err, http.StatusNotFound) {
+				return err
+			}
 
-		case window.Begun():
-			// If a migration window has not been defined, or it has and we have passed the start time, begin the final migration.
-			workerCommand.Command = api.WORKERCOMMAND_FINALIZE_IMPORT
+			if err != nil {
+				slog.Warn("No matching migration window found, skipping final import for now", slog.String("instance", instance.Properties.Location), slog.Any("error", err))
+				return nil
+			}
 
-			newStatus = api.MIGRATIONSTATUS_FINAL_IMPORT
-			newStatusMessage = string(api.MIGRATIONSTATUS_FINAL_IMPORT)
+			begun := window.Begun()
+			slog.Info("Selected migration window", slog.String("start", window.Start.String()), slog.String("end", window.End.String()), slog.Bool("begun", begun), slog.String("location", instance.Properties.Location))
+			if begun {
+				// If a migration window has not been defined, or it has and we have passed the start time, begin the final migration.
+				workerCommand.Command = api.WORKERCOMMAND_FINALIZE_IMPORT
+
+				newStatus = api.MIGRATIONSTATUS_FINAL_IMPORT
+				newStatusMessage = string(api.MIGRATIONSTATUS_FINAL_IMPORT)
+			}
 		}
 
 		// Update queueEntry in the database, and set the worker update time.

--- a/internal/migration/queue_service_mock_gen_test.go
+++ b/internal/migration/queue_service_mock_gen_test.go
@@ -37,7 +37,7 @@ var _ migration.QueueService = &QueueServiceMock{}
 //			GetAllByBatchFunc: func(ctx context.Context, batch string) (migration.QueueEntries, error) {
 //				panic("mock out the GetAllByBatch method")
 //			},
-//			GetAllByBatchAndStateFunc: func(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error) {
+//			GetAllByBatchAndStateFunc: func(ctx context.Context, batch string, status ...api.MigrationStatusType) (migration.QueueEntries, error) {
 //				panic("mock out the GetAllByBatchAndState method")
 //			},
 //			GetAllByStateFunc: func(ctx context.Context, status ...api.MigrationStatusType) (migration.QueueEntries, error) {
@@ -84,7 +84,7 @@ type QueueServiceMock struct {
 	GetAllByBatchFunc func(ctx context.Context, batch string) (migration.QueueEntries, error)
 
 	// GetAllByBatchAndStateFunc mocks the GetAllByBatchAndState method.
-	GetAllByBatchAndStateFunc func(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error)
+	GetAllByBatchAndStateFunc func(ctx context.Context, batch string, status ...api.MigrationStatusType) (migration.QueueEntries, error)
 
 	// GetAllByStateFunc mocks the GetAllByState method.
 	GetAllByStateFunc func(ctx context.Context, status ...api.MigrationStatusType) (migration.QueueEntries, error)
@@ -149,7 +149,7 @@ type QueueServiceMock struct {
 			// Batch is the batch argument value.
 			Batch string
 			// Status is the status argument value.
-			Status api.MigrationStatusType
+			Status []api.MigrationStatusType
 		}
 		// GetAllByState holds details about calls to the GetAllByState method.
 		GetAllByState []struct {
@@ -405,14 +405,14 @@ func (mock *QueueServiceMock) GetAllByBatchCalls() []struct {
 }
 
 // GetAllByBatchAndState calls GetAllByBatchAndStateFunc.
-func (mock *QueueServiceMock) GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error) {
+func (mock *QueueServiceMock) GetAllByBatchAndState(ctx context.Context, batch string, status ...api.MigrationStatusType) (migration.QueueEntries, error) {
 	if mock.GetAllByBatchAndStateFunc == nil {
 		panic("QueueServiceMock.GetAllByBatchAndStateFunc: method is nil but QueueService.GetAllByBatchAndState was just called")
 	}
 	callInfo := struct {
 		Ctx    context.Context
 		Batch  string
-		Status api.MigrationStatusType
+		Status []api.MigrationStatusType
 	}{
 		Ctx:    ctx,
 		Batch:  batch,
@@ -421,7 +421,7 @@ func (mock *QueueServiceMock) GetAllByBatchAndState(ctx context.Context, batch s
 	mock.lockGetAllByBatchAndState.Lock()
 	mock.calls.GetAllByBatchAndState = append(mock.calls.GetAllByBatchAndState, callInfo)
 	mock.lockGetAllByBatchAndState.Unlock()
-	return mock.GetAllByBatchAndStateFunc(ctx, batch, status)
+	return mock.GetAllByBatchAndStateFunc(ctx, batch, status...)
 }
 
 // GetAllByBatchAndStateCalls gets all the calls that were made to GetAllByBatchAndState.
@@ -431,12 +431,12 @@ func (mock *QueueServiceMock) GetAllByBatchAndState(ctx context.Context, batch s
 func (mock *QueueServiceMock) GetAllByBatchAndStateCalls() []struct {
 	Ctx    context.Context
 	Batch  string
-	Status api.MigrationStatusType
+	Status []api.MigrationStatusType
 } {
 	var calls []struct {
 		Ctx    context.Context
 		Batch  string
-		Status api.MigrationStatusType
+		Status []api.MigrationStatusType
 	}
 	mock.lockGetAllByBatchAndState.RLock()
 	calls = mock.calls.GetAllByBatchAndState

--- a/internal/migration/repo/middleware/queue_slog_gen.go
+++ b/internal/migration/repo/middleware/queue_slog_gen.go
@@ -125,11 +125,11 @@ func (_d QueueRepoWithSlog) GetAllByBatch(ctx context.Context, batch string) (q1
 }
 
 // GetAllByBatchAndState implements _sourceMigration.QueueRepo
-func (_d QueueRepoWithSlog) GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (q1 _sourceMigration.QueueEntries, err error) {
+func (_d QueueRepoWithSlog) GetAllByBatchAndState(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (q1 _sourceMigration.QueueEntries, err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
 		slog.String("batch", batch),
-		slog.Any("status", status),
+		slog.Any("statuses", statuses),
 	).Debug("QueueRepoWithSlog: calling GetAllByBatchAndState")
 	defer func() {
 		log := _d._log.With(
@@ -142,7 +142,7 @@ func (_d QueueRepoWithSlog) GetAllByBatchAndState(ctx context.Context, batch str
 			log.Debug("QueueRepoWithSlog: method GetAllByBatchAndState finished")
 		}
 	}()
-	return _d._base.GetAllByBatchAndState(ctx, batch, status)
+	return _d._base.GetAllByBatchAndState(ctx, batch, statuses...)
 }
 
 // GetAllByState implements _sourceMigration.QueueRepo

--- a/internal/migration/repo/mock/queue_repo_mock_gen.go
+++ b/internal/migration/repo/mock/queue_repo_mock_gen.go
@@ -37,7 +37,7 @@ var _ migration.QueueRepo = &QueueRepoMock{}
 //			GetAllByBatchFunc: func(ctx context.Context, batch string) (migration.QueueEntries, error) {
 //				panic("mock out the GetAllByBatch method")
 //			},
-//			GetAllByBatchAndStateFunc: func(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error) {
+//			GetAllByBatchAndStateFunc: func(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (migration.QueueEntries, error) {
 //				panic("mock out the GetAllByBatchAndState method")
 //			},
 //			GetAllByStateFunc: func(ctx context.Context, status ...api.MigrationStatusType) (migration.QueueEntries, error) {
@@ -75,7 +75,7 @@ type QueueRepoMock struct {
 	GetAllByBatchFunc func(ctx context.Context, batch string) (migration.QueueEntries, error)
 
 	// GetAllByBatchAndStateFunc mocks the GetAllByBatchAndState method.
-	GetAllByBatchAndStateFunc func(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error)
+	GetAllByBatchAndStateFunc func(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (migration.QueueEntries, error)
 
 	// GetAllByStateFunc mocks the GetAllByState method.
 	GetAllByStateFunc func(ctx context.Context, status ...api.MigrationStatusType) (migration.QueueEntries, error)
@@ -130,8 +130,8 @@ type QueueRepoMock struct {
 			Ctx context.Context
 			// Batch is the batch argument value.
 			Batch string
-			// Status is the status argument value.
-			Status api.MigrationStatusType
+			// Statuses is the statuses argument value.
+			Statuses []api.MigrationStatusType
 		}
 		// GetAllByState holds details about calls to the GetAllByState method.
 		GetAllByState []struct {
@@ -353,23 +353,23 @@ func (mock *QueueRepoMock) GetAllByBatchCalls() []struct {
 }
 
 // GetAllByBatchAndState calls GetAllByBatchAndStateFunc.
-func (mock *QueueRepoMock) GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error) {
+func (mock *QueueRepoMock) GetAllByBatchAndState(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (migration.QueueEntries, error) {
 	if mock.GetAllByBatchAndStateFunc == nil {
 		panic("QueueRepoMock.GetAllByBatchAndStateFunc: method is nil but QueueRepo.GetAllByBatchAndState was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		Batch  string
-		Status api.MigrationStatusType
+		Ctx      context.Context
+		Batch    string
+		Statuses []api.MigrationStatusType
 	}{
-		Ctx:    ctx,
-		Batch:  batch,
-		Status: status,
+		Ctx:      ctx,
+		Batch:    batch,
+		Statuses: statuses,
 	}
 	mock.lockGetAllByBatchAndState.Lock()
 	mock.calls.GetAllByBatchAndState = append(mock.calls.GetAllByBatchAndState, callInfo)
 	mock.lockGetAllByBatchAndState.Unlock()
-	return mock.GetAllByBatchAndStateFunc(ctx, batch, status)
+	return mock.GetAllByBatchAndStateFunc(ctx, batch, statuses...)
 }
 
 // GetAllByBatchAndStateCalls gets all the calls that were made to GetAllByBatchAndState.
@@ -377,14 +377,14 @@ func (mock *QueueRepoMock) GetAllByBatchAndState(ctx context.Context, batch stri
 //
 //	len(mockedQueueRepo.GetAllByBatchAndStateCalls())
 func (mock *QueueRepoMock) GetAllByBatchAndStateCalls() []struct {
-	Ctx    context.Context
-	Batch  string
-	Status api.MigrationStatusType
+	Ctx      context.Context
+	Batch    string
+	Statuses []api.MigrationStatusType
 } {
 	var calls []struct {
-		Ctx    context.Context
-		Batch  string
-		Status api.MigrationStatusType
+		Ctx      context.Context
+		Batch    string
+		Statuses []api.MigrationStatusType
 	}
 	mock.lockGetAllByBatchAndState.RLock()
 	calls = mock.calls.GetAllByBatchAndState

--- a/internal/migration/repo/sqlite/entities/batch.mapper.go
+++ b/internal/migration/repo/sqlite/entities/batch.mapper.go
@@ -14,14 +14,14 @@ import (
 )
 
 var batchObjects = RegisterStmt(`
-SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression
+SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression, batches.constraints
   FROM batches
   JOIN targets ON batches.target_id = targets.id
   ORDER BY batches.name
 `)
 
 var batchObjectsByID = RegisterStmt(`
-SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression
+SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression, batches.constraints
   FROM batches
   JOIN targets ON batches.target_id = targets.id
   WHERE ( batches.id = ? )
@@ -29,7 +29,7 @@ SELECT batches.id, batches.name, targets.name AS target, batches.target_project,
 `)
 
 var batchObjectsByName = RegisterStmt(`
-SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression
+SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression, batches.constraints
   FROM batches
   JOIN targets ON batches.target_id = targets.id
   WHERE ( batches.name = ? )
@@ -37,7 +37,7 @@ SELECT batches.id, batches.name, targets.name AS target, batches.target_project,
 `)
 
 var batchObjectsByStatus = RegisterStmt(`
-SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression
+SELECT batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression, batches.constraints
   FROM batches
   JOIN targets ON batches.target_id = targets.id
   WHERE ( batches.status = ? )
@@ -63,13 +63,13 @@ SELECT batches.id FROM batches
 `)
 
 var batchCreate = RegisterStmt(`
-INSERT INTO batches (name, target_id, target_project, status, status_message, storage_pool, include_expression)
-  VALUES (?, (SELECT targets.id FROM targets WHERE targets.name = ?), ?, ?, ?, ?, ?)
+INSERT INTO batches (name, target_id, target_project, status, status_message, storage_pool, include_expression, constraints)
+  VALUES (?, (SELECT targets.id FROM targets WHERE targets.name = ?), ?, ?, ?, ?, ?, ?)
 `)
 
 var batchUpdate = RegisterStmt(`
 UPDATE batches
-  SET name = ?, target_id = (SELECT targets.id FROM targets WHERE targets.name = ?), target_project = ?, status = ?, status_message = ?, storage_pool = ?, include_expression = ?
+  SET name = ?, target_id = (SELECT targets.id FROM targets WHERE targets.name = ?), target_project = ?, status = ?, status_message = ?, storage_pool = ?, include_expression = ?, constraints = ?
  WHERE id = ?
 `)
 
@@ -161,7 +161,7 @@ func GetBatch(ctx context.Context, db dbtx, name string) (_ *migration.Batch, _e
 // batchColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Batch entity.
 func batchColumns() string {
-	return "batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression"
+	return "batches.id, batches.name, targets.name AS target, batches.target_project, batches.status, batches.status_message, batches.storage_pool, batches.include_expression, batches.constraints"
 }
 
 // getBatches can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -170,7 +170,13 @@ func getBatches(ctx context.Context, stmt *sql.Stmt, args ...any) ([]migration.B
 
 	dest := func(scan func(dest ...any) error) error {
 		b := migration.Batch{}
-		err := scan(&b.ID, &b.Name, &b.Target, &b.TargetProject, &b.Status, &b.StatusMessage, &b.StoragePool, &b.IncludeExpression)
+		var constraintsStr string
+		err := scan(&b.ID, &b.Name, &b.Target, &b.TargetProject, &b.Status, &b.StatusMessage, &b.StoragePool, &b.IncludeExpression, &constraintsStr)
+		if err != nil {
+			return err
+		}
+
+		err = unmarshalJSON(constraintsStr, &b.Constraints)
 		if err != nil {
 			return err
 		}
@@ -194,7 +200,13 @@ func getBatchesRaw(ctx context.Context, db dbtx, sql string, args ...any) ([]mig
 
 	dest := func(scan func(dest ...any) error) error {
 		b := migration.Batch{}
-		err := scan(&b.ID, &b.Name, &b.Target, &b.TargetProject, &b.Status, &b.StatusMessage, &b.StoragePool, &b.IncludeExpression)
+		var constraintsStr string
+		err := scan(&b.ID, &b.Name, &b.Target, &b.TargetProject, &b.Status, &b.StatusMessage, &b.StoragePool, &b.IncludeExpression, &constraintsStr)
+		if err != nil {
+			return err
+		}
+
+		err = unmarshalJSON(constraintsStr, &b.Constraints)
 		if err != nil {
 			return err
 		}
@@ -426,7 +438,7 @@ func CreateBatch(ctx context.Context, db dbtx, object migration.Batch) (_ int64,
 		_err = mapErr(_err, "Batch")
 	}()
 
-	args := make([]any, 7)
+	args := make([]any, 8)
 
 	// Populate the statement arguments.
 	args[0] = object.Name
@@ -436,6 +448,12 @@ func CreateBatch(ctx context.Context, db dbtx, object migration.Batch) (_ int64,
 	args[4] = object.StatusMessage
 	args[5] = object.StoragePool
 	args[6] = object.IncludeExpression
+	marshaledConstraints, err := marshalJSON(object.Constraints)
+	if err != nil {
+		return -1, err
+	}
+
+	args[7] = marshaledConstraints
 
 	// Prepared statement to use.
 	stmt, err := Stmt(db, batchCreate)
@@ -481,7 +499,12 @@ func UpdateBatch(ctx context.Context, db tx, name string, object migration.Batch
 		return fmt.Errorf("Failed to get \"batchUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Target, object.TargetProject, object.Status, object.StatusMessage, object.StoragePool, object.IncludeExpression, id)
+	marshaledConstraints, err := marshalJSON(object.Constraints)
+	if err != nil {
+		return err
+	}
+
+	result, err := stmt.Exec(object.Name, object.Target, object.TargetProject, object.Status, object.StatusMessage, object.StoragePool, object.IncludeExpression, marshaledConstraints, id)
 	if err != nil {
 		return fmt.Errorf("Update \"batches\" entry failed: %w", err)
 	}

--- a/internal/migration/repo/sqlite/queue.go
+++ b/internal/migration/repo/sqlite/queue.go
@@ -45,8 +45,13 @@ func (q queue) GetAllByBatch(ctx context.Context, batch string) (migration.Queue
 	return entities.GetQueueEntries(ctx, transaction.GetDBTX(ctx, q.db), entities.QueueEntryFilter{BatchName: &batch})
 }
 
-func (q queue) GetAllByBatchAndState(ctx context.Context, batch string, status api.MigrationStatusType) (migration.QueueEntries, error) {
-	return entities.GetQueueEntries(ctx, transaction.GetDBTX(ctx, q.db), entities.QueueEntryFilter{BatchName: &batch, MigrationStatus: &status})
+func (q queue) GetAllByBatchAndState(ctx context.Context, batch string, statuses ...api.MigrationStatusType) (migration.QueueEntries, error) {
+	filters := []entities.QueueEntryFilter{}
+	for _, s := range statuses {
+		filters = append(filters, entities.QueueEntryFilter{BatchName: &batch, MigrationStatus: &s})
+	}
+
+	return entities.GetQueueEntries(ctx, transaction.GetDBTX(ctx, q.db), filters...)
 }
 
 func (q queue) GetAllNeedingImport(ctx context.Context, batch string, needsDiskImport bool) (migration.QueueEntries, error) {

--- a/shared/api/batch.go
+++ b/shared/api/batch.go
@@ -73,17 +73,18 @@ type BatchPut struct {
 	IncludeExpression string `json:"include_expression" yaml:"include_expression"`
 
 	// Set of migration window timings.
-	MigrationWindows []MigrationWindow
+	MigrationWindows []MigrationWindow `json:"migration_windows" yaml:"migration_windows"`
 }
 
 // MigrationWindow defines the scheduling of a batch migration.
 type MigrationWindow struct {
 	// Start time for finalizing migrations after background import.
-	Start time.Time
+	Start time.Time `json:"start" yaml:"start"`
 
 	// End time for finalizing migrations after background import.
-	End time.Time
+	End time.Time `json:"end" yaml:"end"`
 
 	// Lockout time after which the batch can no longer modify the target instance.
-	Lockout time.Time
+	Lockout time.Time `json:"lockout" yaml:"lockout"`
+}
 }

--- a/shared/api/batch.go
+++ b/shared/api/batch.go
@@ -74,6 +74,9 @@ type BatchPut struct {
 
 	// Set of migration window timings.
 	MigrationWindows []MigrationWindow `json:"migration_windows" yaml:"migration_windows"`
+
+	// Set of constraints to apply to the batch.
+	Constraints []BatchConstraint `json:"constraints" yaml:"constraints"`
 }
 
 // MigrationWindow defines the scheduling of a batch migration.
@@ -87,4 +90,21 @@ type MigrationWindow struct {
 	// Lockout time after which the batch can no longer modify the target instance.
 	Lockout time.Time `json:"lockout" yaml:"lockout"`
 }
+
+// BatchConstraint is a constraint to be applied to a batch to determine which instances can be migrated.
+type BatchConstraint struct {
+	// Name of the constraint.
+	Name string `json:"name" yaml:"name"`
+
+	// Description of the constraint.
+	Description string `json:"description" yaml:"description"`
+
+	// Expression used to select instances for the constraint.
+	IncludeExpression string `json:"include_expression" yaml:"include_expression"`
+
+	// Maximum amount of matched instances that can concurrently migrate, before moving to the next migration window.
+	MaxConcurrentInstances int `json:"max_concurrent_instances" yaml:"max_concurrent_instances"`
+
+	// Minimum amount of time required for an instance to boot after initial disk import. Migration window duration must be at least this much.
+	MinInstanceBootTime string `json:"min_instance_boot_time" yaml:"min_instance_boot_time"`
 }


### PR DESCRIPTION
Closes #157

Batches can have a list of constraints now.

Each constraint has the following fields:

Name | Description
:-- | :--
name (required)  | name of the constraint
description | description of the constraint
include_expression (required) | expression to match instances
max_concurrent_instances | maximum number of instances matching the constraint that can be in the final migration steps
min_instance_boot_time | minimum time it takes for an instance to boot. The migration window chosen must last at least this long, plus buffer of 1 minute*

*We should add an override per-instance to increase the buffer time once we assign instances to a migration window.


Constraints will be checked in order. The first constraint that an instance matches against will apply to it. If no constraints match an instance, it will start with no restrictions, using the first available migration window.