### PR TITLE
ui: Support for multiple migration windows

### DIFF
--- a/ui/src/api/instances.tsx
+++ b/ui/src/api/instances.tsx
@@ -19,18 +19,6 @@ export const fetchInstance = (uuid: string): Promise<Instance> => {
   });
 };
 
-export const createInstanceOverride = (uuid: string, body: string): Promise<APIResponse<null>> => {
-  return new Promise((resolve, reject) => {
-    fetch(`/1.0/instances/${uuid}/override`, {
-      method: "POST",
-      body: body,
-    })
-      .then((response) => response.json())
-      .then((data) => resolve(data))
-      .catch(reject);
-  });
-};
-
 export const updateInstanceOverride = (uuid: string, body: string): Promise<APIResponse<null>> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/instances/${uuid}/override`, {

--- a/ui/src/components/BatchForm.test.tsx
+++ b/ui/src/components/BatchForm.test.tsx
@@ -38,8 +38,6 @@ test('renders and submit BaseForm', async () => {
     include_expression: 'false',
     storage_pool: "local",
     target_project: "default",
-    migration_window_end: null,
-    migration_window_start: null,
     status: "",
     status_message: "",
   });

--- a/ui/src/components/BatchForm.test.tsx
+++ b/ui/src/components/BatchForm.test.tsx
@@ -40,6 +40,7 @@ test('renders and submit BaseForm', async () => {
     target_project: "default",
     status: "",
     status_message: "",
+    migration_windows: [],
   });
 });
 

--- a/ui/src/components/BatchForm.tsx
+++ b/ui/src/components/BatchForm.tsx
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useFormik } from 'formik';
 import { fetchTargets } from 'api/targets';
 import { Batch } from 'types/batch';
-import { formatDate, isMigrationWindowDateValid} from 'util/date';
 
 interface Props {
   batch?: Batch;
@@ -34,14 +33,6 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
       errors.include_expression = 'Include expression is required';
     }
 
-    if (values.migration_window_start && !isMigrationWindowDateValid(values.migration_window_start)) {
-      errors.migration_window_start = 'Not valid date format';
-    }
-
-    if (values.migration_window_end && !isMigrationWindowDateValid(values.migration_window_end)) {
-      errors.migration_window_end = 'Not valid date format';
-    }
-
     return errors;
   };
 
@@ -53,8 +44,6 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
     status_message: '',
     storage_pool: 'local',
     include_expression: '',
-    migration_window_start: '',
-    migration_window_end: '',
   };
 
   if (batch) {
@@ -66,8 +55,6 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
       status_message: batch.status_message,
       storage_pool: batch.storage_pool,
       include_expression: batch.include_expression,
-      migration_window_start: formatDate(batch.migration_window_start.toString()),
-      migration_window_end: formatDate(batch.migration_window_end.toString()),
     };
   }
 
@@ -76,23 +63,10 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
     validate: validateForm,
     enableReinitialize: true,
     onSubmit: (values) => {
-      let windowStart = null;
-      let windowEnd = null;
-
-      if (values.migration_window_start) {
-        windowStart = new Date(values.migration_window_start).toISOString();
-      }
-
-      if (values.migration_window_end) {
-        windowEnd = new Date(values.migration_window_end).toISOString();
-      }
-
       const modifiedValues = {
         ...values,
         target_project: values.target_project != '' ? values.target_project : 'default',
         storage_pool: values.storage_pool != '' ? values.storage_pool : 'local',
-        migration_window_start: windowStart,
-        migration_window_end: windowEnd,
       };
 
       onSubmit(modifiedValues);
@@ -167,38 +141,6 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
               <Form.Control.Feedback type="invalid">
                 {formik.errors.include_expression}
               </Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group className="mb-3" controlId="windowStart">
-            <Form.Label>Migration window start</Form.Label>
-            <Form.Control
-              type="text"
-              name="migration_window_start"
-              value={formik.values.migration_window_start}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
-              isInvalid={!!formik.errors.migration_window_start && formik.touched.migration_window_start}/>
-            <Form.Text className="text-muted">
-              YYYY-MM-DD HH:MM:SS / YYYY-MM-DD HH:MM:SS UTC (e.g., {formatDate(new Date().toISOString())})
-            </Form.Text>
-            <Form.Control.Feedback type="invalid">
-              {formik.errors.migration_window_start}
-            </Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group className="mb-3" controlId="windowEnd">
-            <Form.Label>Migration window end</Form.Label>
-            <Form.Control
-              type="text"
-              name="migration_window_end"
-              value={formik.values.migration_window_end}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
-              isInvalid={!!formik.errors.migration_window_end && formik.touched.migration_window_end}/>
-            <Form.Text className="text-muted">
-              YYYY-MM-DD HH:MM:SS / YYYY-MM-DD HH:MM:SS UTC (e.g., {formatDate(new Date().toISOString())})
-            </Form.Text>
-            <Form.Control.Feedback type="invalid">
-              {formik.errors.migration_window_end}
-            </Form.Control.Feedback>
           </Form.Group>
         </Form>
       </div>

--- a/ui/src/components/BatchOverview.tsx
+++ b/ui/src/components/BatchOverview.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
+import { Table } from 'react-bootstrap';
 import { useParams } from 'react-router';
 import { fetchBatch } from 'api/batches';
+import { formatDate } from 'util/date';
 
 const BatchOverview = () => {
   const { name } = useParams();
@@ -50,6 +52,29 @@ const BatchOverview = () => {
       <div className="row">
         <div className="col-2 detail-table-header">Include expression</div>
         <div className="col-10 detail-table-cell">{ batch?.include_expression }</div>
+      </div>
+      <div className="row">
+        <div className="col-2 detail-table-header">Migration windows</div>
+        <div className="col-10 detail-table-cell">
+          <Table borderless size="sm">
+            <thead>
+              <tr>
+                <th>Start</th>
+                <th>End</th>
+                <th>Lockout</th>
+              </tr>
+            </thead>
+            <tbody>
+              {batch?.migration_windows.map((item, index) => (
+                <tr key={index}>
+                  <td>{formatDate(item.start.toString())}</td>
+                  <td>{formatDate(item.end.toString())}</td>
+                  <td>{formatDate(item.lockout.toString())}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/BatchOverview.tsx
+++ b/ui/src/components/BatchOverview.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { fetchBatch } from 'api/batches';
-import { formatDate } from 'util/date';
 
 const BatchOverview = () => {
   const { name } = useParams();
@@ -51,14 +50,6 @@ const BatchOverview = () => {
       <div className="row">
         <div className="col-2 detail-table-header">Include expression</div>
         <div className="col-10 detail-table-cell">{ batch?.include_expression }</div>
-      </div>
-      <div className="row">
-        <div className="col-2 detail-table-header">Window start</div>
-        <div className="col-10 detail-table-cell">{ formatDate(batch?.migration_window_start.toString()) }</div>
-      </div>
-      <div className="row">
-        <div className="col-2 detail-table-header">Window stop</div>
-        <div className="col-10 detail-table-cell">{ formatDate(batch?.migration_window_end.toString()) }</div>
       </div>
     </div>
   );

--- a/ui/src/components/InstanceDataTable.tsx
+++ b/ui/src/components/InstanceDataTable.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const InstanceDataTable: FC<Props> = ({instances}) => {
 
-  const headers = ["Source", "Location", "OS version", "CPU", "Memory", "Migration status", ""];
+  const headers = ["Source", "Location", "OS version", "CPU", "Memory", ""];
   const rows = instances.map((item) => {
     const className = item.overrides?.disable_migration === true ? 'item-deleted' : '';
     const isOverrideDefined = hasOverride(item);
@@ -50,11 +50,6 @@ const InstanceDataTable: FC<Props> = ({instances}) => {
           override={bytesToHumanReadable(item.overrides?.properties.memory)}
           showOverride={isOverrideDefined && item.overrides.properties.memory > 0}/>,
         sortKey: isOverrideDefined && item.overrides.properties.memory > 0 ? item.overrides.properties.memory : item.properties.memory,
-        class: className,
-      },
-      {
-        content: item.migration_status_message,
-        sortKey: item.migration_status_message,
         class: className,
       },
       {

--- a/ui/src/components/InstanceOverrides.tsx
+++ b/ui/src/components/InstanceOverrides.tsx
@@ -6,7 +6,6 @@ import { useParams } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useFormik } from 'formik';
 import {
-  createInstanceOverride,
   deleteInstanceOverride,
   updateInstanceOverride,
   fetchInstance
@@ -111,23 +110,14 @@ const InstanceOverrides: FC = () => {
           config: values.config,
         }
       };
-      if (!overrideExists) {
-        createInstanceOverride(uuid ?? '', JSON.stringify(modifiedValues, null, 2))
-          .then((response) => {
-            handleSuccessResponse(response);
-          })
-          .catch((e) => {
-            handleErrorResponse(e);
-          });
-      } else {
-        updateInstanceOverride(uuid ?? '', JSON.stringify(modifiedValues, null, 2))
-          .then((response) => {
-            handleSuccessResponse(response);
-          })
-          .catch((e) => {
-            handleErrorResponse(e);
-          });
-      }
+
+      updateInstanceOverride(uuid ?? '', JSON.stringify(modifiedValues, null, 2))
+        .then((response) => {
+          handleSuccessResponse(response);
+        })
+        .catch((e) => {
+          handleErrorResponse(e);
+        });
      },
    });
 

--- a/ui/src/components/InstanceOverview.tsx
+++ b/ui/src/components/InstanceOverview.tsx
@@ -42,6 +42,10 @@ const InstanceOverview = () => {
         <div className="col-10 detail-table-cell"> { instance.source }</div>
       </div>
       <div className="row">
+        <div className="col-2 detail-table-header">Source type</div>
+        <div className="col-10 detail-table-cell"> { instance.source_type }</div>
+      </div>
+      <div className="row">
         <div className="col-2 detail-table-header">Location</div>
         <div className="col-10 detail-table-cell">{ instance.properties.location }</div>
       </div>
@@ -70,10 +74,6 @@ const InstanceOverview = () => {
             override={bytesToHumanReadable(instance.overrides?.properties.memory)}
             showOverride={hasOverride(instance) && instance.overrides.properties.memory > 0}/>
         </div>
-      </div>
-      <div className="row">
-        <div className="col-2 detail-table-header">Migration status</div>
-        <div className="col-10 detail-table-cell">{ instance.migration_status_message }</div>
       </div>
     </div>
   );

--- a/ui/src/components/MigrationWindowsWidget.test.tsx
+++ b/ui/src/components/MigrationWindowsWidget.test.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test, vi } from 'vitest';
+import MigrationWindowsWidget from 'components/MigrationWindowsWidget';
+
+test('add new item to MigrationWindowsWidget', async () => {
+  const handleChange = vi.fn();
+
+  render(<MigrationWindowsWidget value={[]} onChange={handleChange}/>);
+
+  const startInput = screen.getByPlaceholderText('Start');
+  const endInput = screen.getByPlaceholderText('End');
+  const lockoutInput = screen.getByPlaceholderText('Lockout');
+  const addButton = screen.getByTitle('Add');
+
+  await userEvent.type(startInput, '2025-06-01 09:00:00 UTC');
+  await userEvent.type(endInput, '2025-06-02 09:00:00 UTC');
+  await userEvent.type(lockoutInput, '2025-06-03 09:00:00 UTC');
+
+  await act(async () => {
+    await fireEvent.click(addButton);
+  });
+
+  // Check if onChange was called with correct data
+  expect(handleChange).toHaveBeenCalledTimes(1);
+  expect(handleChange).toHaveBeenCalledWith([{
+    start: "2025-06-01 09:00:00 UTC",
+    end: "2025-06-02 09:00:00 UTC",
+    lockout: "2025-06-03 09:00:00 UTC",
+  }]);
+});
+
+test('remove item from MigrationWindowsWidget', async () => {
+  const handleChange = vi.fn();
+
+  const val = [
+    {
+      start: "2025-06-01 09:00:00 UTC",
+      end: "2025-06-02 09:00:00 UTC",
+      lockout: "2025-06-03 09:00:00 UTC",
+    },
+    {
+      start: "2025-06-04 09:00:00 UTC",
+      end: "2025-06-05 09:00:00 UTC",
+      lockout: "",
+    },
+  ];
+
+  render(<MigrationWindowsWidget value={val} onChange={handleChange}/>);
+
+  const deleteButtons = screen.getAllByTitle('Delete');
+
+  await act(async () => {
+    await fireEvent.click(deleteButtons[0]);
+  });
+
+  // Check if onChange was called with correct data
+  expect(handleChange).toHaveBeenCalledTimes(1);
+  expect(handleChange).toHaveBeenCalledWith([{
+      start: "2025-06-04 09:00:00 UTC",
+      end: "2025-06-05 09:00:00 UTC",
+      lockout: "",
+  }]);
+});

--- a/ui/src/components/MigrationWindowsWidget.tsx
+++ b/ui/src/components/MigrationWindowsWidget.tsx
@@ -1,0 +1,130 @@
+import { FC, useEffect, useState } from "react";
+import { Button, Form, Table } from "react-bootstrap";
+import { BsPlus, BsTrash } from "react-icons/bs";
+import { MigrationWindow } from "types/batch";
+import { formatDate } from 'util/date';
+
+interface Props {
+  value: MigrationWindow[];
+  onChange: (value: MigrationWindow[]) => void;
+}
+
+const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
+  const [entries, setEntries] = useState<MigrationWindow[]>(value || []);
+  const [migrationWindow, setMigrationWindow] = useState<MigrationWindow>({start: "", end: "", lockout: ""});
+
+  const handleAdd = () => {
+    const newValues = [...entries, migrationWindow];
+    setEntries(newValues);
+    onChange(newValues);
+    setMigrationWindow({start: "", end: "", lockout: ""})
+  };
+
+  useEffect(() => {
+    setEntries(value || {});
+  }, [value]);
+
+  const handleDelete = (index: number) => {
+    const updated = entries.filter((_, idx) => idx != index);
+    setEntries(updated);
+    onChange(updated);
+  };
+
+  function updateMigrationWindowField<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
+    obj[key] = value;
+  }
+
+  const handleEdit = (index: number, field: string, value: string) => {
+    const newValue = entries[index];
+    updateMigrationWindowField(newValue, field as keyof MigrationWindow, value);
+
+    const newValues = entries.map((item, idx) =>
+      idx === index ? newValue : item
+    );
+    setEntries(newValues);
+    onChange(newValues);
+  };
+
+  return (
+    <div>
+      <Table borderless>
+        <tbody>
+          {entries.map((item, index) => (
+            <>
+            <tr key={index}>
+              <td style={{ display: 'flex', gap: '8px' }}>
+                <Form.Control
+                  type="text"
+                  size="sm"
+                  value={item.start}
+                  onChange={(e) => handleEdit(index, "start", e.target.value)}
+                />
+                <Form.Control
+                  type="text"
+                  size="sm"
+                  value={item.end}
+                  onChange={(e) => handleEdit(index, "end", e.target.value)}
+                />
+              </td>
+              <td>
+                <Button title="Delete" size="sm" variant="outline-secondary" className="bg-white border no-hover" onClick={() => handleDelete(index)}>
+                  <BsTrash />
+                </Button>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Form.Control
+                  type="text"
+                  size="sm"
+                  value={item.lockout}
+                  onChange={(e) => handleEdit(index, "lockout", e.target.value)}
+                />
+              </td>
+            </tr>
+            </>
+          ))}
+          <tr>
+            <td style={{ display: 'flex', gap: '8px' }}>
+              <Form.Control
+                type="text"
+                size="sm"
+                placeholder="Start"
+                value={migrationWindow.start}
+                onChange={(e) => setMigrationWindow({...migrationWindow, start: e.target.value})}
+              />
+              <Form.Control
+                type="text"
+                size="sm"
+                placeholder="End"
+                value={migrationWindow.end}
+                onChange={(e) => setMigrationWindow({...migrationWindow, end: e.target.value})}
+              />
+            </td>
+            <td>
+              <Button title="Add" size="sm" variant="outline-secondary" className="bg-white border no-hover" onClick={handleAdd}>
+                <BsPlus />
+              </Button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <Form.Control
+                type="text"
+                size="sm"
+                placeholder="Lockout"
+                value={migrationWindow.lockout}
+                onChange={(e) => setMigrationWindow({...migrationWindow, lockout: e.target.value})}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td className="text-muted small">Required format: YYYY-MM-DD HH:MM:SS / YYYY-MM-DD HH:MM:SS UTC (e.g., {formatDate(new Date().toISOString())})</td>
+          </tr>
+        </tbody>
+      </Table>
+    </div>
+  );
+};
+
+export default MigrationWindowsWidget;

--- a/ui/src/pages/Batch.tsx
+++ b/ui/src/pages/Batch.tsx
@@ -4,7 +4,6 @@ import { Link, useNavigate } from 'react-router';
 import { fetchBatches } from 'api/batches';
 import BatchActions from 'components/BatchActions';
 import DataTable from 'components/DataTable.tsx';
-import { formatDate } from 'util/date';
 
 const Batch = () => {
   const navigate = useNavigate();
@@ -19,7 +18,7 @@ const Batch = () => {
     refetchInterval: refetchInterval,
   })
 
-  const headers = ["Name", "Status", "Target", "Project", "Storage pool", "Include expression", "Window start", "Window end", "Actions"];
+  const headers = ["Name", "Status", "Target", "Project", "Storage pool", "Include expression", "Actions"];
   const rows = batches.map((item) => {
     return [
       {
@@ -45,14 +44,6 @@ const Batch = () => {
       {
         content: item.include_expression,
         sortKey: item.include_expression
-      },
-      {
-        content: formatDate(item.migration_window_start.toString()),
-        sortKey: formatDate(item.migration_window_start.toString()),
-      },
-      {
-        content: formatDate(item.migration_window_end.toString()),
-        sortKey: formatDate(item.migration_window_end.toString())
       },
       {
         content: <BatchActions batch={item} />

--- a/ui/src/types/batch.d.ts
+++ b/ui/src/types/batch.d.ts
@@ -1,12 +1,25 @@
-export interface Batch {
-  database_id: number;
+export interface BatchConstraint {
+  name: string;
+  description: string;
   include_expression: string;
-  migration_window_end: Date;
-  migration_window_start: Date;
+  max_concurrent_instances: number;
+  min_instance_boot_time: string;
+}
+
+export interface MigrationWindow {
+  start: Date;
+  end: Date;
+  lockout: Date;
+}
+
+export interface Batch {
+  include_expression: string;
   name: string;
   status: string;
   status_message: string;
   storage_pool: string;
   target: string;
   target_project: string;
+  migration_windows: MigrationWindow[];
+  constraints: BatchConstraint[];
 }

--- a/ui/src/types/batch.d.ts
+++ b/ui/src/types/batch.d.ts
@@ -7,9 +7,9 @@ export interface BatchConstraint {
 }
 
 export interface MigrationWindow {
-  start: Date;
-  end: Date;
-  lockout: Date;
+  start: string;
+  end: string;
+  lockout: string;
 }
 
 export interface Batch {

--- a/ui/src/types/instance.d.ts
+++ b/ui/src/types/instance.d.ts
@@ -47,19 +47,16 @@ export interface InstancePropertiesConfigurable {
 }
 
 export interface InstanceOverride {
-  uuid: string;
-  last_update: Date;
+  last_update: string;
   comment: string;
   disable_migration: boolean;
   properties: InstancePropertiesConfigurable;
 }
 
 export interface Instance {
-  migration_status: string;
-  migration_status_message: string;
   last_update_from_source: string;
   source: string;
-  batch_id: string;
+  source_type: SourceType;
   properties: InstanceProperties;
   overrides: InstanceOverride;
 }

--- a/ui/src/util/instance.test.ts
+++ b/ui/src/util/instance.test.ts
@@ -10,7 +10,7 @@ test('hasOverride', () => {
   expect(hasOverride(undefined)).toBe(false);
 
   const emptyOverride = {
-      uuid: '00000000-0000-0000-0000-000000000000'
+    last_update: "0001-01-01T00:00:00Z",
   } as InstanceOverride;
 
   expect(hasOverride({
@@ -18,7 +18,7 @@ test('hasOverride', () => {
   } as Instance)).toBe(false);
 
   const testOverride = {
-      uuid: '52b2a489-dec6-49ed-b321-93468a05bd51'
+    last_update: "2025-04-17T07:38:46.644478767Z",
   } as InstanceOverride;
 
   expect(hasOverride({

--- a/ui/src/util/instance.ts
+++ b/ui/src/util/instance.ts
@@ -1,11 +1,12 @@
 import { Instance } from 'types/instance';
+import { formatDate } from 'util/date';
 
 export const hasOverride = (item: Instance | undefined) => {
   if (!item) {
     return false;
   }
 
-  if (item.overrides && item.overrides.uuid !== "00000000-0000-0000-0000-000000000000") {
+  if (item.overrides && formatDate(item.overrides.last_update) !== "") {
     return true;
   }
 


### PR DESCRIPTION
1. Fixes after API changes
  - Removed `createInstanceOverride` – only `PUT` is supported for instance creation
  - Added `source_type` field to instance
  - Reorganized fields in `Batch` and `Instance` models
3. Support for multiple migration windows

**Screenshots**

<img src="https://github.com/user-attachments/assets/a29d0006-c19f-4b3b-b1c6-2a02ee55afa5" width=500 />
<img src="https://github.com/user-attachments/assets/508c0d13-18bb-4859-89b2-f42acba6f855" width=500 />
