### PR TITLE
Multiple disk support

### DIFF
--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -414,7 +414,7 @@ func (d *Daemon) finalizeCompleteInstances(ctx context.Context) (_err error) {
 			if entry.MigrationStatus != api.MIGRATIONSTATUS_IMPORT_COMPLETE {
 				_, err := d.queueHandler.ReceivedWorkerUpdate(entry.InstanceUUID, time.Second*30)
 				if err != nil && !incusAPI.StatusErrorCheck(err, http.StatusNotFound) {
-					_, err = d.queue.UpdateStatusByUUID(ctx, entry.InstanceUUID, api.MIGRATIONSTATUS_ERROR, "Timed out waiting for worker", false)
+					_, err = d.queue.UpdateStatusByUUID(ctx, entry.InstanceUUID, entry.MigrationStatus, "Timed out waiting for worker", false)
 					if err != nil {
 						return fmt.Errorf("Failed to set errored state on instance %q: %w", state.Instances[entry.InstanceUUID].Properties.Location, err)
 					}

--- a/internal/migratekit/nbdcopy/nbdcopy.go
+++ b/internal/migratekit/nbdcopy/nbdcopy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/migratekit/progress"
 )
 
-func Run(source, destination string, size int64, targetIsClean bool, diskName string, statusCallback func(string, bool)) error {
+func Run(message string, source string, destination string, size int64, targetIsClean bool, diskName string, statusCallback func(string, bool)) error {
 	log := slog.With(
 		slog.String("command", "nbdcopy"),
 		slog.String("source", source),
@@ -75,7 +75,7 @@ func Run(source, destination string, size int64, targetIsClean bool, diskName st
 			}
 
 			bar.Set64(progress * size / 100)
-			statusCallback(fmt.Sprintf("Importing disk %q: %02.2f%% complete", diskName, float64(progress)), false)
+			statusCallback(fmt.Sprintf("%s %q: %02.2f%% complete", message, diskName, float64(progress)), false)
 		}
 
 		if err := scanner.Err(); err != nil {

--- a/internal/migratekit/target/disk.go
+++ b/internal/migratekit/target/disk.go
@@ -3,8 +3,10 @@ package target
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -51,7 +53,8 @@ func (t *DiskTarget) Exists(ctx context.Context) (bool, error) {
 }
 
 func (t *DiskTarget) GetCurrentChangeID(ctx context.Context) (*vmware.ChangeID, error) {
-	data, err := os.ReadFile("/tmp/migration-manager.cid")
+	diskParts := strings.Split(t.DeviceTarget, "/")
+	data, err := os.ReadFile(fmt.Sprintf("/tmp/migration-manager_%s.cid", diskParts[len(diskParts)-1]))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
@@ -60,5 +63,6 @@ func (t *DiskTarget) GetCurrentChangeID(ctx context.Context) (*vmware.ChangeID, 
 }
 
 func (t *DiskTarget) WriteChangeID(ctx context.Context, changeID *vmware.ChangeID) error {
-	return os.WriteFile("/tmp/migration-manager.cid", []byte(changeID.Value), 0o644)
+	diskParts := strings.Split(t.DeviceTarget, "/")
+	return os.WriteFile(fmt.Sprintf("/tmp/migration-manager_%s.cid", diskParts[len(diskParts)-1]), []byte(changeID.Value), 0o644)
 }

--- a/internal/migratekit/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/migratekit/vmware_nbdkit/vmware_nbdkit.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/vmware/govmomi/object"
@@ -95,6 +98,12 @@ func (s *NbdkitServers) Start(ctx context.Context) error {
 	for _, device := range snapshot.Config.Hardware.Device {
 		switch disk := device.(type) {
 		case *types.VirtualDisk:
+			// Ignore raw disks or those excluded from snapshots.
+			_, err := vmware.IsSupportedDisk(disk)
+			if err != nil {
+				continue
+			}
+
 			backing := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
 			info := backing.GetVirtualDeviceFileBackingInfo()
 
@@ -181,6 +190,64 @@ func (s *NbdkitServers) Stop(ctx context.Context) error {
 	return nil
 }
 
+func resolveRootDisk() (string, error) {
+	entries, err := os.ReadDir("/dev/disk/by-id")
+	if err != nil {
+		return "", err
+	}
+
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), "_incus_root") {
+			continue
+		}
+
+		diskID, err := filepath.EvalSymlinks(filepath.Join("/dev/disk/by-id", e.Name()))
+		if err != nil {
+			return "", err
+		}
+
+		return diskID, nil
+	}
+
+	return "", fmt.Errorf("Failed to find root disk device")
+}
+
+func resolveDiskBySize(disk *types.VirtualDisk) (string, error) {
+	entries, err := os.ReadDir("/dev/disk/by-id")
+	if err != nil {
+		return "", err
+	}
+
+	for _, e := range entries {
+		// Skip the root disk.
+		if strings.HasSuffix(e.Name(), "_incus_root") {
+			continue
+		}
+
+		diskPath, err := filepath.EvalSymlinks(filepath.Join("/dev/disk/by-id", e.Name()))
+		if err != nil {
+			return "", err
+		}
+
+		sizePath := filepath.Join(filepath.Join("/sys/class/block", filepath.Base(diskPath)), "size")
+		b, err := os.ReadFile(sizePath)
+		if err != nil {
+			return "", err
+		}
+
+		value, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+		if err != nil {
+			return "", err
+		}
+
+		if disk.CapacityInBytes == int64(value)*512 {
+			return diskPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("Failed to find disk with capacity %d", disk.CapacityInBytes)
+}
+
 func (s *NbdkitServers) MigrationCycle(ctx context.Context, runV2V bool) error {
 	err := s.Start(ctx)
 	if err != nil {
@@ -194,13 +261,21 @@ func (s *NbdkitServers) MigrationCycle(ctx context.Context, runV2V bool) error {
 	}()
 
 	for index, server := range s.Servers {
-		t, err := target.NewDiskTarget(s.VirtualMachine, server.Disk, fmt.Sprintf("/dev/sd%c", 'a'+index))
+		var diskID string
+		if index == 0 {
+			diskID, err = resolveRootDisk()
+		} else {
+			runV2V = false
+			diskID, err = resolveDiskBySize(server.Disk)
+		}
+
 		if err != nil {
 			return err
 		}
 
-		if index != 0 {
-			runV2V = false
+		t, err := target.NewDiskTarget(s.VirtualMachine, server.Disk, diskID)
+		if err != nil {
+			return err
 		}
 
 		err = server.SyncToTarget(ctx, t, runV2V, s.StatusCallback)

--- a/internal/migratekit/vmware_nbdkit/vmware_nbdkit.go
+++ b/internal/migratekit/vmware_nbdkit/vmware_nbdkit.go
@@ -295,12 +295,25 @@ func (s *NbdkitServer) FullCopyToTarget(t target.Target, path string, targetIsCl
 
 	log.Info("Starting full copy")
 
+	diskName := s.Disk.Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
+
+	index := 1
+	for i, server := range s.Servers.Servers {
+		serverDiskName := server.Disk.Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
+		if serverDiskName == diskName {
+			index = i + 1
+			break
+		}
+	}
+
+	msg := fmt.Sprintf("(%d/%d) Importing disk", index, len(s.Servers.Servers))
 	err := nbdcopy.Run(
+		msg,
 		s.Nbdkit.LibNBDExportName(),
 		path,
 		s.Disk.CapacityInBytes,
 		targetIsClean,
-		s.Disk.Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName,
+		diskName,
 		statusCallback,
 	)
 	if err != nil {

--- a/internal/properties/definitions.go
+++ b/internal/properties/definitions.go
@@ -295,7 +295,7 @@ func (p *RawPropertySet[T]) Add(key Name, val any) error {
 
 // ToAPI converts the raw properties list to an API compatible type.
 // Since we already validated the inputs when calling Add, this just remarshals the value maps as the API type.
-func (p RawPropertySet[T]) ToAPI() (*api.InstanceProperties, error) {
+func (p RawPropertySet[T]) ToAPI(unsupportedDisks map[string]bool) (*api.InstanceProperties, error) {
 	data := map[string]any{}
 
 	for k, v := range p.propValues {
@@ -327,6 +327,10 @@ func (p RawPropertySet[T]) ToAPI() (*api.InstanceProperties, error) {
 
 	if detectedProperties.Config == nil {
 		detectedProperties.Config = map[string]string{}
+	}
+
+	for i, disk := range detectedProperties.Disks {
+		detectedProperties.Disks[i].Supported = !unsupportedDisks[disk.Name]
 	}
 
 	return &detectedProperties, nil

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -41,9 +41,10 @@ type InstancePropertiesNIC struct {
 
 // InstancePropertiesDisk are all properties supported by instance disks.
 type InstancePropertiesDisk struct {
-	Capacity int64  `json:"capacity" yaml:"capacity" expr:"capacity"`
-	Name     string `json:"name"     yaml:"name"     expr:"name"`
-	Shared   bool   `json:"shared"   yaml:"shared"   expr:"shared"`
+	Capacity  int64  `json:"capacity"  yaml:"capacity"  expr:"capacity"`
+	Name      string `json:"name"      yaml:"name"      expr:"name"`
+	Shared    bool   `json:"shared"    yaml:"shared"    expr:"shared"`
+	Supported bool   `json:"supported" yaml:"supported" expr:"supported"`
 }
 
 // InstancePropertiesSnapshot are all properties supported by snapshots.


### PR DESCRIPTION
* Add support for syncing multiple disks to an Incus target.
* VMs with raw disks, shared disks, or disks without snapshot capabilities are automatically disabled upon detection, and a warning is logged, indicating the VM, its offending disk, and the reason for the lack of support. If this is manually overridden, the VM can be migrated and those disks will be ignored.
* Disk properties now have a `supported` field that shows whether a detected disk supports migration. This was done so those disks can still be used for filtering purposes.
* Worker timeouts don't result in a total failure anymore. Now it's just a message, and if the worker reports back later, the migration will continue where it left off.

The target instance is created first, so that the scheduler can place it, and additional volumes are created on the same target. We may need some smarter scheduling logic in the future so that an instance's expected volumes are taken into account when placing the instance initially.