### PR TITLE
NSX network visibility

### DIFF
--- a/cmd/migration-manager/internal/cmds/network.go
+++ b/cmd/migration-manager/internal/cmds/network.go
@@ -80,7 +80,7 @@ func (c *cmdNetworkAdd) Run(cmd *cobra.Command, args []string) error {
 
 	// Add the network.
 	n := api.Network{
-		Name: args[0],
+		Identifier: args[0],
 	}
 
 	_, err = c.global.Asker.AskString("Enter a JSON string with any network-specific configuration (empty to skip): ", "", func(s string) error {
@@ -105,7 +105,7 @@ func (c *cmdNetworkAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cmd.Printf("Successfully added new network %q.\n", n.Name)
+	cmd.Printf("Successfully added new network %q.\n", n.Identifier)
 	return nil
 }
 
@@ -163,7 +163,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 			configString, _ = json.Marshal(n.Config)
 		}
 
-		data = append(data, []string{n.Name, n.Location, n.Source, string(n.Type), string(configString)})
+		data = append(data, []string{n.Identifier, n.Location, n.Source, string(n.Type), string(configString)})
 	}
 
 	sort.Sort(util.SortColumnsNaturally(data))
@@ -249,7 +249,7 @@ func (c *cmdNetworkUpdate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prompt for updates.
-	origNetworkName := network.Name
+	origNetworkName := network.Identifier
 	configString := []byte{}
 	if network.Config != nil {
 		configString, err = json.Marshal(network.Config)
@@ -274,7 +274,7 @@ func (c *cmdNetworkUpdate) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	newNetworkName := network.Name
+	newNetworkName := network.Identifier
 
 	// Update the network.
 	content, err := json.Marshal(network.NetworkPut)

--- a/cmd/migration-manager/internal/cmds/network.go
+++ b/cmd/migration-manager/internal/cmds/network.go
@@ -154,7 +154,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the table.
-	header := []string{"Name", "Location", "Config"}
+	header := []string{"Name", "Location", "Source", "Type", "Config"}
 	data := [][]string{}
 
 	for _, n := range networks {
@@ -163,7 +163,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 			configString, _ = json.Marshal(n.Config)
 		}
 
-		data = append(data, []string{n.Name, n.Location, string(configString)})
+		data = append(data, []string{n.Name, n.Location, n.Source, string(n.Type), string(configString)})
 	}
 
 	sort.Sort(util.SortColumnsNaturally(data))

--- a/cmd/migration-manager/internal/cmds/source.go
+++ b/cmd/migration-manager/internal/cmds/source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
-var supportedSourceTypes = []string{"vmware"}
+var supportedSourceTypes = []string{string(api.SOURCETYPE_VMWARE), string(api.SOURCETYPE_NSX)}
 
 type CmdSource struct {
 	Global *CmdGlobal
@@ -88,7 +88,7 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sourceType := "vmware"
+	sourceType := string(api.SOURCETYPE_VMWARE)
 	sourceName := ""
 	sourceEndpoint := ""
 
@@ -107,8 +107,10 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the source.
-	switch sourceType {
-	case "vmware":
+	switch api.SourceType(sourceType) {
+	case api.SOURCETYPE_NSX:
+		fallthrough
+	case api.SOURCETYPE_VMWARE:
 		sourceUsername, err := c.global.Asker.AskString("Please enter username for endpoint '"+sourceEndpoint+"': ", "", validate.IsNotEmpty)
 		if err != nil {
 			return err
@@ -127,7 +129,7 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 			SourcePut: api.SourcePut{
 				Name: sourceName,
 			},
-			SourceType: api.SOURCETYPE_VMWARE,
+			SourceType: api.SourceType(sourceType),
 		}
 
 		s.Properties, err = json.Marshal(vmwareProperties)
@@ -216,6 +218,8 @@ func (c *cmdSourceList) Run(cmd *cobra.Command, args []string) error {
 
 	for _, s := range sources {
 		switch s.SourceType {
+		case api.SOURCETYPE_NSX:
+			fallthrough
 		case api.SOURCETYPE_VMWARE:
 			vmwareProperties := api.VMwareProperties{}
 			err := json.Unmarshal(s.Properties, &vmwareProperties)
@@ -317,6 +321,8 @@ func (c *cmdSourceUpdate) Run(cmd *cobra.Command, args []string) error {
 	origSourceName := ""
 	newSourceName := ""
 	switch src.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		vmwareProperties := api.VMwareProperties{}
 		err := json.Unmarshal(src.Properties, &vmwareProperties)

--- a/internal/api/nsx.go
+++ b/internal/api/nsx.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+// NSXSourceProperties represent the properties of a Migration Manager source with type NSX.
+type NSXSourceProperties struct {
+	api.VMwareProperties `yaml:",inline"`
+
+	ComputeManagers []NSXComputeManager    `json:"compute_managers" yaml:"compute_managers"`
+	Segments        []NSXSegment           `json:"segments"         yaml:"segments"`
+	EdgeNodes       []NSXEdgeTransportNode `json:"edge_nodes"       yaml:"edge_nodes"`
+	Policies        []NSXSecurityPolicy    `json:"policies"         yaml:"policies"`
+}
+
+// VCenterNetworkProperties is the set of network properties we can obtain from vCenter.
+type VCenterNetworkProperties struct {
+	SegmentPath       string    `json:"segment_id,omitempty"          yaml:"segment_id,omitempty"`
+	TransportZoneUUID uuid.UUID `json:"transport_zone_uuid,omitempty" yaml:"transport_zone_uuid,omitempty"`
+}
+
+// NSXNetworkProperties is the set of network properties we can obtain from an NSX Manager.
+type NSXNetworkProperties struct {
+	Source        string           `json:"source"         yaml:"source"`
+	Segment       NSXSegment       `json:"segment"        yaml:"segment"`
+	TransportZone NSXTransportZone `json:"transport_zone" yaml:"transport_zone"`
+}
+
+// NSXSegment is an NSX segment from /policy/api/v1/{path/to/segmentID}.
+type NSXSegment struct {
+	UUID             uuid.UUID          `json:"unique_id"                   yaml:"unique_id"`
+	Name             string             `json:"display_name"                yaml:"display_name"`
+	Path             string             `json:"path"                        yaml:"path"`
+	ID               string             `json:"id"                          yaml:"id"`
+	ConnectivityPath string             `json:"connectivity_path,omitempty" yaml:"connectivity_path,omitempty"`
+	Type             string             `json:"type"                        yaml:"type"`
+	Subnets          []NSXSegmentSubnet `json:"subnets"                     yaml:"subnets"`
+	VLANs            []string           `json:"vlan_ids,omitempty"          yaml:"vlan_ids,omitempty"`
+
+	// Aggregated types.
+	Rules NSXGatewayPolicy    `json:"rules,omitempty" yaml:"rules,omitempty"`
+	VMs   []NSXVirtualMachine `json:"vms"             yaml:"vms"`
+}
+
+// NSXVirtualMachine is an NSX registered VM from /api/v1/fabric/virtual-machines.
+type NSXVirtualMachine struct {
+	UUID        uuid.UUID `json:"external_id"  yaml:"external_id"`
+	DisplayName string    `json:"display_name" yaml:"display_name"`
+	VIFs        []NSXVIF  `json:"vifs"         yaml:"vifs"`
+}
+
+// NSXVIF is an NSX registered VIF from /api/v1/fabric/vifs.
+type NSXVIF struct {
+	SegmentPortID string      `json:"lport_attachment_id" yaml:"lport_attachment_id"`
+	UUID          uuid.UUID   `json:"owner_vm_id"         yaml:"owner_vm_id"`
+	IPs           []NSXIPInfo `json:"ip_address_info"     yaml:"ip_address_info"`
+	MacAddress    string      `json:"mac_address"         yaml:"mac_address"`
+}
+
+// NSXIPInfo is a sub-property of NSXVIF.
+type NSXIPInfo struct {
+	IPs []string `json:"ip_addresses" yaml:"ip_addresses"`
+}
+
+// NSXSegmentPort is an NSX segment port from /policy/api/v1/{path/to/segmentID}/ports.
+type NSXSegmentPort struct {
+	UUID       uuid.UUID                `json:"unique_id"  yaml:"unique_id"`
+	Path       string                   `json:"path"       yaml:"path"`
+	Attachment NSXSegmentPortAttachment `json:"attachment" yaml:"attachment"`
+}
+
+// NSXSegmentPortAttachment is a sub-property of NSXSegmentPort.
+type NSXSegmentPortAttachment struct {
+	ID         string `json:"id"          yaml:"id"`
+	TrafficTag int    `json:"traffic_tag" yaml:"traffic_tag"`
+}
+
+// NSXSegmentSubnet is a sub-property of NSXSegmentPort.
+type NSXSegmentSubnet struct {
+	GatewayAddress string `json:"gateway_address" yaml:"gateway_address"`
+	Networks       string `json:"network"         yaml:"network"`
+}
+
+// NSXGatewayPolicy is an NSX segment gateway policy from /policy/api/v1/{path/to/segmentID}/gateway-firewall.
+type NSXGatewayPolicy struct {
+	UUID           uuid.UUID `json:"unique_id"       yaml:"unique_id"`
+	Name           string    `json:"display_name"    yaml:"display_name"`
+	Path           string    `json:"path"            yaml:"path"`
+	SequenceNumber int       `json:"sequence_number" yaml:"sequence_number"`
+	Rules          []NSXRule `json:"rules"           yaml:"rules"`
+}
+
+// NSXTransportZone is an NSX transport zone from /api/v1/transport-zones.
+type NSXTransportZone struct {
+	UUID            uuid.UUID `json:"transport_zone_id" yaml:"transport_zone_id"`
+	Nested          bool      `json:"nested_nsx"        yaml:"nested_nsx"`
+	AuthorizedVLANs []string  `json:"authorized_vlans"  yaml:"authorized_vlans"`
+	Name            string    `json:"display_name"      yaml:"display_name"`
+}
+
+// NSXEdgeTransportNode is an NSX edge transport node from /api/v1/transport-nodes.
+type NSXEdgeTransportNode struct {
+	Name         string                `json:"display_name"         yaml:"display_name"`
+	Info         NSXNodeDeploymentInfo `json:"node_deployment_info" yaml:"node_deployment_info"`
+	HostSwitches NSXHostSwitchSpec     `json:"host_switch_spec"     yaml:"host_switch_spec"`
+}
+
+// NSXNodeDeploymentInfo is a sub-property of NSXEdgeTransportNode.
+type NSXNodeDeploymentInfo struct {
+	UUID     uuid.UUID       `json:"external_id"   yaml:"external_id"`
+	Type     string          `json:"resource_type" yaml:"resource_type"`
+	IPs      []string        `json:"ip_addresses"  yaml:"ip_addresses"`
+	Settings NSXNodeSettings `json:"node_settings" yaml:"node_settings"`
+}
+
+// NSXNodeSettings is a sub-property of NSXNodeDeploymentInfo.
+type NSXNodeSettings struct {
+	Hostname      string   `json:"hostname"       yaml:"hostname"`
+	DNSServers    []string `json:"dns_servers"    yaml:"dns_servers"`
+	SearchDomains []string `json:"search_domains" yaml:"search_domains"`
+}
+
+// NSXHostSwitchSpec is a sub-property of NSXEdgeTransportNode.
+type NSXHostSwitchSpec struct {
+	Switches []NSXHostSwitch `json:"host_switches" yaml:"host_switches"`
+}
+
+type NSXHostSwitch struct {
+	UUID           string             `json:"host_switch_id"           yaml:"host_switch_id"`
+	Name           string             `json:"host_switch_name"         yaml:"host_switch_name"`
+	Mode           string             `json:"host_switch_mode"         yaml:"host_switch_mode"`
+	Type           string             `json:"host_switch_type"         yaml:"host_switch_type"`
+	PhysicalNICs   []NSXPhysicalNIC   `json:"pnics"                    yaml:"pnics"`
+	IPPool         NSXIPPool          `json:"ip_assignment_spec"       yaml:"ip_assignment_spec"`
+	TransportZones []NSXTransportZone `json:"transport_zone_endpoints" yaml:"transport_zone_endpoints"`
+}
+
+// NSXIPPool is an NSX IP pool set from /api/v1/pools/ip-pools.
+type NSXIPPool struct {
+	UUID    uuid.UUID         `json:"ip_pool_id,omitempty"     yaml:"ip_pool_id,omitempty"`
+	Type    string            `json:"ip_addess_type,omitempty" yaml:"ip_addess_type,omitempty"`
+	Subnets []NSXIPPoolSubnet `json:"subnets,omitempty"        yaml:"subnets,omitempty"`
+}
+
+// NSXIPPoolSubnet is a sub-property of NSXIPPool.
+type NSXIPPoolSubnet struct {
+	CIDR           string           `json:"cidr"              yaml:"cidr"`
+	GatewayIP      string           `json:"gateway_ip"        yaml:"gateway_ip"`
+	DNSNameservers []string         `json:"dns_nameservers"   yaml:"dns_nameservers"`
+	Ranges         []NSXIPPoolRange `json:"allocation_ranges" yaml:"allocation_ranges"`
+}
+
+// NSXIPPoolRange is a sub-property of NSXIPPoolSubnet.
+type NSXIPPoolRange struct {
+	Start string `json:"start" yaml:"start"`
+	End   string `json:"end"   yaml:"end"`
+}
+
+// NSXPhysicalNIC is a sub-property of NSXHostSwitch.
+type NSXPhysicalNIC struct {
+	DeviceName string `json:"device_name" yaml:"device_name"`
+	UplinkName string `json:"uplink_name" yaml:"uplink_name"`
+}
+
+// NSXDomain is an NSX domain from /policy/api/v1/infra/domains.
+type NSXDomain struct {
+	ID   string `json:"id"           yaml:"id"`
+	Path string `json:"path"         yaml:"path"`
+	Name string `json:"display_name" yaml:"display_name"`
+}
+
+// NSXSecurityPolicy is an NSX security policy from /policy/api/v1/{path/to/domain}/security-policies.
+type NSXSecurityPolicy struct {
+	Domain string    `json:"domain" yaml:"domain"`
+	Rules  []NSXRule `json:"rules"  yaml:"rules"`
+}
+
+// NSXRule is a combined object of all NSX security rules, used by NSXSecurityPolicy and NSXGatewayPolicy.
+type NSXRule struct {
+	Description       string   `json:"description"                  yaml:"description"`
+	ID                string   `json:"id"                           yaml:"id"`
+	Name              string   `json:"display_name"                 yaml:"display_name"`
+	Path              string   `json:"path"                         yaml:"path"`
+	SequenceNumber    int      `json:"sequence_number,omitempty"    yaml:"sequence_number,omitempty"`
+	SourceGroups      []string `json:"source_groups,omitempty"      yaml:"source_groups,omitempty"`
+	DestinationGroups []string `json:"destination_groups,omitempty" yaml:"destination_groups,omitempty"`
+	Services          []string `json:"services,omitempty"           yaml:"services,omitempty"`
+	Profiles          []string `json:"profiles,omitempty"           yaml:"profiles,omitempty"`
+	Scope             []string `json:"scope"                        yaml:"scope"`
+	Overridden        bool     `json:"overridden"                   yaml:"overridden"`
+	Default           bool     `json:"is_default"                   yaml:"is_default"`
+	TCPStrict         bool     `json:"tcp_strict"                   yaml:"tcp_strict"`
+	Category          string   `json:"category,omitempty"           yaml:"category,omitempty"`
+	Action            string   `json:"action,omitempty"             yaml:"action,omitempty"`
+	Direction         string   `json:"direction,omitempty"          yaml:"direction,omitempty"`
+	Disabled          bool     `json:"disabled"                     yaml:"disabled"`
+}
+
+// NSXComputeManager is an NSX compute manager from /api/v1/fabric/compute-managers.
+type NSXComputeManager struct {
+	Server string `json:"server"      yaml:"server"`
+	Type   string `json:"origin_type" yaml:"origin_type"`
+}

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -109,6 +109,28 @@ var updates = map[int]schema.Update{
 	2: updateFromV1,
 	3: updateFromV2,
 	4: updateFromV3,
+	5: updateFromV4,
+}
+
+func updateFromV4(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE networks_new (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+		type       TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    location   TEXT NOT NULL,
+		properties TEXT NOT NULL,
+    source_id  INTEGER NOT NULL,
+    config     INTEGER NOT NULL,
+    UNIQUE (name, source_id),
+    FOREIGN KEY(source_id) REFERENCES sources(id)
+);
+
+DROP TABLE networks;
+ALTER TABLE networks_new RENAME TO networks;
+`)
+
+	return err
 }
 
 func updateFromV3(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/batch_service_test.go
+++ b/internal/migration/batch_service_test.go
@@ -2,7 +2,6 @@ package migration_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -759,12 +758,10 @@ func TestBatchService_UpdateInstancesAssignedToBatch(t *testing.T) {
 			repo := &mock.BatchRepoMock{
 				UnassignBatchFunc: func(ctx context.Context, batchName string, instanceUUID uuid.UUID) error {
 					_, err := queue.Pop(t, &tc.instanceSvcUnassignFromBatch)
-					fmt.Println("1", err != nil)
 					return err
 				},
 				AssignBatchFunc: func(ctx context.Context, batchName string, instanceUUID uuid.UUID) error {
 					_, err := queue.Pop(t, &tc.instanceSvcAssignBatch)
-					fmt.Println("2", err != nil)
 					return err
 				},
 			}

--- a/internal/migration/network_model.go
+++ b/internal/migration/network_model.go
@@ -1,15 +1,22 @@
 package migration
 
 import (
+	"encoding/json"
+	"slices"
+
+	internalAPI "github.com/FuturFusion/migration-manager/internal/api"
 	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 type Network struct {
 	ID       int64
+	Type     api.NetworkType
 	Name     string `db:"primary=yes"`
 	Location string
+	Source   string `db:"primary=yes&join=sources.name"`
 
-	Config map[string]string `db:"marshal=json"`
+	Properties json.RawMessage   `db:"marshal=json"`
+	Config     map[string]string `db:"marshal=json"`
 }
 
 func (n Network) Validate() error {
@@ -21,11 +28,48 @@ func (n Network) Validate() error {
 		return NewValidationErrf("Invalid network, name can not be empty")
 	}
 
+	types := []api.NetworkType{api.NETWORKTYPE_VMWARE_DISTRIBUTED, api.NETWORKTYPE_VMWARE_DISTRIBUTED_NSX, api.NETWORKTYPE_VMWARE_STANDARD, api.NETWORKTYPE_VMWARE_NSX}
+	if !slices.Contains(types, n.Type) {
+		return NewValidationErrf("Invalid network, type %q is invalid", n.Type)
+	}
+
 	if n.Location == "" {
 		return NewValidationErrf("Invalid network, location can not be empty")
 	}
 
+	if n.Source == "" {
+		return NewValidationErrf("Invalid network, source can not be empty")
+	}
+
+	if n.Properties != nil {
+		var props internalAPI.NSXNetworkProperties
+		err := json.Unmarshal(n.Properties, &props)
+		if err != nil {
+			return NewValidationErrf("Invalid network, unexpected properties data: %v", err)
+		}
+	}
+
 	return nil
+}
+
+// FilterUsedNetworks returns the subset of supplied networks that are in use by the supplied instances.
+func FilterUsedNetworks(nets Networks, vms Instances) Networks {
+	instanceNICsToSources := map[string]string{}
+	for _, vm := range vms {
+		for _, nic := range vm.Properties.NICs {
+			instanceNICsToSources[nic.ID] = vm.Source
+		}
+	}
+
+	usedNetworks := Networks{}
+	for _, n := range nets {
+		src, ok := instanceNICsToSources[n.Name]
+		if ok && n.Source == src {
+			usedNetworks = append(usedNetworks, n)
+		}
+	}
+
+	return usedNetworks
 }
 
 type Networks []Network
@@ -33,8 +77,11 @@ type Networks []Network
 // ToAPI returns the API representation of a network.
 func (n Network) ToAPI() api.Network {
 	return api.Network{
-		Name:     n.Name,
-		Location: n.Location,
+		Name:       n.Name,
+		Location:   n.Location,
+		Source:     n.Source,
+		Type:       n.Type,
+		Properties: n.Properties,
 		NetworkPut: api.NetworkPut{
 			Config: n.Config,
 		},

--- a/internal/migration/network_model.go
+++ b/internal/migration/network_model.go
@@ -77,7 +77,7 @@ type Networks []Network
 // ToAPI returns the API representation of a network.
 func (n Network) ToAPI() api.Network {
 	return api.Network{
-		Name:       n.Name,
+		Identifier: n.Name,
 		Location:   n.Location,
 		Source:     n.Source,
 		Type:       n.Type,

--- a/internal/migration/network_ports.go
+++ b/internal/migration/network_ports.go
@@ -7,10 +7,10 @@ import "context"
 type NetworkService interface {
 	Create(ctx context.Context, network Network) (Network, error)
 	GetAll(ctx context.Context) (Networks, error)
-	GetAllNames(ctx context.Context) ([]string, error)
-	GetByName(ctx context.Context, name string) (*Network, error)
+	GetAllBySource(ctx context.Context, src string) (Networks, error)
+	GetByNameAndSource(ctx context.Context, name string, src string) (*Network, error)
 	Update(ctx context.Context, network *Network) error
-	DeleteByName(ctx context.Context, name string) error
+	DeleteByNameAndSource(ctx context.Context, name string, src string) error
 }
 
 //go:generate go run github.com/matryer/moq -fmt goimports -pkg mock -out repo/mock/network_repo_mock_gen.go -rm . NetworkRepo
@@ -20,9 +20,9 @@ type NetworkService interface {
 type NetworkRepo interface {
 	Create(ctx context.Context, network Network) (int64, error)
 	GetAll(ctx context.Context) (Networks, error)
-	GetAllNames(ctx context.Context) ([]string, error)
-	GetByName(ctx context.Context, name string) (*Network, error)
+	GetAllBySource(ctx context.Context, src string) (Networks, error)
+	GetByNameAndSource(ctx context.Context, name string, src string) (*Network, error)
 	Update(ctx context.Context, network Network) error
-	Rename(ctx context.Context, oldName string, newName string) error
-	DeleteByName(ctx context.Context, name string) error
+	RenameBySource(ctx context.Context, oldName string, newName string, src string) error
+	DeleteByNameAndSource(ctx context.Context, name string, src string) error
 }

--- a/internal/migration/network_service.go
+++ b/internal/migration/network_service.go
@@ -35,16 +35,20 @@ func (n networkService) GetAll(ctx context.Context) (Networks, error) {
 	return n.repo.GetAll(ctx)
 }
 
-func (n networkService) GetAllNames(ctx context.Context) ([]string, error) {
-	return n.repo.GetAllNames(ctx)
+func (n networkService) GetAllBySource(ctx context.Context, srcName string) (Networks, error) {
+	return n.repo.GetAllBySource(ctx, srcName)
 }
 
-func (n networkService) GetByName(ctx context.Context, name string) (*Network, error) {
+func (n networkService) GetByNameAndSource(ctx context.Context, name string, srcName string) (*Network, error) {
 	if name == "" {
 		return nil, fmt.Errorf("Network name cannot be empty: %w", ErrOperationNotPermitted)
 	}
 
-	return n.repo.GetByName(ctx, name)
+	if srcName == "" {
+		return nil, fmt.Errorf("Network source cannot be empty: %w", ErrOperationNotPermitted)
+	}
+
+	return n.repo.GetByNameAndSource(ctx, name, srcName)
 }
 
 func (n networkService) Update(ctx context.Context, newNetwork *Network) error {
@@ -56,10 +60,14 @@ func (n networkService) Update(ctx context.Context, newNetwork *Network) error {
 	return n.repo.Update(ctx, *newNetwork)
 }
 
-func (n networkService) DeleteByName(ctx context.Context, name string) error {
+func (n networkService) DeleteByNameAndSource(ctx context.Context, name string, srcName string) error {
 	if name == "" {
 		return fmt.Errorf("Network name cannot be empty: %w", ErrOperationNotPermitted)
 	}
 
-	return n.repo.DeleteByName(ctx, name)
+	if srcName == "" {
+		return fmt.Errorf("Network source cannot be empty: %w", ErrOperationNotPermitted)
+	}
+
+	return n.repo.DeleteByNameAndSource(ctx, name, srcName)
 }

--- a/internal/migration/network_service_mock_gen_test.go
+++ b/internal/migration/network_service_mock_gen_test.go
@@ -23,17 +23,17 @@ var _ migration.NetworkService = &NetworkServiceMock{}
 //			CreateFunc: func(ctx context.Context, network migration.Network) (migration.Network, error) {
 //				panic("mock out the Create method")
 //			},
-//			DeleteByNameFunc: func(ctx context.Context, name string) error {
-//				panic("mock out the DeleteByName method")
+//			DeleteByNameAndSourceFunc: func(ctx context.Context, name string, src string) error {
+//				panic("mock out the DeleteByNameAndSource method")
 //			},
 //			GetAllFunc: func(ctx context.Context) (migration.Networks, error) {
 //				panic("mock out the GetAll method")
 //			},
-//			GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
-//				panic("mock out the GetAllNames method")
+//			GetAllBySourceFunc: func(ctx context.Context, src string) (migration.Networks, error) {
+//				panic("mock out the GetAllBySource method")
 //			},
-//			GetByNameFunc: func(ctx context.Context, name string) (*migration.Network, error) {
-//				panic("mock out the GetByName method")
+//			GetByNameAndSourceFunc: func(ctx context.Context, name string, src string) (*migration.Network, error) {
+//				panic("mock out the GetByNameAndSource method")
 //			},
 //			UpdateFunc: func(ctx context.Context, network *migration.Network) error {
 //				panic("mock out the Update method")
@@ -48,17 +48,17 @@ type NetworkServiceMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, network migration.Network) (migration.Network, error)
 
-	// DeleteByNameFunc mocks the DeleteByName method.
-	DeleteByNameFunc func(ctx context.Context, name string) error
+	// DeleteByNameAndSourceFunc mocks the DeleteByNameAndSource method.
+	DeleteByNameAndSourceFunc func(ctx context.Context, name string, src string) error
 
 	// GetAllFunc mocks the GetAll method.
 	GetAllFunc func(ctx context.Context) (migration.Networks, error)
 
-	// GetAllNamesFunc mocks the GetAllNames method.
-	GetAllNamesFunc func(ctx context.Context) ([]string, error)
+	// GetAllBySourceFunc mocks the GetAllBySource method.
+	GetAllBySourceFunc func(ctx context.Context, src string) (migration.Networks, error)
 
-	// GetByNameFunc mocks the GetByName method.
-	GetByNameFunc func(ctx context.Context, name string) (*migration.Network, error)
+	// GetByNameAndSourceFunc mocks the GetByNameAndSource method.
+	GetByNameAndSourceFunc func(ctx context.Context, name string, src string) (*migration.Network, error)
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(ctx context.Context, network *migration.Network) error
@@ -72,29 +72,35 @@ type NetworkServiceMock struct {
 			// Network is the network argument value.
 			Network migration.Network
 		}
-		// DeleteByName holds details about calls to the DeleteByName method.
-		DeleteByName []struct {
+		// DeleteByNameAndSource holds details about calls to the DeleteByNameAndSource method.
+		DeleteByNameAndSource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+			// Src is the src argument value.
+			Src string
 		}
 		// GetAll holds details about calls to the GetAll method.
 		GetAll []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
-		// GetAllNames holds details about calls to the GetAllNames method.
-		GetAllNames []struct {
+		// GetAllBySource holds details about calls to the GetAllBySource method.
+		GetAllBySource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Src is the src argument value.
+			Src string
 		}
-		// GetByName holds details about calls to the GetByName method.
-		GetByName []struct {
+		// GetByNameAndSource holds details about calls to the GetByNameAndSource method.
+		GetByNameAndSource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+			// Src is the src argument value.
+			Src string
 		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
@@ -104,12 +110,12 @@ type NetworkServiceMock struct {
 			Network *migration.Network
 		}
 	}
-	lockCreate       sync.RWMutex
-	lockDeleteByName sync.RWMutex
-	lockGetAll       sync.RWMutex
-	lockGetAllNames  sync.RWMutex
-	lockGetByName    sync.RWMutex
-	lockUpdate       sync.RWMutex
+	lockCreate                sync.RWMutex
+	lockDeleteByNameAndSource sync.RWMutex
+	lockGetAll                sync.RWMutex
+	lockGetAllBySource        sync.RWMutex
+	lockGetByNameAndSource    sync.RWMutex
+	lockUpdate                sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -148,39 +154,43 @@ func (mock *NetworkServiceMock) CreateCalls() []struct {
 	return calls
 }
 
-// DeleteByName calls DeleteByNameFunc.
-func (mock *NetworkServiceMock) DeleteByName(ctx context.Context, name string) error {
-	if mock.DeleteByNameFunc == nil {
-		panic("NetworkServiceMock.DeleteByNameFunc: method is nil but NetworkService.DeleteByName was just called")
+// DeleteByNameAndSource calls DeleteByNameAndSourceFunc.
+func (mock *NetworkServiceMock) DeleteByNameAndSource(ctx context.Context, name string, src string) error {
+	if mock.DeleteByNameAndSourceFunc == nil {
+		panic("NetworkServiceMock.DeleteByNameAndSourceFunc: method is nil but NetworkService.DeleteByNameAndSource was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}{
 		Ctx:  ctx,
 		Name: name,
+		Src:  src,
 	}
-	mock.lockDeleteByName.Lock()
-	mock.calls.DeleteByName = append(mock.calls.DeleteByName, callInfo)
-	mock.lockDeleteByName.Unlock()
-	return mock.DeleteByNameFunc(ctx, name)
+	mock.lockDeleteByNameAndSource.Lock()
+	mock.calls.DeleteByNameAndSource = append(mock.calls.DeleteByNameAndSource, callInfo)
+	mock.lockDeleteByNameAndSource.Unlock()
+	return mock.DeleteByNameAndSourceFunc(ctx, name, src)
 }
 
-// DeleteByNameCalls gets all the calls that were made to DeleteByName.
+// DeleteByNameAndSourceCalls gets all the calls that were made to DeleteByNameAndSource.
 // Check the length with:
 //
-//	len(mockedNetworkService.DeleteByNameCalls())
-func (mock *NetworkServiceMock) DeleteByNameCalls() []struct {
+//	len(mockedNetworkService.DeleteByNameAndSourceCalls())
+func (mock *NetworkServiceMock) DeleteByNameAndSourceCalls() []struct {
 	Ctx  context.Context
 	Name string
+	Src  string
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}
-	mock.lockDeleteByName.RLock()
-	calls = mock.calls.DeleteByName
-	mock.lockDeleteByName.RUnlock()
+	mock.lockDeleteByNameAndSource.RLock()
+	calls = mock.calls.DeleteByNameAndSource
+	mock.lockDeleteByNameAndSource.RUnlock()
 	return calls
 }
 
@@ -216,71 +226,79 @@ func (mock *NetworkServiceMock) GetAllCalls() []struct {
 	return calls
 }
 
-// GetAllNames calls GetAllNamesFunc.
-func (mock *NetworkServiceMock) GetAllNames(ctx context.Context) ([]string, error) {
-	if mock.GetAllNamesFunc == nil {
-		panic("NetworkServiceMock.GetAllNamesFunc: method is nil but NetworkService.GetAllNames was just called")
+// GetAllBySource calls GetAllBySourceFunc.
+func (mock *NetworkServiceMock) GetAllBySource(ctx context.Context, src string) (migration.Networks, error) {
+	if mock.GetAllBySourceFunc == nil {
+		panic("NetworkServiceMock.GetAllBySourceFunc: method is nil but NetworkService.GetAllBySource was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Src string
 	}{
 		Ctx: ctx,
+		Src: src,
 	}
-	mock.lockGetAllNames.Lock()
-	mock.calls.GetAllNames = append(mock.calls.GetAllNames, callInfo)
-	mock.lockGetAllNames.Unlock()
-	return mock.GetAllNamesFunc(ctx)
+	mock.lockGetAllBySource.Lock()
+	mock.calls.GetAllBySource = append(mock.calls.GetAllBySource, callInfo)
+	mock.lockGetAllBySource.Unlock()
+	return mock.GetAllBySourceFunc(ctx, src)
 }
 
-// GetAllNamesCalls gets all the calls that were made to GetAllNames.
+// GetAllBySourceCalls gets all the calls that were made to GetAllBySource.
 // Check the length with:
 //
-//	len(mockedNetworkService.GetAllNamesCalls())
-func (mock *NetworkServiceMock) GetAllNamesCalls() []struct {
+//	len(mockedNetworkService.GetAllBySourceCalls())
+func (mock *NetworkServiceMock) GetAllBySourceCalls() []struct {
 	Ctx context.Context
+	Src string
 } {
 	var calls []struct {
 		Ctx context.Context
+		Src string
 	}
-	mock.lockGetAllNames.RLock()
-	calls = mock.calls.GetAllNames
-	mock.lockGetAllNames.RUnlock()
+	mock.lockGetAllBySource.RLock()
+	calls = mock.calls.GetAllBySource
+	mock.lockGetAllBySource.RUnlock()
 	return calls
 }
 
-// GetByName calls GetByNameFunc.
-func (mock *NetworkServiceMock) GetByName(ctx context.Context, name string) (*migration.Network, error) {
-	if mock.GetByNameFunc == nil {
-		panic("NetworkServiceMock.GetByNameFunc: method is nil but NetworkService.GetByName was just called")
+// GetByNameAndSource calls GetByNameAndSourceFunc.
+func (mock *NetworkServiceMock) GetByNameAndSource(ctx context.Context, name string, src string) (*migration.Network, error) {
+	if mock.GetByNameAndSourceFunc == nil {
+		panic("NetworkServiceMock.GetByNameAndSourceFunc: method is nil but NetworkService.GetByNameAndSource was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}{
 		Ctx:  ctx,
 		Name: name,
+		Src:  src,
 	}
-	mock.lockGetByName.Lock()
-	mock.calls.GetByName = append(mock.calls.GetByName, callInfo)
-	mock.lockGetByName.Unlock()
-	return mock.GetByNameFunc(ctx, name)
+	mock.lockGetByNameAndSource.Lock()
+	mock.calls.GetByNameAndSource = append(mock.calls.GetByNameAndSource, callInfo)
+	mock.lockGetByNameAndSource.Unlock()
+	return mock.GetByNameAndSourceFunc(ctx, name, src)
 }
 
-// GetByNameCalls gets all the calls that were made to GetByName.
+// GetByNameAndSourceCalls gets all the calls that were made to GetByNameAndSource.
 // Check the length with:
 //
-//	len(mockedNetworkService.GetByNameCalls())
-func (mock *NetworkServiceMock) GetByNameCalls() []struct {
+//	len(mockedNetworkService.GetByNameAndSourceCalls())
+func (mock *NetworkServiceMock) GetByNameAndSourceCalls() []struct {
 	Ctx  context.Context
 	Name string
+	Src  string
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}
-	mock.lockGetByName.RLock()
-	calls = mock.calls.GetByName
-	mock.lockGetByName.RUnlock()
+	mock.lockGetByNameAndSource.RLock()
+	calls = mock.calls.GetByNameAndSource
+	mock.lockGetByNameAndSource.RUnlock()
 	return calls
 }
 

--- a/internal/migration/repo/middleware/network_slog_gen.go
+++ b/internal/migration/repo/middleware/network_slog_gen.go
@@ -45,23 +45,24 @@ func (_d NetworkRepoWithSlog) Create(ctx context.Context, network _sourceMigrati
 	return _d._base.Create(ctx, network)
 }
 
-// DeleteByName implements _sourceMigration.NetworkRepo
-func (_d NetworkRepoWithSlog) DeleteByName(ctx context.Context, name string) (err error) {
+// DeleteByNameAndSource implements _sourceMigration.NetworkRepo
+func (_d NetworkRepoWithSlog) DeleteByNameAndSource(ctx context.Context, name string, src string) (err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
 		slog.String("name", name),
-	).Debug("NetworkRepoWithSlog: calling DeleteByName")
+		slog.String("src", src),
+	).Debug("NetworkRepoWithSlog: calling DeleteByNameAndSource")
 	defer func() {
 		log := _d._log.With(
 			slog.Any("err", err),
 		)
 		if err != nil {
-			log.Error("NetworkRepoWithSlog: method DeleteByName returned an error")
+			log.Error("NetworkRepoWithSlog: method DeleteByNameAndSource returned an error")
 		} else {
-			log.Debug("NetworkRepoWithSlog: method DeleteByName finished")
+			log.Debug("NetworkRepoWithSlog: method DeleteByNameAndSource finished")
 		}
 	}()
-	return _d._base.DeleteByName(ctx, name)
+	return _d._base.DeleteByNameAndSource(ctx, name, src)
 }
 
 // GetAll implements _sourceMigration.NetworkRepo
@@ -83,63 +84,66 @@ func (_d NetworkRepoWithSlog) GetAll(ctx context.Context) (n1 _sourceMigration.N
 	return _d._base.GetAll(ctx)
 }
 
-// GetAllNames implements _sourceMigration.NetworkRepo
-func (_d NetworkRepoWithSlog) GetAllNames(ctx context.Context) (sa1 []string, err error) {
+// GetAllBySource implements _sourceMigration.NetworkRepo
+func (_d NetworkRepoWithSlog) GetAllBySource(ctx context.Context, src string) (n1 _sourceMigration.Networks, err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
-	).Debug("NetworkRepoWithSlog: calling GetAllNames")
+		slog.String("src", src),
+	).Debug("NetworkRepoWithSlog: calling GetAllBySource")
 	defer func() {
 		log := _d._log.With(
-			slog.Any("sa1", sa1),
+			slog.Any("n1", n1),
 			slog.Any("err", err),
 		)
 		if err != nil {
-			log.Error("NetworkRepoWithSlog: method GetAllNames returned an error")
+			log.Error("NetworkRepoWithSlog: method GetAllBySource returned an error")
 		} else {
-			log.Debug("NetworkRepoWithSlog: method GetAllNames finished")
+			log.Debug("NetworkRepoWithSlog: method GetAllBySource finished")
 		}
 	}()
-	return _d._base.GetAllNames(ctx)
+	return _d._base.GetAllBySource(ctx, src)
 }
 
-// GetByName implements _sourceMigration.NetworkRepo
-func (_d NetworkRepoWithSlog) GetByName(ctx context.Context, name string) (np1 *_sourceMigration.Network, err error) {
+// GetByNameAndSource implements _sourceMigration.NetworkRepo
+func (_d NetworkRepoWithSlog) GetByNameAndSource(ctx context.Context, name string, src string) (np1 *_sourceMigration.Network, err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
 		slog.String("name", name),
-	).Debug("NetworkRepoWithSlog: calling GetByName")
+		slog.String("src", src),
+	).Debug("NetworkRepoWithSlog: calling GetByNameAndSource")
 	defer func() {
 		log := _d._log.With(
 			slog.Any("np1", np1),
 			slog.Any("err", err),
 		)
 		if err != nil {
-			log.Error("NetworkRepoWithSlog: method GetByName returned an error")
+			log.Error("NetworkRepoWithSlog: method GetByNameAndSource returned an error")
 		} else {
-			log.Debug("NetworkRepoWithSlog: method GetByName finished")
+			log.Debug("NetworkRepoWithSlog: method GetByNameAndSource finished")
 		}
 	}()
-	return _d._base.GetByName(ctx, name)
+	return _d._base.GetByNameAndSource(ctx, name, src)
 }
 
-// Rename implements _sourceMigration.NetworkRepo
-func (_d NetworkRepoWithSlog) Rename(ctx context.Context, oldName string, newName string) (err error) {
+// RenameBySource implements _sourceMigration.NetworkRepo
+func (_d NetworkRepoWithSlog) RenameBySource(ctx context.Context, oldName string, newName string, src string) (err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
 		slog.String("oldName", oldName),
 		slog.String("newName", newName),
-	).Debug("NetworkRepoWithSlog: calling Rename")
+		slog.String("src", src),
+	).Debug("NetworkRepoWithSlog: calling RenameBySource")
 	defer func() {
 		log := _d._log.With(
 			slog.Any("err", err),
 		)
 		if err != nil {
-			log.Error("NetworkRepoWithSlog: method Rename returned an error")
+			log.Error("NetworkRepoWithSlog: method RenameBySource returned an error")
 		} else {
-			log.Debug("NetworkRepoWithSlog: method Rename finished")
+			log.Debug("NetworkRepoWithSlog: method RenameBySource finished")
 		}
 	}()
-	return _d._base.Rename(ctx, oldName, newName)
+	return _d._base.RenameBySource(ctx, oldName, newName, src)
 }
 
 // Update implements _sourceMigration.NetworkRepo

--- a/internal/migration/repo/middleware/source_slog_gen.go
+++ b/internal/migration/repo/middleware/source_slog_gen.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	_sourceMigration "github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 // SourceRepoWithSlog implements _sourceMigration.SourceRepo that is instrumented with slog logger
@@ -65,9 +66,10 @@ func (_d SourceRepoWithSlog) DeleteByName(ctx context.Context, name string) (err
 }
 
 // GetAll implements _sourceMigration.SourceRepo
-func (_d SourceRepoWithSlog) GetAll(ctx context.Context) (s1 _sourceMigration.Sources, err error) {
+func (_d SourceRepoWithSlog) GetAll(ctx context.Context, sourceTypes ...api.SourceType) (s1 _sourceMigration.Sources, err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
+		slog.Any("sourceTypes", sourceTypes),
 	).Debug("SourceRepoWithSlog: calling GetAll")
 	defer func() {
 		log := _d._log.With(
@@ -80,13 +82,14 @@ func (_d SourceRepoWithSlog) GetAll(ctx context.Context) (s1 _sourceMigration.So
 			log.Debug("SourceRepoWithSlog: method GetAll finished")
 		}
 	}()
-	return _d._base.GetAll(ctx)
+	return _d._base.GetAll(ctx, sourceTypes...)
 }
 
 // GetAllNames implements _sourceMigration.SourceRepo
-func (_d SourceRepoWithSlog) GetAllNames(ctx context.Context) (sa1 []string, err error) {
+func (_d SourceRepoWithSlog) GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) (sa1 []string, err error) {
 	_d._log.With(
 		slog.Any("ctx", ctx),
+		slog.Any("sourceTypes", sourceTypes),
 	).Debug("SourceRepoWithSlog: calling GetAllNames")
 	defer func() {
 		log := _d._log.With(
@@ -99,7 +102,7 @@ func (_d SourceRepoWithSlog) GetAllNames(ctx context.Context) (sa1 []string, err
 			log.Debug("SourceRepoWithSlog: method GetAllNames finished")
 		}
 	}()
-	return _d._base.GetAllNames(ctx)
+	return _d._base.GetAllNames(ctx, sourceTypes...)
 }
 
 // GetByName implements _sourceMigration.SourceRepo

--- a/internal/migration/repo/mock/network_repo_mock_gen.go
+++ b/internal/migration/repo/mock/network_repo_mock_gen.go
@@ -23,20 +23,20 @@ var _ migration.NetworkRepo = &NetworkRepoMock{}
 //			CreateFunc: func(ctx context.Context, network migration.Network) (int64, error) {
 //				panic("mock out the Create method")
 //			},
-//			DeleteByNameFunc: func(ctx context.Context, name string) error {
-//				panic("mock out the DeleteByName method")
+//			DeleteByNameAndSourceFunc: func(ctx context.Context, name string, src string) error {
+//				panic("mock out the DeleteByNameAndSource method")
 //			},
 //			GetAllFunc: func(ctx context.Context) (migration.Networks, error) {
 //				panic("mock out the GetAll method")
 //			},
-//			GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
-//				panic("mock out the GetAllNames method")
+//			GetAllBySourceFunc: func(ctx context.Context, src string) (migration.Networks, error) {
+//				panic("mock out the GetAllBySource method")
 //			},
-//			GetByNameFunc: func(ctx context.Context, name string) (*migration.Network, error) {
-//				panic("mock out the GetByName method")
+//			GetByNameAndSourceFunc: func(ctx context.Context, name string, src string) (*migration.Network, error) {
+//				panic("mock out the GetByNameAndSource method")
 //			},
-//			RenameFunc: func(ctx context.Context, oldName string, newName string) error {
-//				panic("mock out the Rename method")
+//			RenameBySourceFunc: func(ctx context.Context, oldName string, newName string, src string) error {
+//				panic("mock out the RenameBySource method")
 //			},
 //			UpdateFunc: func(ctx context.Context, network migration.Network) error {
 //				panic("mock out the Update method")
@@ -51,20 +51,20 @@ type NetworkRepoMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, network migration.Network) (int64, error)
 
-	// DeleteByNameFunc mocks the DeleteByName method.
-	DeleteByNameFunc func(ctx context.Context, name string) error
+	// DeleteByNameAndSourceFunc mocks the DeleteByNameAndSource method.
+	DeleteByNameAndSourceFunc func(ctx context.Context, name string, src string) error
 
 	// GetAllFunc mocks the GetAll method.
 	GetAllFunc func(ctx context.Context) (migration.Networks, error)
 
-	// GetAllNamesFunc mocks the GetAllNames method.
-	GetAllNamesFunc func(ctx context.Context) ([]string, error)
+	// GetAllBySourceFunc mocks the GetAllBySource method.
+	GetAllBySourceFunc func(ctx context.Context, src string) (migration.Networks, error)
 
-	// GetByNameFunc mocks the GetByName method.
-	GetByNameFunc func(ctx context.Context, name string) (*migration.Network, error)
+	// GetByNameAndSourceFunc mocks the GetByNameAndSource method.
+	GetByNameAndSourceFunc func(ctx context.Context, name string, src string) (*migration.Network, error)
 
-	// RenameFunc mocks the Rename method.
-	RenameFunc func(ctx context.Context, oldName string, newName string) error
+	// RenameBySourceFunc mocks the RenameBySource method.
+	RenameBySourceFunc func(ctx context.Context, oldName string, newName string, src string) error
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(ctx context.Context, network migration.Network) error
@@ -78,38 +78,46 @@ type NetworkRepoMock struct {
 			// Network is the network argument value.
 			Network migration.Network
 		}
-		// DeleteByName holds details about calls to the DeleteByName method.
-		DeleteByName []struct {
+		// DeleteByNameAndSource holds details about calls to the DeleteByNameAndSource method.
+		DeleteByNameAndSource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+			// Src is the src argument value.
+			Src string
 		}
 		// GetAll holds details about calls to the GetAll method.
 		GetAll []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
-		// GetAllNames holds details about calls to the GetAllNames method.
-		GetAllNames []struct {
+		// GetAllBySource holds details about calls to the GetAllBySource method.
+		GetAllBySource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Src is the src argument value.
+			Src string
 		}
-		// GetByName holds details about calls to the GetByName method.
-		GetByName []struct {
+		// GetByNameAndSource holds details about calls to the GetByNameAndSource method.
+		GetByNameAndSource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+			// Src is the src argument value.
+			Src string
 		}
-		// Rename holds details about calls to the Rename method.
-		Rename []struct {
+		// RenameBySource holds details about calls to the RenameBySource method.
+		RenameBySource []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// OldName is the oldName argument value.
 			OldName string
 			// NewName is the newName argument value.
 			NewName string
+			// Src is the src argument value.
+			Src string
 		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
@@ -119,13 +127,13 @@ type NetworkRepoMock struct {
 			Network migration.Network
 		}
 	}
-	lockCreate       sync.RWMutex
-	lockDeleteByName sync.RWMutex
-	lockGetAll       sync.RWMutex
-	lockGetAllNames  sync.RWMutex
-	lockGetByName    sync.RWMutex
-	lockRename       sync.RWMutex
-	lockUpdate       sync.RWMutex
+	lockCreate                sync.RWMutex
+	lockDeleteByNameAndSource sync.RWMutex
+	lockGetAll                sync.RWMutex
+	lockGetAllBySource        sync.RWMutex
+	lockGetByNameAndSource    sync.RWMutex
+	lockRenameBySource        sync.RWMutex
+	lockUpdate                sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -164,39 +172,43 @@ func (mock *NetworkRepoMock) CreateCalls() []struct {
 	return calls
 }
 
-// DeleteByName calls DeleteByNameFunc.
-func (mock *NetworkRepoMock) DeleteByName(ctx context.Context, name string) error {
-	if mock.DeleteByNameFunc == nil {
-		panic("NetworkRepoMock.DeleteByNameFunc: method is nil but NetworkRepo.DeleteByName was just called")
+// DeleteByNameAndSource calls DeleteByNameAndSourceFunc.
+func (mock *NetworkRepoMock) DeleteByNameAndSource(ctx context.Context, name string, src string) error {
+	if mock.DeleteByNameAndSourceFunc == nil {
+		panic("NetworkRepoMock.DeleteByNameAndSourceFunc: method is nil but NetworkRepo.DeleteByNameAndSource was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}{
 		Ctx:  ctx,
 		Name: name,
+		Src:  src,
 	}
-	mock.lockDeleteByName.Lock()
-	mock.calls.DeleteByName = append(mock.calls.DeleteByName, callInfo)
-	mock.lockDeleteByName.Unlock()
-	return mock.DeleteByNameFunc(ctx, name)
+	mock.lockDeleteByNameAndSource.Lock()
+	mock.calls.DeleteByNameAndSource = append(mock.calls.DeleteByNameAndSource, callInfo)
+	mock.lockDeleteByNameAndSource.Unlock()
+	return mock.DeleteByNameAndSourceFunc(ctx, name, src)
 }
 
-// DeleteByNameCalls gets all the calls that were made to DeleteByName.
+// DeleteByNameAndSourceCalls gets all the calls that were made to DeleteByNameAndSource.
 // Check the length with:
 //
-//	len(mockedNetworkRepo.DeleteByNameCalls())
-func (mock *NetworkRepoMock) DeleteByNameCalls() []struct {
+//	len(mockedNetworkRepo.DeleteByNameAndSourceCalls())
+func (mock *NetworkRepoMock) DeleteByNameAndSourceCalls() []struct {
 	Ctx  context.Context
 	Name string
+	Src  string
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}
-	mock.lockDeleteByName.RLock()
-	calls = mock.calls.DeleteByName
-	mock.lockDeleteByName.RUnlock()
+	mock.lockDeleteByNameAndSource.RLock()
+	calls = mock.calls.DeleteByNameAndSource
+	mock.lockDeleteByNameAndSource.RUnlock()
 	return calls
 }
 
@@ -232,111 +244,123 @@ func (mock *NetworkRepoMock) GetAllCalls() []struct {
 	return calls
 }
 
-// GetAllNames calls GetAllNamesFunc.
-func (mock *NetworkRepoMock) GetAllNames(ctx context.Context) ([]string, error) {
-	if mock.GetAllNamesFunc == nil {
-		panic("NetworkRepoMock.GetAllNamesFunc: method is nil but NetworkRepo.GetAllNames was just called")
+// GetAllBySource calls GetAllBySourceFunc.
+func (mock *NetworkRepoMock) GetAllBySource(ctx context.Context, src string) (migration.Networks, error) {
+	if mock.GetAllBySourceFunc == nil {
+		panic("NetworkRepoMock.GetAllBySourceFunc: method is nil but NetworkRepo.GetAllBySource was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Src string
 	}{
 		Ctx: ctx,
+		Src: src,
 	}
-	mock.lockGetAllNames.Lock()
-	mock.calls.GetAllNames = append(mock.calls.GetAllNames, callInfo)
-	mock.lockGetAllNames.Unlock()
-	return mock.GetAllNamesFunc(ctx)
+	mock.lockGetAllBySource.Lock()
+	mock.calls.GetAllBySource = append(mock.calls.GetAllBySource, callInfo)
+	mock.lockGetAllBySource.Unlock()
+	return mock.GetAllBySourceFunc(ctx, src)
 }
 
-// GetAllNamesCalls gets all the calls that were made to GetAllNames.
+// GetAllBySourceCalls gets all the calls that were made to GetAllBySource.
 // Check the length with:
 //
-//	len(mockedNetworkRepo.GetAllNamesCalls())
-func (mock *NetworkRepoMock) GetAllNamesCalls() []struct {
+//	len(mockedNetworkRepo.GetAllBySourceCalls())
+func (mock *NetworkRepoMock) GetAllBySourceCalls() []struct {
 	Ctx context.Context
+	Src string
 } {
 	var calls []struct {
 		Ctx context.Context
+		Src string
 	}
-	mock.lockGetAllNames.RLock()
-	calls = mock.calls.GetAllNames
-	mock.lockGetAllNames.RUnlock()
+	mock.lockGetAllBySource.RLock()
+	calls = mock.calls.GetAllBySource
+	mock.lockGetAllBySource.RUnlock()
 	return calls
 }
 
-// GetByName calls GetByNameFunc.
-func (mock *NetworkRepoMock) GetByName(ctx context.Context, name string) (*migration.Network, error) {
-	if mock.GetByNameFunc == nil {
-		panic("NetworkRepoMock.GetByNameFunc: method is nil but NetworkRepo.GetByName was just called")
+// GetByNameAndSource calls GetByNameAndSourceFunc.
+func (mock *NetworkRepoMock) GetByNameAndSource(ctx context.Context, name string, src string) (*migration.Network, error) {
+	if mock.GetByNameAndSourceFunc == nil {
+		panic("NetworkRepoMock.GetByNameAndSourceFunc: method is nil but NetworkRepo.GetByNameAndSource was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}{
 		Ctx:  ctx,
 		Name: name,
+		Src:  src,
 	}
-	mock.lockGetByName.Lock()
-	mock.calls.GetByName = append(mock.calls.GetByName, callInfo)
-	mock.lockGetByName.Unlock()
-	return mock.GetByNameFunc(ctx, name)
+	mock.lockGetByNameAndSource.Lock()
+	mock.calls.GetByNameAndSource = append(mock.calls.GetByNameAndSource, callInfo)
+	mock.lockGetByNameAndSource.Unlock()
+	return mock.GetByNameAndSourceFunc(ctx, name, src)
 }
 
-// GetByNameCalls gets all the calls that were made to GetByName.
+// GetByNameAndSourceCalls gets all the calls that were made to GetByNameAndSource.
 // Check the length with:
 //
-//	len(mockedNetworkRepo.GetByNameCalls())
-func (mock *NetworkRepoMock) GetByNameCalls() []struct {
+//	len(mockedNetworkRepo.GetByNameAndSourceCalls())
+func (mock *NetworkRepoMock) GetByNameAndSourceCalls() []struct {
 	Ctx  context.Context
 	Name string
+	Src  string
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Name string
+		Src  string
 	}
-	mock.lockGetByName.RLock()
-	calls = mock.calls.GetByName
-	mock.lockGetByName.RUnlock()
+	mock.lockGetByNameAndSource.RLock()
+	calls = mock.calls.GetByNameAndSource
+	mock.lockGetByNameAndSource.RUnlock()
 	return calls
 }
 
-// Rename calls RenameFunc.
-func (mock *NetworkRepoMock) Rename(ctx context.Context, oldName string, newName string) error {
-	if mock.RenameFunc == nil {
-		panic("NetworkRepoMock.RenameFunc: method is nil but NetworkRepo.Rename was just called")
+// RenameBySource calls RenameBySourceFunc.
+func (mock *NetworkRepoMock) RenameBySource(ctx context.Context, oldName string, newName string, src string) error {
+	if mock.RenameBySourceFunc == nil {
+		panic("NetworkRepoMock.RenameBySourceFunc: method is nil but NetworkRepo.RenameBySource was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
 		OldName string
 		NewName string
+		Src     string
 	}{
 		Ctx:     ctx,
 		OldName: oldName,
 		NewName: newName,
+		Src:     src,
 	}
-	mock.lockRename.Lock()
-	mock.calls.Rename = append(mock.calls.Rename, callInfo)
-	mock.lockRename.Unlock()
-	return mock.RenameFunc(ctx, oldName, newName)
+	mock.lockRenameBySource.Lock()
+	mock.calls.RenameBySource = append(mock.calls.RenameBySource, callInfo)
+	mock.lockRenameBySource.Unlock()
+	return mock.RenameBySourceFunc(ctx, oldName, newName, src)
 }
 
-// RenameCalls gets all the calls that were made to Rename.
+// RenameBySourceCalls gets all the calls that were made to RenameBySource.
 // Check the length with:
 //
-//	len(mockedNetworkRepo.RenameCalls())
-func (mock *NetworkRepoMock) RenameCalls() []struct {
+//	len(mockedNetworkRepo.RenameBySourceCalls())
+func (mock *NetworkRepoMock) RenameBySourceCalls() []struct {
 	Ctx     context.Context
 	OldName string
 	NewName string
+	Src     string
 } {
 	var calls []struct {
 		Ctx     context.Context
 		OldName string
 		NewName string
+		Src     string
 	}
-	mock.lockRename.RLock()
-	calls = mock.calls.Rename
-	mock.lockRename.RUnlock()
+	mock.lockRenameBySource.RLock()
+	calls = mock.calls.RenameBySource
+	mock.lockRenameBySource.RUnlock()
 	return calls
 }
 

--- a/internal/migration/repo/mock/source_repo_mock_gen.go
+++ b/internal/migration/repo/mock/source_repo_mock_gen.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 // Ensure, that SourceRepoMock does implement migration.SourceRepo.
@@ -26,10 +27,10 @@ var _ migration.SourceRepo = &SourceRepoMock{}
 //			DeleteByNameFunc: func(ctx context.Context, name string) error {
 //				panic("mock out the DeleteByName method")
 //			},
-//			GetAllFunc: func(ctx context.Context) (migration.Sources, error) {
+//			GetAllFunc: func(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error) {
 //				panic("mock out the GetAll method")
 //			},
-//			GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
+//			GetAllNamesFunc: func(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
 //				panic("mock out the GetAllNames method")
 //			},
 //			GetByNameFunc: func(ctx context.Context, name string) (*migration.Source, error) {
@@ -55,10 +56,10 @@ type SourceRepoMock struct {
 	DeleteByNameFunc func(ctx context.Context, name string) error
 
 	// GetAllFunc mocks the GetAll method.
-	GetAllFunc func(ctx context.Context) (migration.Sources, error)
+	GetAllFunc func(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error)
 
 	// GetAllNamesFunc mocks the GetAllNames method.
-	GetAllNamesFunc func(ctx context.Context) ([]string, error)
+	GetAllNamesFunc func(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error)
 
 	// GetByNameFunc mocks the GetByName method.
 	GetByNameFunc func(ctx context.Context, name string) (*migration.Source, error)
@@ -89,11 +90,15 @@ type SourceRepoMock struct {
 		GetAll []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// SourceTypes is the sourceTypes argument value.
+			SourceTypes []api.SourceType
 		}
 		// GetAllNames holds details about calls to the GetAllNames method.
 		GetAllNames []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// SourceTypes is the sourceTypes argument value.
+			SourceTypes []api.SourceType
 		}
 		// GetByName holds details about calls to the GetByName method.
 		GetByName []struct {
@@ -203,19 +208,21 @@ func (mock *SourceRepoMock) DeleteByNameCalls() []struct {
 }
 
 // GetAll calls GetAllFunc.
-func (mock *SourceRepoMock) GetAll(ctx context.Context) (migration.Sources, error) {
+func (mock *SourceRepoMock) GetAll(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error) {
 	if mock.GetAllFunc == nil {
 		panic("SourceRepoMock.GetAllFunc: method is nil but SourceRepo.GetAll was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
+		SourceTypes: sourceTypes,
 	}
 	mock.lockGetAll.Lock()
 	mock.calls.GetAll = append(mock.calls.GetAll, callInfo)
 	mock.lockGetAll.Unlock()
-	return mock.GetAllFunc(ctx)
+	return mock.GetAllFunc(ctx, sourceTypes...)
 }
 
 // GetAllCalls gets all the calls that were made to GetAll.
@@ -223,10 +230,12 @@ func (mock *SourceRepoMock) GetAll(ctx context.Context) (migration.Sources, erro
 //
 //	len(mockedSourceRepo.GetAllCalls())
 func (mock *SourceRepoMock) GetAllCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
+	SourceTypes []api.SourceType
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}
 	mock.lockGetAll.RLock()
 	calls = mock.calls.GetAll
@@ -235,19 +244,21 @@ func (mock *SourceRepoMock) GetAllCalls() []struct {
 }
 
 // GetAllNames calls GetAllNamesFunc.
-func (mock *SourceRepoMock) GetAllNames(ctx context.Context) ([]string, error) {
+func (mock *SourceRepoMock) GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
 	if mock.GetAllNamesFunc == nil {
 		panic("SourceRepoMock.GetAllNamesFunc: method is nil but SourceRepo.GetAllNames was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
+		SourceTypes: sourceTypes,
 	}
 	mock.lockGetAllNames.Lock()
 	mock.calls.GetAllNames = append(mock.calls.GetAllNames, callInfo)
 	mock.lockGetAllNames.Unlock()
-	return mock.GetAllNamesFunc(ctx)
+	return mock.GetAllNamesFunc(ctx, sourceTypes...)
 }
 
 // GetAllNamesCalls gets all the calls that were made to GetAllNames.
@@ -255,10 +266,12 @@ func (mock *SourceRepoMock) GetAllNames(ctx context.Context) ([]string, error) {
 //
 //	len(mockedSourceRepo.GetAllNamesCalls())
 func (mock *SourceRepoMock) GetAllNamesCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
+	SourceTypes []api.SourceType
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}
 	mock.lockGetAllNames.RLock()
 	calls = mock.calls.GetAllNames

--- a/internal/migration/repo/sqlite/entities/network.go
+++ b/internal/migration/repo/sqlite/entities/network.go
@@ -7,23 +7,24 @@ package entities
 //
 //generate-database:mapper stmt -e network objects
 //generate-database:mapper stmt -e network objects-by-Name
-//generate-database:mapper stmt -e network names
+//generate-database:mapper stmt -e network objects-by-Name-and-Source
+//generate-database:mapper stmt -e network objects-by-Source
 //generate-database:mapper stmt -e network id
 //generate-database:mapper stmt -e network create
 //generate-database:mapper stmt -e network update
 //generate-database:mapper stmt -e network rename
-//generate-database:mapper stmt -e network delete-by-Name
+//generate-database:mapper stmt -e network delete-by-Name-and-Source
 //
 //generate-database:mapper method -e network ID
 //generate-database:mapper method -e network Exists
 //generate-database:mapper method -e network GetOne
 //generate-database:mapper method -e network GetMany
-//generate-database:mapper method -e network GetNames
 //generate-database:mapper method -e network Create
 //generate-database:mapper method -e network Update
 //generate-database:mapper method -e network Rename
-//generate-database:mapper method -e network DeleteOne-by-Name
+//generate-database:mapper method -e network DeleteOne-by-Name-and-Source
 
 type NetworkFilter struct {
-	Name *string
+	Name   *string
+	Source *string
 }

--- a/internal/migration/repo/sqlite/entities/source.go
+++ b/internal/migration/repo/sqlite/entities/source.go
@@ -1,12 +1,16 @@
 package entities
 
+import "github.com/FuturFusion/migration-manager/shared/api"
+
 // Code generation directives.
 //
 //generate-database:mapper target source.mapper.go
 //generate-database:mapper reset
 //
 //generate-database:mapper stmt -e source objects
+//generate-database:mapper stmt -e source objects-by-SourceType
 //generate-database:mapper stmt -e source objects-by-Name
+//generate-database:mapper stmt -e source objects-by-Name-and-SourceType
 //generate-database:mapper stmt -e source names
 //generate-database:mapper stmt -e source id
 //generate-database:mapper stmt -e source create
@@ -25,5 +29,6 @@ package entities
 //generate-database:mapper method -e source DeleteOne-by-Name
 
 type SourceFilter struct {
-	Name *string
+	SourceType *api.SourceType
+	Name       *string
 }

--- a/internal/migration/repo/sqlite/network.go
+++ b/internal/migration/repo/sqlite/network.go
@@ -29,24 +29,24 @@ func (n network) GetAll(ctx context.Context) (migration.Networks, error) {
 	return entities.GetNetworks(ctx, transaction.GetDBTX(ctx, n.db))
 }
 
-func (n network) GetAllNames(ctx context.Context) ([]string, error) {
-	return entities.GetNetworkNames(ctx, transaction.GetDBTX(ctx, n.db))
+func (n network) GetAllBySource(ctx context.Context, srcName string) (migration.Networks, error) {
+	return entities.GetNetworks(ctx, transaction.GetDBTX(ctx, n.db), entities.NetworkFilter{Source: &srcName})
 }
 
-func (n network) GetByName(ctx context.Context, name string) (*migration.Network, error) {
-	return entities.GetNetwork(ctx, transaction.GetDBTX(ctx, n.db), name)
+func (n network) GetByNameAndSource(ctx context.Context, name string, srcName string) (*migration.Network, error) {
+	return entities.GetNetwork(ctx, transaction.GetDBTX(ctx, n.db), name, srcName)
 }
 
 func (n network) Update(ctx context.Context, in migration.Network) error {
 	return transaction.ForceTx(ctx, transaction.GetDBTX(ctx, n.db), func(ctx context.Context, tx transaction.TX) error {
-		return entities.UpdateNetwork(ctx, tx, in.Name, in)
+		return entities.UpdateNetwork(ctx, tx, in.Name, in.Source, in)
 	})
 }
 
-func (n network) Rename(ctx context.Context, oldName string, newName string) error {
-	return entities.RenameNetwork(ctx, transaction.GetDBTX(ctx, n.db), oldName, newName)
+func (n network) RenameBySource(ctx context.Context, oldName string, newName string, srcName string) error {
+	return entities.RenameNetwork(ctx, transaction.GetDBTX(ctx, n.db), oldName, srcName, newName)
 }
 
-func (n network) DeleteByName(ctx context.Context, name string) error {
-	return entities.DeleteNetwork(ctx, transaction.GetDBTX(ctx, n.db), name)
+func (n network) DeleteByNameAndSource(ctx context.Context, name string, srcName string) error {
+	return entities.DeleteNetwork(ctx, transaction.GetDBTX(ctx, n.db), name, srcName)
 }

--- a/internal/migration/repo/sqlite/source.go
+++ b/internal/migration/repo/sqlite/source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/migration/repo"
 	"github.com/FuturFusion/migration-manager/internal/migration/repo/sqlite/entities"
 	"github.com/FuturFusion/migration-manager/internal/transaction"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 type source struct {
@@ -25,12 +26,22 @@ func (s source) Create(ctx context.Context, in migration.Source) (int64, error) 
 	return entities.CreateSource(ctx, transaction.GetDBTX(ctx, s.db), in)
 }
 
-func (s source) GetAll(ctx context.Context) (migration.Sources, error) {
-	return entities.GetSources(ctx, transaction.GetDBTX(ctx, s.db))
+func (s source) GetAll(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error) {
+	filters := []entities.SourceFilter{}
+	for _, s := range sourceTypes {
+		filters = append(filters, entities.SourceFilter{SourceType: &s})
+	}
+
+	return entities.GetSources(ctx, transaction.GetDBTX(ctx, s.db), filters...)
 }
 
-func (s source) GetAllNames(ctx context.Context) ([]string, error) {
-	return entities.GetSourceNames(ctx, transaction.GetDBTX(ctx, s.db))
+func (s source) GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
+	filters := []entities.SourceFilter{}
+	for _, s := range sourceTypes {
+		filters = append(filters, entities.SourceFilter{SourceType: &s})
+	}
+
+	return entities.GetSourceNames(ctx, transaction.GetDBTX(ctx, s.db), filters...)
 }
 
 func (s source) GetByName(ctx context.Context, name string) (*migration.Source, error) {

--- a/internal/migration/source_model.go
+++ b/internal/migration/source_model.go
@@ -27,7 +27,7 @@ func (s Source) Validate() error {
 		return NewValidationErrf("Invalid source, name can not be empty")
 	}
 
-	if s.SourceType != api.SOURCETYPE_COMMON && s.SourceType != api.SOURCETYPE_VMWARE {
+	if s.SourceType != api.SOURCETYPE_COMMON && s.SourceType != api.SOURCETYPE_VMWARE && s.SourceType != api.SOURCETYPE_NSX {
 		return NewValidationErrf("Invalid source, %s is not a valid source type", s.SourceType)
 	}
 
@@ -86,6 +86,8 @@ func (s Source) validateSourceTypeVMware() error {
 
 func (s Source) GetExternalConnectivityStatus() api.ExternalConnectivityStatus {
 	switch s.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		var properties api.VMwareProperties
 		err := json.Unmarshal(s.Properties, &properties)
@@ -101,6 +103,8 @@ func (s Source) GetExternalConnectivityStatus() api.ExternalConnectivityStatus {
 
 func (s Source) GetServerCertificate() *x509.Certificate {
 	switch s.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		var properties api.VMwareProperties
 		err := json.Unmarshal(s.Properties, &properties)
@@ -121,6 +125,8 @@ func (s Source) GetServerCertificate() *x509.Certificate {
 
 func (s Source) GetTrustedServerCertificateFingerprint() string {
 	switch s.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		var properties api.VMwareProperties
 		err := json.Unmarshal(s.Properties, &properties)
@@ -136,6 +142,8 @@ func (s Source) GetTrustedServerCertificateFingerprint() string {
 
 func (s *Source) SetExternalConnectivityStatus(status api.ExternalConnectivityStatus) {
 	switch s.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		var properties api.VMwareProperties
 		err := json.Unmarshal(s.Properties, &properties)
@@ -150,6 +158,8 @@ func (s *Source) SetExternalConnectivityStatus(status api.ExternalConnectivitySt
 
 func (s *Source) SetServerCertificate(cert *x509.Certificate) {
 	switch s.SourceType {
+	case api.SOURCETYPE_NSX:
+		fallthrough
 	case api.SOURCETYPE_VMWARE:
 		var properties api.VMwareProperties
 		err := json.Unmarshal(s.Properties, &properties)

--- a/internal/migration/source_ports.go
+++ b/internal/migration/source_ports.go
@@ -11,8 +11,8 @@ import (
 
 type SourceService interface {
 	Create(ctx context.Context, source Source) (Source, error)
-	GetAll(ctx context.Context) (Sources, error)
-	GetAllNames(ctx context.Context) ([]string, error)
+	GetAll(ctx context.Context, sourceTypes ...api.SourceType) (Sources, error)
+	GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Source, error)
 	Update(ctx context.Context, name string, source *Source, instanceService InstanceService) error
 	DeleteByName(ctx context.Context, name string, instanceService InstanceService) error
@@ -24,8 +24,8 @@ type SourceService interface {
 
 type SourceRepo interface {
 	Create(ctx context.Context, source Source) (int64, error)
-	GetAll(ctx context.Context) (Sources, error)
-	GetAllNames(ctx context.Context) ([]string, error)
+	GetAll(ctx context.Context, sourceTypes ...api.SourceType) (Sources, error)
+	GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Source, error)
 	Update(ctx context.Context, name string, source Source) error
 	Rename(ctx context.Context, oldName string, newName string) error

--- a/internal/migration/source_service.go
+++ b/internal/migration/source_service.go
@@ -41,12 +41,12 @@ func (s sourceService) Create(ctx context.Context, newSource Source) (Source, er
 	return newSource, nil
 }
 
-func (s sourceService) GetAll(ctx context.Context) (Sources, error) {
-	return s.repo.GetAll(ctx)
+func (s sourceService) GetAll(ctx context.Context, sourceTypes ...api.SourceType) (Sources, error) {
+	return s.repo.GetAll(ctx, sourceTypes...)
 }
 
-func (s sourceService) GetAllNames(ctx context.Context) ([]string, error) {
-	return s.repo.GetAllNames(ctx)
+func (s sourceService) GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
+	return s.repo.GetAllNames(ctx, sourceTypes...)
 }
 
 func (s sourceService) GetByName(ctx context.Context, name string) (*Source, error) {

--- a/internal/migration/source_service_mock_gen_test.go
+++ b/internal/migration/source_service_mock_gen_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 // Ensure, that SourceServiceMock does implement migration.SourceService.
@@ -26,10 +27,10 @@ var _ migration.SourceService = &SourceServiceMock{}
 //			DeleteByNameFunc: func(ctx context.Context, name string, instanceService migration.InstanceService) error {
 //				panic("mock out the DeleteByName method")
 //			},
-//			GetAllFunc: func(ctx context.Context) (migration.Sources, error) {
+//			GetAllFunc: func(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error) {
 //				panic("mock out the GetAll method")
 //			},
-//			GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
+//			GetAllNamesFunc: func(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
 //				panic("mock out the GetAllNames method")
 //			},
 //			GetByNameFunc: func(ctx context.Context, name string) (*migration.Source, error) {
@@ -52,10 +53,10 @@ type SourceServiceMock struct {
 	DeleteByNameFunc func(ctx context.Context, name string, instanceService migration.InstanceService) error
 
 	// GetAllFunc mocks the GetAll method.
-	GetAllFunc func(ctx context.Context) (migration.Sources, error)
+	GetAllFunc func(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error)
 
 	// GetAllNamesFunc mocks the GetAllNames method.
-	GetAllNamesFunc func(ctx context.Context) ([]string, error)
+	GetAllNamesFunc func(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error)
 
 	// GetByNameFunc mocks the GetByName method.
 	GetByNameFunc func(ctx context.Context, name string) (*migration.Source, error)
@@ -85,11 +86,15 @@ type SourceServiceMock struct {
 		GetAll []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// SourceTypes is the sourceTypes argument value.
+			SourceTypes []api.SourceType
 		}
 		// GetAllNames holds details about calls to the GetAllNames method.
 		GetAllNames []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// SourceTypes is the sourceTypes argument value.
+			SourceTypes []api.SourceType
 		}
 		// GetByName holds details about calls to the GetByName method.
 		GetByName []struct {
@@ -195,19 +200,21 @@ func (mock *SourceServiceMock) DeleteByNameCalls() []struct {
 }
 
 // GetAll calls GetAllFunc.
-func (mock *SourceServiceMock) GetAll(ctx context.Context) (migration.Sources, error) {
+func (mock *SourceServiceMock) GetAll(ctx context.Context, sourceTypes ...api.SourceType) (migration.Sources, error) {
 	if mock.GetAllFunc == nil {
 		panic("SourceServiceMock.GetAllFunc: method is nil but SourceService.GetAll was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
+		SourceTypes: sourceTypes,
 	}
 	mock.lockGetAll.Lock()
 	mock.calls.GetAll = append(mock.calls.GetAll, callInfo)
 	mock.lockGetAll.Unlock()
-	return mock.GetAllFunc(ctx)
+	return mock.GetAllFunc(ctx, sourceTypes...)
 }
 
 // GetAllCalls gets all the calls that were made to GetAll.
@@ -215,10 +222,12 @@ func (mock *SourceServiceMock) GetAll(ctx context.Context) (migration.Sources, e
 //
 //	len(mockedSourceService.GetAllCalls())
 func (mock *SourceServiceMock) GetAllCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
+	SourceTypes []api.SourceType
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}
 	mock.lockGetAll.RLock()
 	calls = mock.calls.GetAll
@@ -227,19 +236,21 @@ func (mock *SourceServiceMock) GetAllCalls() []struct {
 }
 
 // GetAllNames calls GetAllNamesFunc.
-func (mock *SourceServiceMock) GetAllNames(ctx context.Context) ([]string, error) {
+func (mock *SourceServiceMock) GetAllNames(ctx context.Context, sourceTypes ...api.SourceType) ([]string, error) {
 	if mock.GetAllNamesFunc == nil {
 		panic("SourceServiceMock.GetAllNamesFunc: method is nil but SourceService.GetAllNames was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
+		SourceTypes: sourceTypes,
 	}
 	mock.lockGetAllNames.Lock()
 	mock.calls.GetAllNames = append(mock.calls.GetAllNames, callInfo)
 	mock.lockGetAllNames.Unlock()
-	return mock.GetAllNamesFunc(ctx)
+	return mock.GetAllNamesFunc(ctx, sourceTypes...)
 }
 
 // GetAllNamesCalls gets all the calls that were made to GetAllNames.
@@ -247,10 +258,12 @@ func (mock *SourceServiceMock) GetAllNames(ctx context.Context) ([]string, error
 //
 //	len(mockedSourceService.GetAllNamesCalls())
 func (mock *SourceServiceMock) GetAllNamesCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
+	SourceTypes []api.SourceType
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
+		SourceTypes []api.SourceType
 	}
 	mock.lockGetAllNames.RLock()
 	calls = mock.calls.GetAllNames

--- a/internal/migration/source_service_test.go
+++ b/internal/migration/source_service_test.go
@@ -305,7 +305,7 @@ func TestSourceService_GetAll(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			repo := &mock.SourceRepoMock{
-				GetAllFunc: func(ctx context.Context) (migration.Sources, error) {
+				GetAllFunc: func(ctx context.Context, srcTypes ...api.SourceType) (migration.Sources, error) {
 					return tc.repoGetAllSources, tc.repoGetAllErr
 				},
 			}
@@ -353,7 +353,7 @@ func TestSourceService_GetAllNames(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			repo := &mock.SourceRepoMock{
-				GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
+				GetAllNamesFunc: func(ctx context.Context, srcTypes ...api.SourceType) ([]string, error) {
 					return tc.repoGetAllNames, tc.repoGetAllErr
 				},
 			}

--- a/internal/source/interface.go
+++ b/internal/source/interface.go
@@ -50,7 +50,7 @@ type Source interface {
 	// Returns an array of all networks available from the source, encoded as Networks.
 	//
 	// Returns an error if there is a problem fetching networks or their properties.
-	GetAllNetworks(ctx context.Context) ([]api.Network, error)
+	GetAllNetworks(ctx context.Context) (migration.Networks, error)
 
 	// Deletes a given snapshot, if it exists, from the specified VM.
 	//

--- a/internal/source/mock_gen.go
+++ b/internal/source/mock_gen.go
@@ -34,7 +34,7 @@ var _ Source = &SourceMock{}
 //			DoBasicConnectivityCheckFunc: func() (api.ExternalConnectivityStatus, *x509.Certificate) {
 //				panic("mock out the DoBasicConnectivityCheck method")
 //			},
-//			GetAllNetworksFunc: func(ctx context.Context) ([]api.Network, error) {
+//			GetAllNetworksFunc: func(ctx context.Context) (migration.Networks, error) {
 //				panic("mock out the GetAllNetworks method")
 //			},
 //			GetAllVMsFunc: func(ctx context.Context) (migration.Instances, error) {
@@ -75,7 +75,7 @@ type SourceMock struct {
 	DoBasicConnectivityCheckFunc func() (api.ExternalConnectivityStatus, *x509.Certificate)
 
 	// GetAllNetworksFunc mocks the GetAllNetworks method.
-	GetAllNetworksFunc func(ctx context.Context) ([]api.Network, error)
+	GetAllNetworksFunc func(ctx context.Context) (migration.Networks, error)
 
 	// GetAllVMsFunc mocks the GetAllVMs method.
 	GetAllVMsFunc func(ctx context.Context) (migration.Instances, error)
@@ -302,7 +302,7 @@ func (mock *SourceMock) DoBasicConnectivityCheckCalls() []struct {
 }
 
 // GetAllNetworks calls GetAllNetworksFunc.
-func (mock *SourceMock) GetAllNetworks(ctx context.Context) ([]api.Network, error) {
+func (mock *SourceMock) GetAllNetworks(ctx context.Context) (migration.Networks, error) {
 	if mock.GetAllNetworksFunc == nil {
 		panic("SourceMock.GetAllNetworksFunc: method is nil but Source.GetAllNetworks was just called")
 	}

--- a/internal/source/nsx.go
+++ b/internal/source/nsx.go
@@ -1,0 +1,665 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	incusAPI "github.com/lxc/incus/v6/shared/api"
+	incusTLS "github.com/lxc/incus/v6/shared/tls"
+
+	internalAPI "github.com/FuturFusion/migration-manager/internal/api"
+	"github.com/FuturFusion/migration-manager/internal/util"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+type InternalNSXSource struct {
+	InternalSource            `yaml:",inline"`
+	InternalNSXSourceSpecific `yaml:",inline"`
+}
+
+type InternalNSXSourceSpecific struct {
+	internalAPI.NSXSourceProperties `yaml:",inline"`
+
+	c *http.Client
+}
+
+// PaginationResponse handles paginated API responses.
+type PaginationResponse struct {
+	Results []any  `json:"results"`
+	Count   int    `json:"result_count"`
+	Cursor  string `json:"cursor"`
+}
+
+// VersionResponse is returned from the NSX API when fetching the version.
+type VersionResponse struct {
+	Version string `json:"product_version"`
+	Build   string `json:"product_build_number"`
+}
+
+func NewInternalNSXSourceFrom(apiSource api.Source) (*InternalNSXSource, error) {
+	if apiSource.SourceType != api.SOURCETYPE_NSX {
+		return nil, errors.New("Source is not of type NSX")
+	}
+
+	var connProperties api.VMwareProperties
+	err := json.Unmarshal(apiSource.Properties, &connProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InternalNSXSource{
+		InternalSource: InternalSource{
+			Source: apiSource,
+		},
+		InternalNSXSourceSpecific: InternalNSXSourceSpecific{
+			NSXSourceProperties: internalAPI.NSXSourceProperties{
+				VMwareProperties: connProperties,
+			},
+		},
+	}, nil
+}
+
+// Connect verifies the NSX server cert against the trusted fingerprint, and fetches the NSX Manager version.
+func (s *InternalNSXSource) Connect(ctx context.Context) error {
+	if s.isConnected {
+		return fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	endpointURL, err := url.Parse(s.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	if endpointURL == nil {
+		return fmt.Errorf("Invalid endpoint: %s", s.Endpoint)
+	}
+
+	var serverCert *x509.Certificate
+	if len(s.ServerCertificate) > 0 {
+		serverCert, err = x509.ParseCertificate(s.ServerCertificate)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Unset TLS server certificate if configured but doesn't match the provided trusted fingerprint.
+	if serverCert != nil && incusTLS.CertFingerprint(serverCert) != strings.ToLower(strings.ReplaceAll(s.TrustedServerCertificateFingerprint, ":", "")) {
+		serverCert = nil
+	}
+
+	// Create an empty client, and populate it with a trusted server cert.
+	s.c = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{}}}
+	if serverCert != nil {
+		certpool := x509.NewCertPool()
+		certpool.AddCert(serverCert)
+		s.c.Transport.(*http.Transport).TLSClientConfig.RootCAs = certpool
+	}
+
+	// Get the version information for this NSX manager.
+	b, err := s.httpGet(ctx, "api/v1/node/version")
+	if err != nil {
+		return err
+	}
+
+	var version VersionResponse
+	err = json.Unmarshal(b, &version)
+	if err != nil {
+		return err
+	}
+
+	s.version = version.Version
+	s.isConnected = true
+
+	return nil
+}
+
+func (s *InternalNSXSource) FetchSourceData(ctx context.Context) error {
+	if !s.isConnected {
+		return fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	segments, err := s.GetSegments(ctx, true)
+	if err != nil {
+		return fmt.Errorf("Failed to get segments for source %q: %w", s.Name, err)
+	}
+
+	computeManagers, err := s.GetComputeManagers(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get compute managers for source %q: %w", s.Name, err)
+	}
+
+	edgeNodes, err := s.GetEdgeNodes(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get edge nodes for source %q: %w", s.Name, err)
+	}
+
+	policies, err := s.GetSecurityPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get security policies for source %q: %w", s.Name, err)
+	}
+
+	s.NSXSourceProperties = internalAPI.NSXSourceProperties{
+		VMwareProperties: s.VMwareProperties,
+		ComputeManagers:  computeManagers,
+		Segments:         segments,
+		EdgeNodes:        edgeNodes,
+		Policies:         policies,
+	}
+
+	return nil
+}
+
+// DoBasicConnectivityCheck performs a connectivity check and verifies the server certificate against the trusted fingerprint.
+func (s *InternalNSXSource) DoBasicConnectivityCheck() (api.ExternalConnectivityStatus, *x509.Certificate) {
+	status, cert := util.DoBasicConnectivityCheck(s.Endpoint, s.TrustedServerCertificateFingerprint)
+	if cert != nil && s.ServerCertificate == nil {
+		// We got an untrusted certificate; if one hasn't already been set, add it to this source.
+		s.ServerCertificate = cert.Raw
+	}
+
+	return status, cert
+}
+
+// GetSegment fetches a segment by its segment path, and includes any VMs from the supplied list if their VIFs use a logical port on the segment.
+func (s *InternalNSXSource) GetSegment(ctx context.Context, segmentPath string, vms []internalAPI.NSXVirtualMachine) (*internalAPI.NSXSegment, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	b, err := s.httpGet(ctx, "policy/api/v1"+segmentPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get segment %q for %q: %w", segmentPath, s.Name, err)
+	}
+
+	vmsBySegmentPort := map[string][]internalAPI.NSXVirtualMachine{}
+	for _, vm := range vms {
+		for _, vif := range vm.VIFs {
+			if vmsBySegmentPort[vif.SegmentPortID] == nil {
+				vmsBySegmentPort[vif.SegmentPortID] = []internalAPI.NSXVirtualMachine{}
+			}
+
+			vmsBySegmentPort[vif.SegmentPortID] = append(vmsBySegmentPort[vif.SegmentPortID], vm)
+		}
+	}
+
+	var segment internalAPI.NSXSegment
+	err = json.Unmarshal(b, &segment)
+	if err != nil {
+		return nil, fmt.Errorf("Segment data from %q is invalid: %w", s.Name, err)
+	}
+
+	return s.AddSegmentData(ctx, &segment, vms)
+}
+
+// AddSegmentData populates the segment data with firewall rules, and adds the VMs from the given set that exist on the segment.
+func (s *InternalNSXSource) AddSegmentData(ctx context.Context, segment *internalAPI.NSXSegment, vms []internalAPI.NSXVirtualMachine) (*internalAPI.NSXSegment, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	vmsBySegmentPort := map[string][]internalAPI.NSXVirtualMachine{}
+	for _, vm := range vms {
+		for _, vif := range vm.VIFs {
+			if vmsBySegmentPort[vif.SegmentPortID] == nil {
+				vmsBySegmentPort[vif.SegmentPortID] = []internalAPI.NSXVirtualMachine{}
+			}
+
+			vmsBySegmentPort[vif.SegmentPortID] = append(vmsBySegmentPort[vif.SegmentPortID], vm)
+		}
+	}
+
+	if segment.ConnectivityPath != "" {
+		path := "policy/api/v1" + segment.ConnectivityPath + "/gateway-firewall"
+		allResults, err := s.paginatedGet(ctx, path)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get gateway firewall rules for %q: %w", s.Name, err)
+		}
+
+		if len(allResults) != 1 {
+			return nil, fmt.Errorf("Expected only one gateway police, got %d", len(allResults))
+		}
+
+		var obj internalAPI.NSXGatewayPolicy
+		entryJSON, err := json.Marshal(allResults[0])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse gateway firewall rule responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(entryJSON, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("Gateway firewall rule data from %q is invalid: %w", s.Name, err)
+		}
+
+		segment.Rules = obj
+	}
+
+	allResults, err := s.paginatedGet(ctx, "policy/api/v1/infra/segments/"+segment.ID+"/ports")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get segment ports for %q: %w", s.Name, err)
+	}
+
+	segment.VMs = []internalAPI.NSXVirtualMachine{}
+	vmMap := map[uuid.UUID]internalAPI.NSXVirtualMachine{}
+	for _, entry := range allResults {
+		var obj internalAPI.NSXSegmentPort
+		entryJSON, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse segment port responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(entryJSON, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("Segment port data from %q is invalid: %w", s.Name, err)
+		}
+
+		vms, ok := vmsBySegmentPort[obj.Attachment.ID]
+		if ok {
+			for _, vm := range vms {
+				_, ok := vmMap[vm.UUID]
+				if !ok {
+					vmMap[vm.UUID] = vm
+					segment.VMs = append(segment.VMs, vm)
+				}
+			}
+		}
+	}
+
+	return segment, nil
+}
+
+// GetSegments fetches all segments, their VMs, and gateway policies.
+func (s *InternalNSXSource) GetSegments(ctx context.Context, populateData bool) ([]internalAPI.NSXSegment, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	allResults, err := s.paginatedGet(ctx, "policy/api/v1/infra/segments")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get segments for %q: %w", s.Name, err)
+	}
+
+	var vms []internalAPI.NSXVirtualMachine
+	if populateData {
+		vms, err = s.GetVMs(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	vmsBySegmentPort := map[string][]internalAPI.NSXVirtualMachine{}
+	for _, vm := range vms {
+		for _, vif := range vm.VIFs {
+			if vmsBySegmentPort[vif.SegmentPortID] == nil {
+				vmsBySegmentPort[vif.SegmentPortID] = []internalAPI.NSXVirtualMachine{}
+			}
+
+			vmsBySegmentPort[vif.SegmentPortID] = append(vmsBySegmentPort[vif.SegmentPortID], vm)
+		}
+	}
+
+	allSegments := make([]internalAPI.NSXSegment, 0, len(allResults))
+	for _, entry := range allResults {
+		var segment internalAPI.NSXSegment
+		entryJSON, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse segment responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(entryJSON, &segment)
+		if err != nil {
+			return nil, fmt.Errorf("Segment data from %q is invalid: %w", s.Name, err)
+		}
+
+		if populateData {
+			_, err = s.AddSegmentData(ctx, &segment, vms)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		allSegments = append(allSegments, segment)
+	}
+
+	return allSegments, nil
+}
+
+// GetVMs fetches all VMs and their VIFs.
+func (s *InternalNSXSource) GetVMs(ctx context.Context) ([]internalAPI.NSXVirtualMachine, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	allVMResults, err := s.paginatedGet(ctx, "api/v1/fabric/virtual-machines")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get VMs for %q: %w", s.Name, err)
+	}
+
+	allVIFResults, err := s.paginatedGet(ctx, "api/v1/fabric/vifs")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get VIFs for %q: %w", s.Name, err)
+	}
+
+	allVMs := make([]internalAPI.NSXVirtualMachine, len(allVMResults))
+	for i, entry := range allVMResults {
+		var obj internalAPI.NSXVirtualMachine
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse VM responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(data, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("VM data from %q is invalid: %w", s.Name, err)
+		}
+
+		allVMs[i] = obj
+	}
+
+	netMap := map[uuid.UUID][]internalAPI.NSXVIF{}
+	for _, entry := range allVIFResults {
+		var obj internalAPI.NSXVIF
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse VIF responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(data, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("VIF data from %q is invalid: %w", s.Name, err)
+		}
+
+		if netMap[obj.UUID] == nil {
+			netMap[obj.UUID] = []internalAPI.NSXVIF{}
+		}
+
+		netMap[obj.UUID] = append(netMap[obj.UUID], obj)
+	}
+
+	for i, vm := range allVMs {
+		if netMap[vm.UUID] != nil {
+			allVMs[i].VIFs = netMap[vm.UUID]
+		}
+	}
+
+	return allVMs, nil
+}
+
+// GetSecurityPolicies fetches all security policies for all domains.
+func (s *InternalNSXSource) GetSecurityPolicies(ctx context.Context) ([]internalAPI.NSXSecurityPolicy, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	policies := []internalAPI.NSXSecurityPolicy{}
+	allResults, err := s.paginatedGet(ctx, "policy/api/v1/infra/domains")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get domains for %q: %w", s.Name, err)
+	}
+
+	for _, entry := range allResults {
+		var obj internalAPI.NSXDomain
+		entryJSON, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse domain responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(entryJSON, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("Domain data from %q is invalid: %w", s.Name, err)
+		}
+
+		path := "policy/api/v1" + obj.Path + "/security-policies"
+		allResults, err := s.paginatedGet(ctx, path)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get security policies for %q: %w", s.Name, err)
+		}
+
+		policy := internalAPI.NSXSecurityPolicy{Domain: obj.Name, Rules: []internalAPI.NSXRule{}}
+		for _, entry := range allResults {
+			var obj internalAPI.NSXRule
+			entryJSON, err := json.Marshal(entry)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to parse security policie responses for %q: %w", s.Name, err)
+			}
+
+			err = json.Unmarshal(entryJSON, &obj)
+			if err != nil {
+				return nil, fmt.Errorf("Security policy data from %q is invalid: %w", s.Name, err)
+			}
+
+			policy.Rules = append(policy.Rules, obj)
+		}
+
+		policies = append(policies, policy)
+	}
+
+	return policies, nil
+}
+
+// GetComputeManagers gets all compute managers registered with the NSX Manager.
+func (s *InternalNSXSource) GetComputeManagers(ctx context.Context) ([]internalAPI.NSXComputeManager, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	allResults, err := s.paginatedGet(ctx, "api/v1/fabric/compute-managers")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get compute managers for %q: %w", s.Name, err)
+	}
+
+	allComputeManagers := make([]internalAPI.NSXComputeManager, 0, len(allResults))
+	for _, computeEntry := range allResults {
+		var comp internalAPI.NSXComputeManager
+		compJSON, err := json.Marshal(computeEntry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse compute manager responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(compJSON, &comp)
+		if err != nil {
+			return nil, fmt.Errorf("Compute manager data from %q is invalid: %w", s.Name, err)
+		}
+
+		allComputeManagers = append(allComputeManagers, comp)
+	}
+
+	return allComputeManagers, nil
+}
+
+// GetTransportZone fetches a transport zone by its UUID.
+func (s *InternalNSXSource) GetTransportZone(ctx context.Context, zoneUUID uuid.UUID) (*internalAPI.NSXTransportZone, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	data, err := s.httpGet(ctx, "api/v1/transport-zones/"+zoneUUID.String())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get transport zones for %q: %w", s.Name, err)
+	}
+
+	var zone internalAPI.NSXTransportZone
+	err = json.Unmarshal(data, &zone)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse transport zone responses for %q: %w", s.Name, err)
+	}
+
+	zone.UUID = zoneUUID
+	return &zone, nil
+}
+
+// GetEdgeNodes fetches all edge transport nodes of the NSX Manager.
+func (s *InternalNSXSource) GetEdgeNodes(ctx context.Context) ([]internalAPI.NSXEdgeTransportNode, error) {
+	if !s.isConnected {
+		return nil, fmt.Errorf("Already connected to endpoint %q", s.Endpoint)
+	}
+
+	allResults, err := s.paginatedGet(ctx, "api/v1/transport-nodes")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get edge transport nodes for %q: %w", s.Name, err)
+	}
+
+	nodes := []internalAPI.NSXEdgeTransportNode{}
+	for _, entry := range allResults {
+		var obj internalAPI.NSXEdgeTransportNode
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse edge transport node responses for %q: %w", s.Name, err)
+		}
+
+		err = json.Unmarshal(data, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("Edge transport node data from %q is invalid: %w", s.Name, err)
+		}
+
+		if obj.Info.Type != "EdgeNode" {
+			continue
+		}
+
+		for i, sw := range obj.HostSwitches.Switches {
+			if sw.IPPool.UUID != uuid.Nil {
+				data, err := s.httpGet(ctx, "api/v1/pools/ip-pools/"+sw.IPPool.UUID.String())
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get IP pools for %q: %w", s.Name, err)
+				}
+
+				var pool internalAPI.NSXIPPool
+				err = json.Unmarshal(data, &pool)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to parse IP pool responses for %q: %w", s.Name, err)
+				}
+
+				pool.UUID = sw.IPPool.UUID
+				obj.HostSwitches.Switches[i].IPPool = pool
+			}
+
+			for j, zoneID := range sw.TransportZones {
+				zone, err := s.GetTransportZone(ctx, zoneID.UUID)
+				if err != nil {
+					return nil, err
+				}
+
+				obj.HostSwitches.Switches[i].TransportZones[j] = *zone
+			}
+		}
+
+		nodes = append(nodes, obj)
+	}
+
+	return nodes, nil
+}
+
+func (s *InternalNSXSource) makeRequest(ctx context.Context, method string, path string, header http.Header, content []byte) (*http.Response, error) {
+	urlPath := s.Endpoint + path
+	req, err := http.NewRequestWithContext(ctx, method, urlPath, bytes.NewBuffer(content))
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(s.Username, s.Password)
+	if header != nil {
+		req.Header = header
+	} else {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := s.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// httpGet makes a single http request to the given path, with the given optional header and contents, and returns the response body.
+func (s *InternalNSXSource) httpGet(ctx context.Context, path string) ([]byte, error) {
+	resp, err := s.makeRequest(ctx, http.MethodGet, "/"+path, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching data from %s: %w", path, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API call failed: URL=%s, Status=%s, Response=%s", path, resp.Status, string(body))
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body from %s: %w", path, err)
+	}
+
+	return body, nil
+}
+
+// paginatedGet makes a request to a paginated API, iterating until all results have been gathered. Returns a list of response bodies.
+func (s *InternalNSXSource) paginatedGet(ctx context.Context, path string) ([]any, error) {
+	var allResults []any
+	var cursor string
+	pageNum := 1
+
+	nextPath := incusAPI.NewURL()
+	nextPath.Path(strings.Split(path, "/")...)
+	for {
+		// Add cursor to query parameters if present
+		if cursor != "" {
+			nextPath = nextPath.WithQuery("cursor", cursor)
+		}
+
+		resp, err := s.makeRequest(ctx, http.MethodGet, nextPath.String(), nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("Error fetching data from %q: %w", nextPath.String(), err)
+		}
+
+		defer func() { _ = resp.Body.Close() }() //nolint:revive
+
+		// Check the response status code
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return nil, fmt.Errorf("NSX API call failed: URL=%q, Status=%q, Response=%q", nextPath.String(), resp.Status, string(body))
+		}
+
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading response body from %q: %w", nextPath.String(), err)
+		}
+
+		// Unmarshal the JSON response
+		var paginatedResp PaginationResponse
+		err = json.Unmarshal(body, &paginatedResp)
+		if err != nil {
+			return nil, fmt.Errorf("Error unmarshaling JSON from %q: %w", nextPath.String(), err)
+		}
+
+		// Append the results to allResults
+		allResults = append(allResults, paginatedResp.Results...)
+
+		// Check if there's a cursor to continue pagination
+		if paginatedResp.Cursor == "" {
+			break
+		}
+
+		err = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		cursor = paginatedResp.Cursor
+		pageNum++
+	}
+
+	return allResults, nil
+}

--- a/internal/source/properties_test.go
+++ b/internal/source/properties_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -529,7 +530,12 @@ func TestGetProperties(t *testing.T) {
 			},
 		}
 
-		props, err := s.getVMProperties(vmInfo, vmProps, networks)
+		networkLocationsByID := map[string]string{}
+		for _, n := range networks {
+			networkLocationsByID[parseNetworkID(context.Background(), n)] = n.GetInventoryPath()
+		}
+
+		props, err := s.getVMProperties(vmInfo, vmProps, networkLocationsByID)
 		if c.expectErr {
 			require.Error(t, err)
 		} else {

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -1,5 +1,23 @@
 package api
 
+import "encoding/json"
+
+type NetworkType string
+
+const (
+	// NETWORKTYPE_VMWARE_STANDARD is a standard vCenter switch-backed port group.
+	NETWORKTYPE_VMWARE_STANDARD NetworkType = "standard"
+
+	// NETWORKTYPE_VMWARE_DISTRIBUTED is a distributed port group backed by a vCenter distributed switch.
+	NETWORKTYPE_VMWARE_DISTRIBUTED NetworkType = "distributed"
+
+	// NETWORKTYPE_VMWARE_DISTRIBUTED_NSX is a distributed port group backed by NSX.
+	NETWORKTYPE_VMWARE_DISTRIBUTED_NSX NetworkType = "nsx-distributed"
+
+	// NETWORKTYPE_VMWARE_NSX is an opaque network managed by NSX.
+	NETWORKTYPE_VMWARE_NSX NetworkType = "nsx"
+)
+
 // Network defines the network config for use by the migration manager.
 //
 // swagger:model
@@ -10,9 +28,20 @@ type Network struct {
 	// Example: network-23
 	Name string `json:"name" yaml:"name"`
 
-	// The location of the network
-	// Example: /path/to/network
+	// vCenter source for the network
+	// Example: vcenter01
+	Source string `json:"source" yaml:"source"`
+
+	// Type of the network
+	// Example: standard
+	Type NetworkType `json:"type" yaml:"type"`
+
+	// Full inventory location path of the network
+	// Example: /vcenter01/network/net0
 	Location string `json:"location" yaml:"location"`
+
+	// Additional properties of the network.
+	Properties json.RawMessage `json:"properties" yaml:"properties"`
 }
 
 // NetworkPut defines the configurable properties of Network.

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -24,9 +24,9 @@ const (
 type Network struct {
 	NetworkPut
 
-	// The name of the network
+	// The identifier of the network
 	// Example: network-23
-	Name string `json:"name" yaml:"name"`
+	Identifier string `json:"identifier" yaml:"identifier"`
 
 	// vCenter source for the network
 	// Example: vcenter01

--- a/shared/api/source.go
+++ b/shared/api/source.go
@@ -9,7 +9,18 @@ type SourceType string
 const (
 	SOURCETYPE_COMMON SourceType = "common"
 	SOURCETYPE_VMWARE SourceType = "vmware"
+	SOURCETYPE_NSX    SourceType = "nsx"
 )
+
+// VMSourceTypes are the list of source types that manage VMs.
+func VMSourceTypes() []SourceType {
+	return []SourceType{SOURCETYPE_VMWARE}
+}
+
+// NetworkSourceTypes are the list of source types that manage networks.
+func NetworkSourceTypes() []SourceType {
+	return []SourceType{SOURCETYPE_NSX}
+}
 
 // Source defines properties common to all sources.
 //


### PR DESCRIPTION
Closes #150 

Whew, finally done with this one!

* Adds `nsx` source type
* Omits VM templates from import
* Adds preliminary set of NSX API objects. These are in `internal/api` since they are as yet quite unstable.
* Uses a more precise network identifier from vCenter networks
* Only imports networks in-use by some VM on a source
* Adds network type (`standard`, `distributed`, `nsx-distributed`, `nsx`)
* Adds network source to maintain uniqueness across different sources
* Adds network properties
  * Initially populated with segment ID and transport zone UUID if applicable from vCenter
  * If an NSX source is detected on next sync, segment data including gateway firewall rules and VMs are added to the properties
* Adds recursion=2 to sources to fetch a wider set of NSX manager information for the source. Only applicable to `nsx` sources.
* Network `name` is renamed to `identifier` since it's almost never actually the network name

Drops all existing networks in the database, as their previous IDs could have been incorrect, and since we were previously agnostic to sources and only took the first network ID, it cannot be determined which source to apply in case of duplicates.
