### PR TITLE
Misc fixes

### DIFF
--- a/cmd/migration-managerd/internal/api/sync.go
+++ b/cmd/migration-managerd/internal/api/sync.go
@@ -390,6 +390,21 @@ func syncInstancesFromSource(ctx context.Context, sourceName string, i migration
 
 		instanceUpdated := false
 
+		if inst.Properties.Location != srcInst.Properties.Location {
+			inst.Properties.Location = srcInst.Properties.Location
+			instanceUpdated = true
+		}
+
+		if inst.Properties.Name != srcInst.Properties.Name {
+			inst.Properties.Name = srcInst.Properties.Name
+			instanceUpdated = true
+		}
+
+		if inst.Properties.BackgroundImport != srcInst.Properties.BackgroundImport {
+			inst.Properties.BackgroundImport = srcInst.Properties.BackgroundImport
+			instanceUpdated = true
+		}
+
 		if inst.Properties.Description != srcInst.Properties.Description {
 			inst.Properties.Description = srcInst.Properties.Description
 			instanceUpdated = true

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -88,6 +88,32 @@ func (d *Daemon) validateForQueue(ctx context.Context, b migration.Batch, w migr
 	return it, nil
 }
 
+func (d *Daemon) reassessBlockedInstances(ctx context.Context) error {
+	blockedEntries, err := d.queue.GetAllByState(ctx, api.MIGRATIONSTATUS_BLOCKED)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch blocked queue entries: %w", err)
+	}
+
+	blockedInstances, err := d.instance.GetAllQueued(ctx, blockedEntries)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch blocked instances: %w", err)
+	}
+
+	for i, inst := range blockedInstances {
+		err := inst.DisabledReason()
+		if err != nil {
+			continue
+		}
+
+		_, err = d.queue.UpdateStatusByUUID(ctx, inst.UUID, api.MIGRATIONSTATUS_CREATING, string(api.MIGRATIONSTATUS_CREATING), blockedEntries[i].NeedsDiskImport)
+		if err != nil {
+			return fmt.Errorf("Failed to unblock queue entry for %q: %w", inst.Properties.Location, err)
+		}
+	}
+
+	return nil
+}
+
 // beginImports creates the target VMs for all CREATING status instances.
 // It sets their batches to RUNNING if they have the necessary files to begin a migration.
 // Errors encountered in one batch do not affect the processing of other batches.
@@ -96,9 +122,22 @@ func (d *Daemon) validateForQueue(ctx context.Context, b migration.Batch, w migr
 //     If any errors occur after the VM has started, the VM will no longer be cleaned up, and its state will be set to ERROR, preventing retries.
 func (d *Daemon) beginImports(ctx context.Context, cleanupInstances bool) error {
 	log := slog.With(slog.String("method", "beginImports"))
-	migrationState, err := d.queueHandler.GetMigrationState(ctx, api.BATCHSTATUS_QUEUED, api.MIGRATIONSTATUS_CREATING)
+	var migrationState map[string]queue.MigrationState
+	err := transaction.Do(ctx, func(ctx context.Context) error {
+		err := d.reassessBlockedInstances(ctx)
+		if err != nil {
+			return err
+		}
+
+		migrationState, err = d.queueHandler.GetMigrationState(ctx, api.BATCHSTATUS_QUEUED, api.MIGRATIONSTATUS_CREATING)
+		if err != nil {
+			return fmt.Errorf("Failed to compile migration state for batch processing: %w", err)
+		}
+
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("Failed to compile migration state for batch processing: %w", err)
+		return err
 	}
 
 	ignoredBatches := []string{}

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -234,7 +234,7 @@ func (d *Daemon) ensureISOImagesExistInStoragePool(ctx context.Context, it *targ
 
 		for _, op := range ops {
 			err = op.Wait()
-			if err != nil {
+			if err != nil && !incusAPI.StatusErrorCheck(err, http.StatusNotFound) {
 				return err
 			}
 		}
@@ -250,14 +250,16 @@ func (d *Daemon) ensureISOImagesExistInStoragePool(ctx context.Context, it *targ
 		if !volumeMap["custom/"+driversISO] {
 			log.Info("ISO image doesn't exist in storage pool, importing...")
 
-			op, err := it.CreateStoragePoolVolumeFromISO(batch.StoragePool, driversISOPath)
+			ops, err := it.CreateStoragePoolVolumeFromISO(batch.StoragePool, driversISOPath)
 			if err != nil {
 				return err
 			}
 
-			err = op.Wait()
-			if err != nil {
-				return err
+			for _, op := range ops {
+				err = op.Wait()
+				if err != nil && !incusAPI.StatusErrorCheck(err, http.StatusNotFound) {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -213,6 +213,7 @@ func (b Batch) CanStart(windows []MigrationWindow) error {
 func (b Batch) CanBeModified() bool {
 	switch b.Status {
 	case api.BATCHSTATUS_DEFINED,
+		api.BATCHSTATUS_STOPPED,
 		api.BATCHSTATUS_FINISHED,
 		api.BATCHSTATUS_ERROR:
 		return true

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,27 @@ func (i Instance) Validate() error {
 
 	if i.Source == "" {
 		return NewValidationErrf("Invalid instance, source id can not be empty")
+	}
+
+	return nil
+}
+
+// DisabledReason returns the underlying reason for why the instance is disabled.
+func (i Instance) DisabledReason() error {
+	if i.Overrides.DisableMigration {
+		reason := "Migration is disabled"
+		if !i.Properties.BackgroundImport {
+			reason += ": Background import is not supported"
+		} else {
+			for _, d := range i.Properties.Disks {
+				if !d.Supported {
+					reason += fmt.Sprintf(": Disk %q does not support snapshots", d.Name)
+					break
+				}
+			}
+		}
+
+		return errors.New(reason)
 	}
 
 	return nil

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -283,10 +283,15 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 			Properties:           *vmProps,
 		}
 
-		for _, d := range inst.Properties.Disks {
-			if !d.Supported {
-				inst.Overrides.DisableMigration = true
-				break
+		// Disqualify instances from migration if they don't meet optimal criteria.
+		if !inst.Properties.BackgroundImport {
+			inst.Overrides.DisableMigration = true
+		} else {
+			for _, d := range inst.Properties.Disks {
+				if !d.Supported {
+					inst.Overrides.DisableMigration = true
+					break
+				}
 			}
 		}
 

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -792,20 +792,69 @@ func (t *InternalIncusTarget) CreateStoragePoolVolumeFromBackup(poolName string,
 	return ops, nil
 }
 
-func (t *InternalIncusTarget) CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) (incus.Operation, error) {
-	file, err := os.Open(isoFilePath)
+func (t *InternalIncusTarget) CreateStoragePoolVolumeFromISO(poolName string, isoFilePath string) ([]incus.Operation, error) {
+	pool, _, err := t.incusClient.GetStoragePool(poolName)
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = file.Close() }()
-
-	createArgs := incus.StorageVolumeBackupArgs{
-		BackupFile: file,
-		Name:       filepath.Base(isoFilePath),
+	s, _, err := t.incusClient.GetServer()
+	if err != nil {
+		return nil, err
 	}
 
-	return t.incusClient.CreateStoragePoolVolumeFromISO(pool, createArgs)
+	poolIsShared := false
+	for _, driver := range s.Environment.StorageSupportedDrivers {
+		if driver.Name == pool.Driver {
+			poolIsShared = driver.Remote
+			break
+		}
+	}
+
+	if poolIsShared {
+		file, err := os.Open(isoFilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		createArgs := incus.StorageVolumeBackupArgs{
+			BackupFile: file,
+			Name:       filepath.Base(isoFilePath),
+		}
+
+		op, err := t.incusClient.CreateStoragePoolVolumeFromISO(poolName, createArgs)
+		if err != nil {
+			return nil, err
+		}
+
+		return []incus.Operation{op}, nil
+	}
+
+	// If the pool is local-only, we have to create the volume for each member.
+	members, err := t.incusClient.GetClusterMemberNames()
+	if err != nil {
+		return nil, err
+	}
+
+	ops := make([]incus.Operation, 0, len(members))
+	for _, member := range members {
+		file, err := os.Open(isoFilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		createArgs := incus.StorageVolumeBackupArgs{BackupFile: file, Name: filepath.Base(isoFilePath)}
+
+		target := t.incusClient.UseTarget(member)
+		op, err := target.CreateStoragePoolVolumeFromISO(poolName, createArgs)
+		if err != nil {
+			return nil, err
+		}
+
+		ops = append(ops, op)
+	}
+
+	return ops, nil
 }
 
 type backupIndexFile struct {

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -975,10 +975,6 @@ func (t *InternalIncusTarget) ReadyForMigration(ctx context.Context, targetProje
 	}
 
 	for _, inst := range instances {
-		if inst.Overrides.DisableMigration {
-			return fmt.Errorf("Migration is disabled for instance %q", inst.Properties.Location)
-		}
-
 		if targetInstanceMap[inst.GetName()] {
 			return fmt.Errorf("Another instance with name %q already exists", inst.GetName())
 		}

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -242,7 +242,11 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(i migration.Instance, all
 
 		// If no network is given, set "default" as the default.
 		if apiDef.Devices[nicDeviceName]["network"] == "" {
-			apiDef.Devices[nicDeviceName]["network"] = "default"
+			if baseNetwork.Type == api.NETWORKTYPE_VMWARE_DISTRIBUTED_NSX || baseNetwork.Type == api.NETWORKTYPE_VMWARE_NSX {
+				apiDef.Devices[nicDeviceName]["network"] = strings.ReplaceAll(filepath.Base(nic.Network), " ", "-")
+			} else {
+				apiDef.Devices[nicDeviceName]["network"] = "default"
+			}
 		}
 
 		// Set a few forced overrides.

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -525,9 +525,8 @@ func (t *InternalIncusTarget) CreateNewVM(instDef migration.Instance, apiDef inc
 				continue
 			}
 
-			diskName := strings.ReplaceAll(disk.Name, "/", "_")
-			diskName, _ = strings.CutSuffix(diskName, ".vmdk")
-
+			diskKey := fmt.Sprintf("disk%d", i)
+			diskName := apiDef.Name + "-" + diskKey
 			reverter.Add(func() {
 				_ = tgtClient.DeleteStoragePoolVolume(storagePool, "custom", diskName)
 			})
@@ -545,7 +544,6 @@ func (t *InternalIncusTarget) CreateNewVM(instDef migration.Instance, apiDef inc
 				return nil, err
 			}
 
-			diskKey := fmt.Sprintf("disk%d", i)
 			instInfo.Devices[diskKey] = map[string]string{}
 			for k, v := range defaultDiskDef {
 				instInfo.Devices[diskKey][k] = v

--- a/internal/worker/windows.go
+++ b/internal/worker/windows.go
@@ -243,6 +243,8 @@ func MapWindowsVersionToAbbrev(version string) (string, error) {
 		return "xp", nil
 	case strings.Contains(version, "Windows 7"):
 		return "w7", nil
+	case strings.Contains(version, "Windows 8.1"):
+		return "w8.1", nil
 	case strings.Contains(version, "Windows 8"):
 		return "w8", nil
 	case strings.Contains(version, "Windows 10"):
@@ -253,6 +255,14 @@ func MapWindowsVersionToAbbrev(version string) (string, error) {
 		return "2k3", nil
 	case strings.Contains(version, "Server 2008 R2"):
 		return "2k8r2", nil
+	case strings.Contains(version, "Server 2008"):
+		return "2k8", nil
+	case strings.Contains(version, "Server 2012 R2"):
+		return "2k12r2", nil
+	case strings.Contains(version, "Server 2012"):
+		return "2k12", nil
+	case strings.Contains(version, "Server 2016"):
+		return "2k16", nil
 	case strings.Contains(version, "Server 2019"):
 		return "2k19", nil
 	case strings.Contains(version, "Server 2022"):

--- a/shared/api/queue.go
+++ b/shared/api/queue.go
@@ -10,6 +10,7 @@ type MigrationStatusType string
 
 const (
 	MIGRATIONSTATUS_CREATING          MigrationStatusType = "Creating new VM"
+	MIGRATIONSTATUS_BLOCKED           MigrationStatusType = "Blocked"
 	MIGRATIONSTATUS_BACKGROUND_IMPORT MigrationStatusType = "Performing background import tasks"
 	MIGRATIONSTATUS_IDLE              MigrationStatusType = "Idle"
 	MIGRATIONSTATUS_FINAL_IMPORT      MigrationStatusType = "Performing final import tasks"
@@ -22,6 +23,7 @@ const (
 func (m MigrationStatusType) Validate() error {
 	switch m {
 	case MIGRATIONSTATUS_BACKGROUND_IMPORT:
+	case MIGRATIONSTATUS_BLOCKED:
 	case MIGRATIONSTATUS_CREATING:
 	case MIGRATIONSTATUS_ERROR:
 	case MIGRATIONSTATUS_FINAL_IMPORT:


### PR DESCRIPTION
Closes #218 
Closes #223 

* Properly add virtio-win ISO to all cluster members if pool is not remote
* Properly check `name`, `location`, and `background_import` for updates upon sync
* Properly handle source param in network CLI
* Fix testing mode for errored/running batches
* Use `instanceName-diskN` for additional volumes
* Support all Windows versions that distrobuilder supports
* If a network is of an NSX type, try to re-use its network name (excluding spaces, replaced with hyphens)
---
* Add BLOCKED migration state, which occurs if an instance has `DisableMigration` set when its batch starts
* Allow manually removing queue entries in state BLOCKED, FINISHED, or ERROR
* Before beginning target instance creation, check if any blocked instances can be unblocked.
* Set `DisableMigration` if an instance does not support background import. 