### PR TITLE
ui: Improve UX for editing migration windows/constraints

### DIFF
--- a/ui/src/components/BatchConstraintsWidget.tsx
+++ b/ui/src/components/BatchConstraintsWidget.tsx
@@ -18,15 +18,10 @@ const INITIAL_CONSTRAINT = {
 
 const BatchConstraintsWidget: FC<Props> = ({ value, onChange }) => {
   const [entries, setEntries] = useState<BatchConstraint[]>(value || []);
-  const [constraint, setConstraint] = useState<BatchConstraint>({
-    ...INITIAL_CONSTRAINT,
-  });
 
   const handleAdd = () => {
-    const newValues = [...entries, constraint];
+    const newValues = [...entries, INITIAL_CONSTRAINT];
     setEntries(newValues);
-    onChange(newValues);
-    setConstraint({ ...INITIAL_CONSTRAINT });
   };
 
   useEffect(() => {
@@ -69,12 +64,14 @@ const BatchConstraintsWidget: FC<Props> = ({ value, onChange }) => {
                   <Form.Control
                     type="text"
                     size="sm"
+                    placeholder="Name"
                     value={item.name}
                     onChange={(e) => handleEdit(index, "name", e.target.value)}
                   />
                   <Form.Control
                     type="text"
                     size="sm"
+                    placeholder="Description"
                     value={item.description}
                     onChange={(e) =>
                       handleEdit(index, "description", e.target.value)
@@ -83,6 +80,7 @@ const BatchConstraintsWidget: FC<Props> = ({ value, onChange }) => {
                   <Form.Control
                     type="text"
                     size="sm"
+                    placeholder="Include expression"
                     value={item.include_expression}
                     onChange={(e) =>
                       handleEdit(index, "include_expression", e.target.value)
@@ -91,18 +89,20 @@ const BatchConstraintsWidget: FC<Props> = ({ value, onChange }) => {
                   <Form.Control
                     type="number"
                     size="sm"
+                    placeholder="Max concurrent instances"
                     value={item.max_concurrent_instances}
                     onChange={(e) =>
                       handleEdit(
                         index,
                         "max_concurrent_instances",
-                        e.target.value,
+                        parseInt(e.target.value),
                       )
                     }
                   />
                   <Form.Control
                     type="text"
                     size="sm"
+                    placeholder="Min instance boot time"
                     value={item.min_instance_boot_time}
                     onChange={(e) =>
                       handleEdit(
@@ -128,62 +128,6 @@ const BatchConstraintsWidget: FC<Props> = ({ value, onChange }) => {
             </>
           ))}
           <tr>
-            <td style={{ display: "flex", gap: "8px" }}>
-              <Form.Control
-                type="text"
-                size="sm"
-                placeholder="Name"
-                value={constraint.name}
-                onChange={(e) =>
-                  setConstraint({ ...constraint, name: e.target.value })
-                }
-              />
-              <Form.Control
-                type="text"
-                size="sm"
-                placeholder="Description"
-                value={constraint.description}
-                onChange={(e) =>
-                  setConstraint({ ...constraint, description: e.target.value })
-                }
-              />
-              <Form.Control
-                type="text"
-                size="sm"
-                placeholder="Include expression"
-                value={constraint.include_expression}
-                onChange={(e) =>
-                  setConstraint({
-                    ...constraint,
-                    include_expression: e.target.value,
-                  })
-                }
-              />
-              <Form.Control
-                type="number"
-                size="sm"
-                placeholder="Max concurrent instances"
-                value={constraint.max_concurrent_instances}
-                onChange={(e) =>
-                  setConstraint({
-                    ...constraint,
-                    max_concurrent_instances: Number(e.target.value),
-                  })
-                }
-              />
-              <Form.Control
-                type="text"
-                size="sm"
-                placeholder="Min instance boot time"
-                value={constraint.min_instance_boot_time}
-                onChange={(e) =>
-                  setConstraint({
-                    ...constraint,
-                    min_instance_boot_time: e.target.value,
-                  })
-                }
-              />
-            </td>
             <td>
               <Button
                 title="Add"

--- a/ui/src/components/MigrationWindowsWidget.tsx
+++ b/ui/src/components/MigrationWindowsWidget.tsx
@@ -12,21 +12,14 @@ interface Props {
 
 const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
   const [entries, setEntries] = useState<MigrationWindow[]>(value || []);
-  const [migrationWindow, setMigrationWindow] = useState<MigrationWindow>({
-    start: "",
-    end: "",
-    lockout: "",
-  });
 
   const handleAdd = () => {
-    const newValues = [...entries, migrationWindow];
+    const newValues = [...entries, { start: "", end: "", lockout: "" }];
     setEntries(newValues);
-    onChange(newValues);
-    setMigrationWindow({ start: "", end: "", lockout: "" });
   };
 
   useEffect(() => {
-    setEntries(value || {});
+    setEntries(value || []);
   }, [value]);
 
   const handleDelete = (index: number) => {
@@ -64,6 +57,7 @@ const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
                 <td style={{ display: "flex", gap: "8px" }}>
                   <DatePicker
                     className="form-control form-control-sm"
+                    placeholderText="Start"
                     selected={item.start ? new Date(item.start) : null}
                     onChange={(date) =>
                       handleEdit(
@@ -80,6 +74,7 @@ const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
                   />
                   <DatePicker
                     className="form-control form-control-sm"
+                    placeholderText="End"
                     selected={item.end ? new Date(item.end) : null}
                     onChange={(date) =>
                       handleEdit(
@@ -96,6 +91,7 @@ const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
                   />
                   <DatePicker
                     className="form-control form-control-sm"
+                    placeholderText="Lockout"
                     selected={item.lockout ? new Date(item.lockout) : null}
                     onChange={(date) =>
                       handleEdit(
@@ -126,64 +122,6 @@ const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
             </>
           ))}
           <tr>
-            <td style={{ display: "flex", gap: "8px" }}>
-              <DatePicker
-                className="form-control form-control-sm"
-                placeholderText="Start"
-                selected={
-                  migrationWindow.start ? new Date(migrationWindow.start) : null
-                }
-                onChange={(date) =>
-                  setMigrationWindow({
-                    ...migrationWindow,
-                    start: date ? formatDate(date.toString()) : null,
-                  })
-                }
-                showTimeSelect
-                timeFormat="HH:mm"
-                timeIntervals={15}
-                timeCaption="time"
-                dateFormat="yyyy-MM-dd HH:mm:ss"
-              />
-              <DatePicker
-                className="form-control form-control-sm"
-                placeholderText="End"
-                selected={
-                  migrationWindow.end ? new Date(migrationWindow.end) : null
-                }
-                onChange={(date) =>
-                  setMigrationWindow({
-                    ...migrationWindow,
-                    end: date ? formatDate(date.toString()) : null,
-                  })
-                }
-                showTimeSelect
-                timeFormat="HH:mm"
-                timeIntervals={15}
-                timeCaption="time"
-                dateFormat="yyyy-MM-dd HH:mm:ss"
-              />
-              <DatePicker
-                className="form-control form-control-sm"
-                placeholderText="Lockout"
-                selected={
-                  migrationWindow.lockout
-                    ? new Date(migrationWindow.lockout)
-                    : null
-                }
-                onChange={(date) =>
-                  setMigrationWindow({
-                    ...migrationWindow,
-                    lockout: date ? formatDate(date.toString()) : null,
-                  })
-                }
-                showTimeSelect
-                timeFormat="HH:mm"
-                timeIntervals={15}
-                timeCaption="time"
-                dateFormat="yyyy-MM-dd HH:mm:ss"
-              />
-            </td>
             <td>
               <Button
                 title="Add"
@@ -196,12 +134,14 @@ const MigrationWindowsWidget: FC<Props> = ({ value, onChange }) => {
               </Button>
             </td>
           </tr>
-          <tr>
-            <td className="text-muted small">
-              Required format: YYYY-MM-DD HH:MM:SS (e.g.,{" "}
-              {formatDate(new Date().toString())})
-            </td>
-          </tr>
+          {entries.length > 0 && (
+            <tr>
+              <td className="text-muted small">
+                Required format: YYYY-MM-DD HH:MM:SS (e.g.,{" "}
+                {formatDate(new Date().toString())})
+              </td>
+            </tr>
+          )}
         </tbody>
       </Table>
     </div>


### PR DESCRIPTION
Previously, after filling in the fields, a new migration window was not added unless the "Add" button was clicked. Now, the user must explicitly click the "Add" button for a new set of fields to appear. This helps avoid confusion when adding migration windows. The same applies to constraints.