### PR TITLE
ui: Improve closing behavior of batch deletion modal

### DIFF
--- a/ui/src/components/BatchActions.tsx
+++ b/ui/src/components/BatchActions.tsx
@@ -113,6 +113,7 @@ const BatchActions: FC<Props> = ({ batch }) => {
       <BatchDeleteModal
         batchName={batch.name}
         show={showDeleteModal}
+        onSuccess={() => setShowDeleteModal(false)}
         handleClose={() => setShowDeleteModal(false)}
       />
     </div>


### PR DESCRIPTION
When deleting a batch from the list, the modal window did not close automatically. This could lead to accidentally deleting another record if the user clicked again.
This fix ensures that the batch deletion modal closes after the operation is completed, preventing unintended additional deletions.