### PR TITLE
Fix network interface name assignment

### DIFF
--- a/cmd/migration-manager-worker/internal/worker/worker.go
+++ b/cmd/migration-manager-worker/internal/worker/worker.go
@@ -272,19 +272,19 @@ func (w *Worker) finalizeImport(ctx context.Context, cmd api.WorkerCommand) (don
 	}
 
 	if strings.Contains(strings.ToLower(cmd.OS), "centos") {
-		err = worker.LinuxDoPostMigrationConfig("CentOS", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "CentOS", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "debian") {
-		err = worker.LinuxDoPostMigrationConfig("Debian", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "Debian", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "opensuse") {
-		err = worker.LinuxDoPostMigrationConfig("openSUSE", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "openSUSE", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "oracle") {
-		err = worker.LinuxDoPostMigrationConfig("Oracle", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "Oracle", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "rhel") {
-		err = worker.LinuxDoPostMigrationConfig("RHEL", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "RHEL", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "sles") {
-		err = worker.LinuxDoPostMigrationConfig("SUSE", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "SUSE", majorVersion)
 	} else if strings.Contains(strings.ToLower(cmd.OS), "ubuntu") {
-		err = worker.LinuxDoPostMigrationConfig("Ubuntu", majorVersion)
+		err = worker.LinuxDoPostMigrationConfig(ctx, "Ubuntu", majorVersion)
 	}
 
 	if err != nil {

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -441,6 +441,12 @@ func (t *InternalIncusTarget) CreateVMDefinition(instanceDef migration.Instance,
 		return incusAPI.InstancesPost{}, err
 	}
 
+	hwaddrs := []string{}
+	for _, nic := range instanceDef.Properties.NICs {
+		hwaddrs = append(hwaddrs, nic.HardwareAddress)
+	}
+
+	ret.Config["user.migration.hwaddrs"] = strings.Join(hwaddrs, " ")
 	ret.Config["user.migration.source_type"] = "VMware"
 	ret.Config["user.migration.source"] = instanceDef.Source
 	ret.Config["user.migration.token"] = secretToken.String()

--- a/internal/worker/linux.go
+++ b/internal/worker/linux.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bufio"
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -50,7 +51,7 @@ type LVSOutput struct {
 
 const chrootMountPath string = "/run/mount/target/"
 
-func LinuxDoPostMigrationConfig(distro string, majorVersion int) error {
+func LinuxDoPostMigrationConfig(ctx context.Context, distro string, majorVersion int) error {
 	slog.Info("Preparing to perform post-migration configuration of VM")
 
 	// Determine the root partition.

--- a/internal/worker/linux.go
+++ b/internal/worker/linux.go
@@ -261,7 +261,7 @@ func determineRootPartition() (string, int, []string, error) {
 	return "", PARTITION_TYPE_UNKNOWN, nil, fmt.Errorf("Failed to determine the root partition")
 }
 
-func runScriptInChroot(scriptName string) error {
+func runScriptInChroot(scriptName string, args ...string) error {
 	// Get the embedded script's contents.
 	script, err := embeddedScripts.ReadFile(filepath.Join("scripts/", scriptName))
 	if err != nil {
@@ -277,7 +277,9 @@ func runScriptInChroot(scriptName string) error {
 	defer func() { _ = os.Remove(filepath.Join(chrootMountPath, scriptName)) }()
 
 	// Run the script within the chroot.
-	_, err = subprocess.RunCommand("chroot", chrootMountPath, filepath.Join("/", scriptName))
+	cmd := []string{chrootMountPath, filepath.Join("/", scriptName)}
+	cmd = append(cmd, args...)
+	_, err = subprocess.RunCommand("chroot", cmd...)
 	return err
 }
 

--- a/internal/worker/scripts/add-udev-network-rules.sh
+++ b/internal/worker/scripts/add-udev-network-rules.sh
@@ -8,17 +8,21 @@
 #  3. /etc/network/interfaces (classic Debian network config)
 #  4. /etc/sysconfig/network{,-scripts}/ifcfg-* (older RHEL/SUSE network config)
 
+if [ $# -ne 1 ]; then
+  exit 0
+fi
+
+hwaddrs="${1}"
 
 process_devs () {
     _device_num=1
-    for dev in /sys/class/net/* ; do
-        dev="$(basename "${dev}")"
-        if echo "${dev}" | grep -q "^lo$" ; then
-          continue
+    for mac in ${hwaddrs} ; do
+        name="$(echo "${1}" | sed -n "${_device_num}p")"
+        if [ -z "${name}" ]; then
+          break
         fi
 
-        name="$(echo "${1}" | sed -n "${_device_num}p")"
-        echo "SUBSYSTEM==\"net\", ACTION==\"add\", KERNEL==\"${dev}\", NAME=\"${name}\"" >> /etc/udev/rules.d/00-net-symlink.rules
+        echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"${mac}\", NAME=\"${name}\"" >> /etc/udev/rules.d/00-net-symlink.rules
         _device_num=$((_device_num + 1))
     done
 }


### PR DESCRIPTION
Since we don't actually attach the nics at the worker step, put their mac addresses in a user config key so we can base the udev rules on those.