### PR TITLE
Error recovery

### DIFF
--- a/cmd/migration-managerd/internal/api/api_queue.go
+++ b/cmd/migration-managerd/internal/api/api_queue.go
@@ -195,13 +195,7 @@ func queueRootGet(d *Daemon, r *http.Request) response.Response {
 					return err
 				}
 
-				result = append(result, api.QueueEntry{
-					InstanceUUID:           queueItem.InstanceUUID,
-					InstanceName:           instance.Properties.Name,
-					MigrationStatus:        queueItem.MigrationStatus,
-					MigrationStatusMessage: queueItem.MigrationStatusMessage,
-					BatchName:              queueItem.BatchName,
-				})
+				result = append(result, queueItem.ToAPI(instance.Properties.Name, d.queueHandler.LastWorkerUpdate(queueItem.InstanceUUID)))
 			}
 
 			return nil
@@ -288,13 +282,7 @@ func queueGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return response.SyncResponseETag(true, api.QueueEntry{
-		InstanceName:           instanceName,
-		InstanceUUID:           queueItem.InstanceUUID,
-		MigrationStatus:        queueItem.MigrationStatus,
-		MigrationStatusMessage: queueItem.MigrationStatusMessage,
-		BatchName:              queueItem.BatchName,
-	}, queueItem)
+	return response.SyncResponseETag(true, queueItem.ToAPI(instanceName, d.queueHandler.LastWorkerUpdate(queueItem.InstanceUUID)), queueItem)
 }
 
 // swagger:operation DELETE /1.0/queues/{name} queues queue_delete

--- a/cmd/migration-managerd/internal/api/sync.go
+++ b/cmd/migration-managerd/internal/api/sync.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -42,15 +43,32 @@ func (d *Daemon) syncActiveBatches(ctx context.Context) error {
 	importingFromSource := map[string]int{}
 	importingToTarget := map[string]int{}
 	creatingOnTarget := map[string]int{}
+	workerUpdates := map[uuid.UUID]time.Time{}
+	now := time.Now().UTC()
 	for _, state := range states {
 		for instUUID, entry := range state.QueueEntries {
-			if entry.MigrationStatus == api.MIGRATIONSTATUS_CREATING {
-				creatingOnTarget[state.Target.Name] = creatingOnTarget[state.Target.Name] + 1
-			}
+			switch entry.MigrationStatus {
+			case api.MIGRATIONSTATUS_IDLE:
+				workerUpdates[instUUID] = now
 
-			if entry.MigrationStatus == api.MIGRATIONSTATUS_FINAL_IMPORT || entry.MigrationStatus == api.MIGRATIONSTATUS_BACKGROUND_IMPORT {
+			case api.MIGRATIONSTATUS_IMPORT_COMPLETE:
+				workerUpdates[instUUID] = now
+
+			case api.MIGRATIONSTATUS_ERROR:
+				workerUpdates[instUUID] = now
+
+			case api.MIGRATIONSTATUS_BACKGROUND_IMPORT:
 				importingFromSource[state.Sources[instUUID].Name] = importingFromSource[state.Sources[instUUID].Name] + 1
 				importingToTarget[state.Target.Name] = importingToTarget[state.Target.Name] + 1
+				workerUpdates[instUUID] = now
+
+			case api.MIGRATIONSTATUS_FINAL_IMPORT:
+				importingFromSource[state.Sources[instUUID].Name] = importingFromSource[state.Sources[instUUID].Name] + 1
+				importingToTarget[state.Target.Name] = importingToTarget[state.Target.Name] + 1
+				workerUpdates[instUUID] = now
+
+			case api.MIGRATIONSTATUS_CREATING:
+				creatingOnTarget[state.Target.Name] = creatingOnTarget[state.Target.Name] + 1
 			}
 		}
 	}
@@ -68,6 +86,11 @@ func (d *Daemon) syncActiveBatches(ctx context.Context) error {
 	err = d.target.InitCreateCache(creatingOnTarget)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize target create cache: %w", err)
+	}
+
+	err = d.queueHandler.InitWorkerCache(workerUpdates)
+	if err != nil {
+		return fmt.Errorf("Failed to initialize worker update cache: %w", err)
 	}
 
 	return nil

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -438,7 +438,7 @@ func (d *Daemon) createTargetVM(ctx context.Context, b migration.Batch, inst mig
 	}
 
 	// Set the instance state to IDLE before triggering the worker.
-	_, err = d.queue.UpdateStatusByUUID(ctx, inst.UUID, api.MIGRATIONSTATUS_IDLE, string(api.MIGRATIONSTATUS_IDLE), true)
+	_, err = d.queue.UpdateStatusByUUID(ctx, inst.UUID, api.MIGRATIONSTATUS_IDLE, "Waiting for worker to connect", true)
 	if err != nil {
 		return fmt.Errorf("Failed to update instance status to %q: %w", api.MIGRATIONSTATUS_IDLE, err)
 	}

--- a/internal/migration/instance_service.go
+++ b/internal/migration/instance_service.go
@@ -85,6 +85,10 @@ func (s instanceService) GetByUUID(ctx context.Context, id uuid.UUID) (*Instance
 }
 
 func (s instanceService) GetAllQueued(ctx context.Context, queue QueueEntries) (Instances, error) {
+	if len(queue) == 0 {
+		return Instances{}, nil
+	}
+
 	uuids := make([]uuid.UUID, len(queue))
 	for i, q := range queue {
 		uuids[i] = q.InstanceUUID

--- a/internal/migration/queue_model.go
+++ b/internal/migration/queue_model.go
@@ -16,6 +16,7 @@ type QueueEntry struct {
 	SecretToken            uuid.UUID
 	MigrationStatus        api.MigrationStatusType
 	MigrationStatusMessage string
+	LastWorkerStatus       api.WorkerResponseType
 }
 
 type QueueEntries []QueueEntry

--- a/internal/migration/queue_model.go
+++ b/internal/migration/queue_model.go
@@ -1,6 +1,8 @@
 package migration
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 
 	"github.com/FuturFusion/migration-manager/shared/api"
@@ -60,4 +62,15 @@ func (q QueueEntry) Validate() error {
 	}
 
 	return nil
+}
+
+func (q QueueEntry) ToAPI(instanceName string, lastWorkerUpdate time.Time) api.QueueEntry {
+	return api.QueueEntry{
+		InstanceUUID:           q.InstanceUUID,
+		MigrationStatus:        q.MigrationStatus,
+		MigrationStatusMessage: q.MigrationStatusMessage,
+		BatchName:              q.BatchName,
+		InstanceName:           instanceName,
+		LastWorkerResponse:     lastWorkerUpdate,
+	}
 }

--- a/internal/migration/queue_service.go
+++ b/internal/migration/queue_service.go
@@ -455,11 +455,11 @@ func (s queueService) ProcessWorkerUpdate(ctx context.Context, id uuid.UUID, wor
 			case api.MIGRATIONSTATUS_BACKGROUND_IMPORT:
 				entry.NeedsDiskImport = false
 				entry.MigrationStatus = api.MIGRATIONSTATUS_IDLE
-				entry.MigrationStatusMessage = string(api.MIGRATIONSTATUS_IDLE)
+				entry.MigrationStatusMessage = "Waiting for migration window"
 
 			case api.MIGRATIONSTATUS_FINAL_IMPORT:
 				entry.MigrationStatus = api.MIGRATIONSTATUS_IMPORT_COMPLETE
-				entry.MigrationStatusMessage = string(api.MIGRATIONSTATUS_IMPORT_COMPLETE)
+				entry.MigrationStatusMessage = "Starting target instance"
 			}
 
 		case api.WORKERRESPONSE_FAILED:

--- a/internal/migration/queue_service_test.go
+++ b/internal/migration/queue_service_test.go
@@ -962,7 +962,7 @@ func TestQueueService_ProcessWorkerUpdate(t *testing.T) {
 
 			assertErr:                  require.NoError,
 			wantMigrationStatus:        api.MIGRATIONSTATUS_IDLE,
-			wantMigrationStatusMessage: "Idle",
+			wantMigrationStatusMessage: "Waiting for migration window",
 		},
 		{
 			name:                  "success - migration success final import",
@@ -978,7 +978,7 @@ func TestQueueService_ProcessWorkerUpdate(t *testing.T) {
 
 			assertErr:                  require.NoError,
 			wantMigrationStatus:        api.MIGRATIONSTATUS_IMPORT_COMPLETE,
-			wantMigrationStatusMessage: "Import tasks complete",
+			wantMigrationStatusMessage: "Starting target instance",
 		},
 		{
 			name:                  "success - migration failed",

--- a/internal/migration/repo/sqlite/entities/queue.mapper.go
+++ b/internal/migration/repo/sqlite/entities/queue.mapper.go
@@ -15,7 +15,7 @@ import (
 )
 
 var queueEntryObjects = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -23,7 +23,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByInstanceUUID = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -32,7 +32,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByBatchName = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -41,7 +41,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByMigrationStatus = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -50,7 +50,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByNeedsDiskImport = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -59,7 +59,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByBatchNameAndMigrationStatus = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -68,7 +68,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByBatchNameAndNeedsDiskImport = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -77,7 +77,7 @@ SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, qu
 `)
 
 var queueEntryObjectsByBatchNameAndMigrationStatusAndNeedsDiskImport = RegisterStmt(`
-SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message
+SELECT queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status
   FROM queue
   JOIN instances ON queue.instance_id = instances.id
   JOIN batches ON queue.batch_id = batches.id
@@ -92,13 +92,13 @@ SELECT queue.id FROM queue
 `)
 
 var queueEntryCreate = RegisterStmt(`
-INSERT INTO queue (instance_id, batch_id, needs_disk_import, secret_token, migration_status, migration_status_message)
-  VALUES ((SELECT instances.id FROM instances WHERE instances.uuid = ?), (SELECT batches.id FROM batches WHERE batches.name = ?), ?, ?, ?, ?)
+INSERT INTO queue (instance_id, batch_id, needs_disk_import, secret_token, migration_status, migration_status_message, last_worker_status)
+  VALUES ((SELECT instances.id FROM instances WHERE instances.uuid = ?), (SELECT batches.id FROM batches WHERE batches.name = ?), ?, ?, ?, ?, ?)
 `)
 
 var queueEntryUpdate = RegisterStmt(`
 UPDATE queue
-  SET instance_id = (SELECT instances.id FROM instances WHERE instances.uuid = ?), batch_id = (SELECT batches.id FROM batches WHERE batches.name = ?), needs_disk_import = ?, secret_token = ?, migration_status = ?, migration_status_message = ?
+  SET instance_id = (SELECT instances.id FROM instances WHERE instances.uuid = ?), batch_id = (SELECT batches.id FROM batches WHERE batches.name = ?), needs_disk_import = ?, secret_token = ?, migration_status = ?, migration_status_message = ?, last_worker_status = ?
  WHERE id = ?
 `)
 
@@ -164,7 +164,7 @@ func GetQueueEntry(ctx context.Context, db dbtx, instanceUUID uuid.UUID) (_ *mig
 // queueEntryColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the QueueEntry entity.
 func queueEntryColumns() string {
-	return "queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message"
+	return "queue.id, instances.uuid AS instance_uuid, batches.name AS batch_name, queue.needs_disk_import, queue.secret_token, queue.migration_status, queue.migration_status_message, queue.last_worker_status"
 }
 
 // getQueueEntries can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -173,7 +173,7 @@ func getQueueEntries(ctx context.Context, stmt *sql.Stmt, args ...any) ([]migrat
 
 	dest := func(scan func(dest ...any) error) error {
 		q := migration.QueueEntry{}
-		err := scan(&q.ID, &q.InstanceUUID, &q.BatchName, &q.NeedsDiskImport, &q.SecretToken, &q.MigrationStatus, &q.MigrationStatusMessage)
+		err := scan(&q.ID, &q.InstanceUUID, &q.BatchName, &q.NeedsDiskImport, &q.SecretToken, &q.MigrationStatus, &q.MigrationStatusMessage, &q.LastWorkerStatus)
 		if err != nil {
 			return err
 		}
@@ -197,7 +197,7 @@ func getQueueEntriesRaw(ctx context.Context, db dbtx, sql string, args ...any) (
 
 	dest := func(scan func(dest ...any) error) error {
 		q := migration.QueueEntry{}
-		err := scan(&q.ID, &q.InstanceUUID, &q.BatchName, &q.NeedsDiskImport, &q.SecretToken, &q.MigrationStatus, &q.MigrationStatusMessage)
+		err := scan(&q.ID, &q.InstanceUUID, &q.BatchName, &q.NeedsDiskImport, &q.SecretToken, &q.MigrationStatus, &q.MigrationStatusMessage, &q.LastWorkerStatus)
 		if err != nil {
 			return err
 		}
@@ -437,7 +437,7 @@ func CreateQueueEntry(ctx context.Context, db dbtx, object migration.QueueEntry)
 		_err = mapErr(_err, "Queue_entry")
 	}()
 
-	args := make([]any, 6)
+	args := make([]any, 7)
 
 	// Populate the statement arguments.
 	args[0] = object.InstanceUUID
@@ -446,6 +446,7 @@ func CreateQueueEntry(ctx context.Context, db dbtx, object migration.QueueEntry)
 	args[3] = object.SecretToken
 	args[4] = object.MigrationStatus
 	args[5] = object.MigrationStatusMessage
+	args[6] = object.LastWorkerStatus
 
 	// Prepared statement to use.
 	stmt, err := Stmt(db, queueEntryCreate)
@@ -491,7 +492,7 @@ func UpdateQueueEntry(ctx context.Context, db tx, instanceUUID uuid.UUID, object
 		return fmt.Errorf("Failed to get \"queueEntryUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.InstanceUUID, object.BatchName, object.NeedsDiskImport, object.SecretToken, object.MigrationStatus, object.MigrationStatusMessage, id)
+	result, err := stmt.Exec(object.InstanceUUID, object.BatchName, object.NeedsDiskImport, object.SecretToken, object.MigrationStatus, object.MigrationStatusMessage, object.LastWorkerStatus, id)
 	if err != nil {
 		return fmt.Errorf("Update \"queue\" entry failed: %w", err)
 	}

--- a/internal/queue/handler.go
+++ b/internal/queue/handler.go
@@ -53,6 +53,10 @@ type MigrationState struct {
 	Sources      map[uuid.UUID]migration.Source
 }
 
+func (s *Handler) InitWorkerCache(initial map[uuid.UUID]time.Time) error {
+	return s.workerUpdateCache.Replace(initial)
+}
+
 // RecordWorkerUpdate caches the last worker update that the corresponding instance has received.
 func (s *Handler) RecordWorkerUpdate(instanceUUID uuid.UUID) {
 	s.workerUpdateCache.Write(instanceUUID, time.Now().UTC(), nil)

--- a/internal/queue/handler.go
+++ b/internal/queue/handler.go
@@ -3,11 +3,9 @@ package queue
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
-	incusAPI "github.com/lxc/incus/v6/shared/api"
 
 	"github.com/FuturFusion/migration-manager/internal/migration"
 	"github.com/FuturFusion/migration-manager/internal/transaction"
@@ -60,20 +58,9 @@ func (s *Handler) RecordWorkerUpdate(instanceUUID uuid.UUID) {
 	s.workerUpdateCache.Write(instanceUUID, time.Now().UTC(), nil)
 }
 
-// ReceivedWorkerUpdate returns the last worker update that the corresponding instance received, if that update is within
-// the given threshold from now.
-// If no worker update is found for this instance, it returns a 404.
-func (s *Handler) ReceivedWorkerUpdate(instanceUUID uuid.UUID, threshold time.Duration) (time.Time, error) {
-	lastUpdate, ok := s.workerUpdateCache.Read(instanceUUID)
-	if !ok {
-		return time.Time{}, incusAPI.StatusErrorf(http.StatusNotFound, "No worker found for instance with UUID %q", instanceUUID)
-	}
-
-	if lastUpdate.Add(threshold).Before(time.Now().UTC()) {
-		return time.Time{}, fmt.Errorf("No worker update received in %q for instance with UUID %q", threshold.String(), instanceUUID)
-	}
-
-	return lastUpdate, nil
+func (s *Handler) LastWorkerUpdate(instanceUUID uuid.UUID) time.Time {
+	lastUpdate, _ := s.workerUpdateCache.Read(instanceUUID)
+	return lastUpdate
 }
 
 // RemoveFromCache removes the given instanceUUID from the worker cache.

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -415,6 +415,31 @@ func (s *InternalVMwareSource) DeleteVMSnapshot(ctx context.Context, vmName stri
 	return nil
 }
 
+func (s *InternalVMwareSource) PowerOnVM(ctx context.Context, vmLocation string) error {
+	vm, err := s.getVM(ctx, vmLocation)
+	if err != nil {
+		return err
+	}
+
+	// Get the VM's current power state.
+	state, err := vm.PowerState(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Don't do anything if the VM is already powered off.
+	if state == types.VirtualMachinePowerStatePoweredOn {
+		return nil
+	}
+
+	task, err := vm.PowerOn(ctx)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}
+
 func (s *InternalVMwareSource) PowerOffVM(ctx context.Context, vmName string) error {
 	vm, err := s.getVM(ctx, vmName)
 	if err != nil {

--- a/shared/api/queue.go
+++ b/shared/api/queue.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -62,4 +63,7 @@ type QueueEntry struct {
 	// A human-friendly name for the batch
 	// Example: MyBatch
 	BatchName string `json:"batch_name" yaml:"batch_name"`
+
+	// Time in UTC that the queue entry received a response from the migration worker
+	LastWorkerResponse time.Time
 }


### PR DESCRIPTION
* Daemon will now instruct the worker to restart imports if the worker crashes for some reason. This is accomplished by storing the last response we received from the worker and using that to judge what state it's in.

* Rather than showing an ominous "timed out waiting for worker" message if the worker takes a long time to respond, the raw timestamp of the last worker response is now part of the queue entry API object, so UI/CLI can handle it directly

* Adds more descriptive migration status messages

* If we encounter an error after powering off the source VM, we now try to start it back up


