### PR TITLE
Misc fixes

### DIFF
--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -444,6 +444,9 @@ func (d *Daemon) createTargetVM(ctx context.Context, b migration.Batch, inst mig
 		return fmt.Errorf("Failed to start instance %q on target %q: %w", instanceDef.Name, it.GetName(), err)
 	}
 
+	// Unblock the concurrency limits for the target so that the Incus agent doesn't block other creations.
+	d.target.RemoveCreation(t.Name)
+
 	// Wait up to 90s for the Incus agent.
 	waitCtx, cancel := context.WithTimeout(ctx, time.Second*90)
 	defer cancel()
@@ -460,7 +463,6 @@ func (d *Daemon) createTargetVM(ctx context.Context, b migration.Batch, inst mig
 
 	// Now that the VM agent is up, expect a worker update to come soon..
 	d.queueHandler.RecordWorkerUpdate(inst.UUID)
-	d.target.RemoveCreation(t.Name)
 
 	reverter.Success()
 

--- a/internal/migratekit/vmware/change_id.go
+++ b/internal/migratekit/vmware/change_id.go
@@ -68,22 +68,46 @@ func IsSupportedDisk(disk *types.VirtualDisk) (string, error) {
 	// Ignore raw disks or disks that are excluded from snapshots.
 	switch t := disk.GetVirtualDevice().Backing.(type) {
 	case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, fmt.Errorf("Raw disk cannot be migrated")
 	case *types.VirtualDiskRawDiskVer2BackingInfo:
 		return t.DeviceName, fmt.Errorf("Raw disk cannot be migrated")
 	case *types.VirtualDiskPartitionedRawDiskVer2BackingInfo:
 		return t.DeviceName, fmt.Errorf("Raw disk cannot be migrated")
 	case *types.VirtualDiskFlatVer2BackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, isSupported(t.DiskMode, t.Sharing)
 	case *types.VirtualDiskFlatVer1BackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, isSupported(t.DiskMode, "")
 	case *types.VirtualDiskLocalPMemBackingInfo:
 		return t.FileName, isSupported(t.DiskMode, "")
 	case *types.VirtualDiskSeSparseBackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, isSupported(t.DiskMode, "")
 	case *types.VirtualDiskSparseVer1BackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, isSupported(t.DiskMode, "")
 	case *types.VirtualDiskSparseVer2BackingInfo:
+		for t.Parent != nil {
+			t = t.Parent
+		}
+
 		return t.FileName, isSupported(t.DiskMode, "")
 	default:
 		return "unknown", fmt.Errorf("Unknown disk type %T", t)

--- a/internal/source/properties_test.go
+++ b/internal/source/properties_test.go
@@ -411,7 +411,9 @@ func TestGetProperties(t *testing.T) {
 					Sharing:                      c.expectedDiskShared,
 				}
 			} else {
-				backing = &types.VirtualDeviceFileBackingInfo{FileName: c.expectedDiskName}
+				backing = &types.VirtualDiskFlatVer1BackingInfo{
+					VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{FileName: c.expectedDiskName},
+				}
 			}
 
 			vmProps.Config.Hardware.Device = append(vmProps.Config.Hardware.Device,

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -693,6 +693,12 @@ func (s *InternalVMwareSource) getVMProperties(vm *object.VirtualMachine, vmProp
 					return nil, fmt.Errorf("Failed to get %q properties: %w", defName.String(), err)
 				}
 
+				// Get the base disk name in case it has a snapshot suffix.
+				err = subProps.Add(properties.InstanceDiskName, diskName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to set disk name property to %q: %w", diskName, err)
+				}
+
 				err = props.Add(defName, *subProps)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to apply %q properties: %w", defName.String(), err)


### PR DESCRIPTION
* Fixes issue with base NSX network info from an instance in an unused source from overwriting the NSX manager data that was retrieved in an earlier sync before the NSX network was locked by an instance in that network from a different source being part of a batch.

* Fully traverses disk parents to hopefully eliminate issues with disk name variability due to snapshots, and also uses the same helper to determine the disk name everywhere.

* Dequeue the concurrent creations as soon as the VM is started, rather than after the Incus agent starts

* Properly set Finished state on batches