### PR TITLE
Add batch start time and max retries

### DIFF
--- a/cmd/migration-manager/internal/cmds/batch.go
+++ b/cmd/migration-manager/internal/cmds/batch.go
@@ -138,6 +138,13 @@ func (c *cmdBatchAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	retries, err := c.global.Asker.AskInt("Maximum retries if post-migration steps are not successful: ", 0, 1024, "5", nil)
+	if err != nil {
+		return err
+	}
+
+	b.PostMigrationRetries = int(retries)
+
 	addWindows := true
 	for addWindows {
 		windowStart, err := c.global.Asker.AskString("Migration window start (YYYY-MM-DD HH:MM:SS) (empty to skip): ", "", func(s string) error {
@@ -621,6 +628,13 @@ func (c *cmdBatchUpdate) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	retries, err := c.global.Asker.AskInt("Maximum retries if post-migration steps are not successful: ", 0, 1024, strconv.Itoa(b.PostMigrationRetries), nil)
+	if err != nil {
+		return err
+	}
+
+	b.PostMigrationRetries = int(retries)
 
 	addWindows, err := c.global.Asker.AskBool("Replace migration windows? (yes/no) [default=no]: ", "no")
 	if err != nil {

--- a/cmd/migration-managerd/internal/api/api_batch.go
+++ b/cmd/migration-managerd/internal/api/api_batch.go
@@ -497,6 +497,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 		StoragePool:       batch.StoragePool,
 		IncludeExpression: batch.IncludeExpression,
 		Constraints:       constraints,
+		StartDate:         batch.StartDate,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating batch %q: %w", batch.Name, err))

--- a/cmd/migration-managerd/internal/api/api_batch.go
+++ b/cmd/migration-managerd/internal/api/api_batch.go
@@ -247,14 +247,15 @@ func batchesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	batch := migration.Batch{
-		Name:              apiBatch.Name,
-		Target:            apiBatch.Target,
-		TargetProject:     apiBatch.TargetProject,
-		Status:            api.BATCHSTATUS_DEFINED,
-		StatusMessage:     string(api.BATCHSTATUS_DEFINED),
-		StoragePool:       apiBatch.StoragePool,
-		IncludeExpression: apiBatch.IncludeExpression,
-		Constraints:       constraints,
+		Name:                 apiBatch.Name,
+		Target:               apiBatch.Target,
+		TargetProject:        apiBatch.TargetProject,
+		Status:               api.BATCHSTATUS_DEFINED,
+		StatusMessage:        string(api.BATCHSTATUS_DEFINED),
+		StoragePool:          apiBatch.StoragePool,
+		IncludeExpression:    apiBatch.IncludeExpression,
+		PostMigrationRetries: apiBatch.PostMigrationRetries,
+		Constraints:          constraints,
 	}
 
 	_, err = d.batch.Create(ctx, batch)
@@ -488,16 +489,17 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = d.batch.Update(ctx, name, &migration.Batch{
-		ID:                currentBatch.ID,
-		Name:              batch.Name,
-		Target:            batch.Target,
-		TargetProject:     batch.TargetProject,
-		Status:            currentBatch.Status,
-		StatusMessage:     currentBatch.StatusMessage,
-		StoragePool:       batch.StoragePool,
-		IncludeExpression: batch.IncludeExpression,
-		Constraints:       constraints,
-		StartDate:         batch.StartDate,
+		ID:                   currentBatch.ID,
+		Name:                 batch.Name,
+		Target:               batch.Target,
+		TargetProject:        batch.TargetProject,
+		Status:               currentBatch.Status,
+		StatusMessage:        currentBatch.StatusMessage,
+		StoragePool:          batch.StoragePool,
+		IncludeExpression:    batch.IncludeExpression,
+		Constraints:          constraints,
+		StartDate:            batch.StartDate,
+		PostMigrationRetries: batch.PostMigrationRetries,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating batch %q: %w", batch.Name, err))

--- a/cmd/migration-managerd/internal/api/daemon.go
+++ b/cmd/migration-managerd/internal/api/daemon.go
@@ -305,7 +305,7 @@ func (d *Daemon) Start() error {
 	d.runPeriodicTask(d.ShutdownCtx, "trySyncAllSources", d.trySyncAllSources, 10*time.Minute)
 	d.runPeriodicTask(d.ShutdownCtx, "beginImports", func(ctx context.Context) error {
 		// Cleanup of instances is set to false for testing. In practice we should set it to true, so that we can retry creating VMs in case it fails.
-		return d.beginImports(ctx, false)
+		return d.beginImports(ctx, !util.InTestingMode())
 	}, 10*time.Second)
 
 	d.runPeriodicTask(d.ShutdownCtx, "finalizeCompleteInstances", d.finalizeCompleteInstances, 10*time.Second)

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -113,6 +113,34 @@ var updates = map[int]schema.Update{
 	6: updateFromV5,
 	7: updateFromV6,
 	8: updateFromV7,
+	9: updateFromV8,
+}
+
+func updateFromV8(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE batches_new (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name                   TEXT NOT NULL,
+    target_id              INTEGER NOT NULL,
+    target_project         TEXT NOT NULL,
+    status                 TEXT NOT NULL,
+    status_message         TEXT NOT NULL,
+    storage_pool           TEXT NOT NULL,
+    include_expression     TEXT NOT NULL,
+    constraints            TEXT NOT NULL,
+    start_date             DATETIME NOT NULL,
+    post_migration_retries INTEGER NOT NULL,
+    UNIQUE (name),
+    FOREIGN KEY(target_id) REFERENCES targets(id)
+);
+
+INSERT INTO batches_new (id, name, target_id, target_project, status, status_message, storage_pool, include_expression, constraints, start_date, post_migration_retries) SELECT id, name, target_id, target_project, status, status_message, storage_pool, include_expression, constraints, ?, 0 FROM batches;
+
+DROP TABLE batches;
+ALTER TABLE batches_new RENAME TO batches;
+`, time.Time{})
+
+	return err
 }
 
 func updateFromV7(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -10,15 +10,16 @@ import (
 )
 
 type Batch struct {
-	ID                int64
-	Name              string `db:"primary=yes"`
-	Target            string `db:"join=targets.name"`
-	TargetProject     string
-	Status            api.BatchStatusType
-	StatusMessage     string
-	StoragePool       string
-	IncludeExpression string
-	StartDate         time.Time
+	ID                   int64
+	Name                 string `db:"primary=yes"`
+	Target               string `db:"join=targets.name"`
+	TargetProject        string
+	Status               api.BatchStatusType
+	StatusMessage        string
+	StoragePool          string
+	IncludeExpression    string
+	StartDate            time.Time
+	PostMigrationRetries int
 
 	Constraints []BatchConstraint `db:"marshal=json"`
 }
@@ -71,6 +72,10 @@ func (b Batch) Validate() error {
 	_, err = InstanceFilterable{}.CompileIncludeExpression(b.IncludeExpression)
 	if err != nil {
 		return NewValidationErrf("Invalid batch %q is not a valid include expression: %v", b.IncludeExpression, err)
+	}
+
+	if b.PostMigrationRetries < 0 {
+		return NewValidationErrf("Invalid batch, post-migration retry count (%d) must be larger than 0", b.PostMigrationRetries)
 	}
 
 	for _, c := range b.Constraints {
@@ -250,14 +255,15 @@ func (b Batch) ToAPI(windows MigrationWindows) api.Batch {
 
 	return api.Batch{
 		BatchPut: api.BatchPut{
-			Name:              b.Name,
-			Target:            b.Target,
-			TargetProject:     b.TargetProject,
-			StoragePool:       b.StoragePool,
-			IncludeExpression: b.IncludeExpression,
-			MigrationWindows:  apiWindows,
-			Constraints:       constraints,
-			StartDate:         b.StartDate,
+			Name:                 b.Name,
+			Target:               b.Target,
+			TargetProject:        b.TargetProject,
+			StoragePool:          b.StoragePool,
+			IncludeExpression:    b.IncludeExpression,
+			MigrationWindows:     apiWindows,
+			Constraints:          constraints,
+			StartDate:            b.StartDate,
+			PostMigrationRetries: b.PostMigrationRetries,
 		},
 		Status:        b.Status,
 		StatusMessage: b.StatusMessage,

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -18,6 +18,7 @@ type Batch struct {
 	StatusMessage     string
 	StoragePool       string
 	IncludeExpression string
+	StartDate         time.Time
 
 	Constraints []BatchConstraint `db:"marshal=json"`
 }
@@ -77,6 +78,10 @@ func (b Batch) Validate() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if b.Status == api.BATCHSTATUS_DEFINED && !b.StartDate.IsZero() {
+		return NewValidationErrf("Cannot set start time before batch %q has started", b.Name)
 	}
 
 	return nil
@@ -252,6 +257,7 @@ func (b Batch) ToAPI(windows MigrationWindows) api.Batch {
 			IncludeExpression: b.IncludeExpression,
 			MigrationWindows:  apiWindows,
 			Constraints:       constraints,
+			StartDate:         b.StartDate,
 		},
 		Status:        b.Status,
 		StatusMessage: b.StatusMessage,

--- a/internal/migration/batch_service.go
+++ b/internal/migration/batch_service.go
@@ -255,6 +255,7 @@ func (s batchService) StartBatchByName(ctx context.Context, name string) (err er
 			return fmt.Errorf("Cannot start batch %q in its current state '%s': %w", batch.Name, batch.Status, ErrOperationNotPermitted)
 		}
 
+		batch.StartDate = time.Now().UTC()
 		batch.Status = api.BATCHSTATUS_QUEUED
 		batch.StatusMessage = string(batch.Status)
 		return s.repo.Update(ctx, batch.Name, *batch)

--- a/internal/migration/instance_ports.go
+++ b/internal/migration/instance_ports.go
@@ -25,6 +25,9 @@ type InstanceService interface {
 	DeleteByUUID(ctx context.Context, id uuid.UUID) error
 
 	RemoveFromQueue(ctx context.Context, id uuid.UUID) error
+
+	GetPostMigrationRetries(id uuid.UUID) int
+	RecordPostMigrationRetry(id uuid.UUID)
 }
 
 //go:generate go run github.com/matryer/moq -fmt goimports -pkg mock -out repo/mock/instance_repo_mock_gen.go -rm . InstanceRepo

--- a/internal/migration/instance_service_mock_gen_test.go
+++ b/internal/migration/instance_service_mock_gen_test.go
@@ -54,6 +54,12 @@ var _ migration.InstanceService = &InstanceServiceMock{}
 //			GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (*migration.Instance, error) {
 //				panic("mock out the GetByUUID method")
 //			},
+//			GetPostMigrationRetriesFunc: func(id uuid.UUID) int {
+//				panic("mock out the GetPostMigrationRetries method")
+//			},
+//			RecordPostMigrationRetryFunc: func(id uuid.UUID)  {
+//				panic("mock out the RecordPostMigrationRetry method")
+//			},
 //			RemoveFromQueueFunc: func(ctx context.Context, id uuid.UUID) error {
 //				panic("mock out the RemoveFromQueue method")
 //			},
@@ -99,6 +105,12 @@ type InstanceServiceMock struct {
 
 	// GetByUUIDFunc mocks the GetByUUID method.
 	GetByUUIDFunc func(ctx context.Context, id uuid.UUID) (*migration.Instance, error)
+
+	// GetPostMigrationRetriesFunc mocks the GetPostMigrationRetries method.
+	GetPostMigrationRetriesFunc func(id uuid.UUID) int
+
+	// RecordPostMigrationRetryFunc mocks the RecordPostMigrationRetry method.
+	RecordPostMigrationRetryFunc func(id uuid.UUID)
 
 	// RemoveFromQueueFunc mocks the RemoveFromQueue method.
 	RemoveFromQueueFunc func(ctx context.Context, id uuid.UUID) error
@@ -179,6 +191,16 @@ type InstanceServiceMock struct {
 			// ID is the id argument value.
 			ID uuid.UUID
 		}
+		// GetPostMigrationRetries holds details about calls to the GetPostMigrationRetries method.
+		GetPostMigrationRetries []struct {
+			// ID is the id argument value.
+			ID uuid.UUID
+		}
+		// RecordPostMigrationRetry holds details about calls to the RecordPostMigrationRetry method.
+		RecordPostMigrationRetry []struct {
+			// ID is the id argument value.
+			ID uuid.UUID
+		}
 		// RemoveFromQueue holds details about calls to the RemoveFromQueue method.
 		RemoveFromQueue []struct {
 			// Ctx is the ctx argument value.
@@ -194,19 +216,21 @@ type InstanceServiceMock struct {
 			Instance *migration.Instance
 		}
 	}
-	lockCreate              sync.RWMutex
-	lockDeleteByUUID        sync.RWMutex
-	lockGetAll              sync.RWMutex
-	lockGetAllByBatch       sync.RWMutex
-	lockGetAllBySource      sync.RWMutex
-	lockGetAllQueued        sync.RWMutex
-	lockGetAllUUIDs         sync.RWMutex
-	lockGetAllUUIDsBySource sync.RWMutex
-	lockGetAllUnassigned    sync.RWMutex
-	lockGetBatchesByUUID    sync.RWMutex
-	lockGetByUUID           sync.RWMutex
-	lockRemoveFromQueue     sync.RWMutex
-	lockUpdate              sync.RWMutex
+	lockCreate                   sync.RWMutex
+	lockDeleteByUUID             sync.RWMutex
+	lockGetAll                   sync.RWMutex
+	lockGetAllByBatch            sync.RWMutex
+	lockGetAllBySource           sync.RWMutex
+	lockGetAllQueued             sync.RWMutex
+	lockGetAllUUIDs              sync.RWMutex
+	lockGetAllUUIDsBySource      sync.RWMutex
+	lockGetAllUnassigned         sync.RWMutex
+	lockGetBatchesByUUID         sync.RWMutex
+	lockGetByUUID                sync.RWMutex
+	lockGetPostMigrationRetries  sync.RWMutex
+	lockRecordPostMigrationRetry sync.RWMutex
+	lockRemoveFromQueue          sync.RWMutex
+	lockUpdate                   sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -590,6 +614,70 @@ func (mock *InstanceServiceMock) GetByUUIDCalls() []struct {
 	mock.lockGetByUUID.RLock()
 	calls = mock.calls.GetByUUID
 	mock.lockGetByUUID.RUnlock()
+	return calls
+}
+
+// GetPostMigrationRetries calls GetPostMigrationRetriesFunc.
+func (mock *InstanceServiceMock) GetPostMigrationRetries(id uuid.UUID) int {
+	if mock.GetPostMigrationRetriesFunc == nil {
+		panic("InstanceServiceMock.GetPostMigrationRetriesFunc: method is nil but InstanceService.GetPostMigrationRetries was just called")
+	}
+	callInfo := struct {
+		ID uuid.UUID
+	}{
+		ID: id,
+	}
+	mock.lockGetPostMigrationRetries.Lock()
+	mock.calls.GetPostMigrationRetries = append(mock.calls.GetPostMigrationRetries, callInfo)
+	mock.lockGetPostMigrationRetries.Unlock()
+	return mock.GetPostMigrationRetriesFunc(id)
+}
+
+// GetPostMigrationRetriesCalls gets all the calls that were made to GetPostMigrationRetries.
+// Check the length with:
+//
+//	len(mockedInstanceService.GetPostMigrationRetriesCalls())
+func (mock *InstanceServiceMock) GetPostMigrationRetriesCalls() []struct {
+	ID uuid.UUID
+} {
+	var calls []struct {
+		ID uuid.UUID
+	}
+	mock.lockGetPostMigrationRetries.RLock()
+	calls = mock.calls.GetPostMigrationRetries
+	mock.lockGetPostMigrationRetries.RUnlock()
+	return calls
+}
+
+// RecordPostMigrationRetry calls RecordPostMigrationRetryFunc.
+func (mock *InstanceServiceMock) RecordPostMigrationRetry(id uuid.UUID) {
+	if mock.RecordPostMigrationRetryFunc == nil {
+		panic("InstanceServiceMock.RecordPostMigrationRetryFunc: method is nil but InstanceService.RecordPostMigrationRetry was just called")
+	}
+	callInfo := struct {
+		ID uuid.UUID
+	}{
+		ID: id,
+	}
+	mock.lockRecordPostMigrationRetry.Lock()
+	mock.calls.RecordPostMigrationRetry = append(mock.calls.RecordPostMigrationRetry, callInfo)
+	mock.lockRecordPostMigrationRetry.Unlock()
+	mock.RecordPostMigrationRetryFunc(id)
+}
+
+// RecordPostMigrationRetryCalls gets all the calls that were made to RecordPostMigrationRetry.
+// Check the length with:
+//
+//	len(mockedInstanceService.RecordPostMigrationRetryCalls())
+func (mock *InstanceServiceMock) RecordPostMigrationRetryCalls() []struct {
+	ID uuid.UUID
+} {
+	var calls []struct {
+		ID uuid.UUID
+	}
+	mock.lockRecordPostMigrationRetry.RLock()
+	calls = mock.calls.RecordPostMigrationRetry
+	mock.lockRecordPostMigrationRetry.RUnlock()
 	return calls
 }
 

--- a/shared/api/batch.go
+++ b/shared/api/batch.go
@@ -72,6 +72,10 @@ type BatchPut struct {
 	// Example: GetInventoryPath() matches "^foobar/.*"
 	IncludeExpression string `json:"include_expression" yaml:"include_expression"`
 
+	// PostMigrationRetries is the maximum number of times post-migration steps will be retried upon errors.
+	// Example: 5
+	PostMigrationRetries int `json:"post_migration_retries" yaml:"post_migration_retries"`
+
 	// Set of migration window timings.
 	MigrationWindows []MigrationWindow `json:"migration_windows" yaml:"migration_windows"`
 

--- a/shared/api/batch.go
+++ b/shared/api/batch.go
@@ -77,6 +77,9 @@ type BatchPut struct {
 
 	// Set of constraints to apply to the batch.
 	Constraints []BatchConstraint `json:"constraints" yaml:"constraints"`
+
+	// Time in UTC when the batch was started.
+	StartDate time.Time `json:"start_date" yaml:"start_date"`
 }
 
 // MigrationWindow defines the scheduling of a batch migration.


### PR DESCRIPTION
* Time that the batch initially started is now recorded in the database

* Maximum retry count is added to batches, defaults to 5 in the CLI. If post-migration steps fail for any instance for any reason, it will be retried in 10s (when the next post-migration periodic task runs). After this many retries, the instance will be set to errored, and the source VM will be restarted.

* For testing, we had disabled instance cleanup on initial creation errors. Now this is tied to the `MIGRATION_MANAGER_TESTING` environment variable. If it is set, then instances will not be cleaned up and the first error will cause migration to stop. Otherwise, instances and volumes created on the target will be cleaned up, and creation will be tried again.