### PR TITLE
Change default instance restriction handling

### DIFF
--- a/cmd/migration-manager/internal/cmds/instance_override.go
+++ b/cmd/migration-manager/internal/cmds/instance_override.go
@@ -137,8 +137,8 @@ func (c *cmdInstanceOverrideShow) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the table.
-	header := []string{"Last Update", "Comment", "Migration Disabled", "Num vCPUs", "Memory"}
-	data := [][]string{{override.LastUpdate.String(), override.Comment, strconv.FormatBool(override.DisableMigration), numCPUSDisplay, memoryDisplay}}
+	header := []string{"Last Update", "Comment", "Migration Disabled", "Ignore Restrictions", "Num vCPUs", "Memory"}
+	data := [][]string{{override.LastUpdate.String(), override.Comment, strconv.FormatBool(override.DisableMigration), strconv.FormatBool(override.IgnoreRestrictions), numCPUSDisplay, memoryDisplay}}
 
 	sort.Sort(util.SortColumnsNaturally(data))
 
@@ -205,6 +205,16 @@ func (c *cmdInstanceOverrideUpdate) Run(cmd *cobra.Command, args []string) error
 	}
 
 	override.DisableMigration, err = c.global.Asker.AskBool("Disable migration of this instance? (yes/no) [default="+disableMigration+"]: ", disableMigration)
+	if err != nil {
+		return err
+	}
+
+	ignoreRestrictions := "no"
+	if override.IgnoreRestrictions {
+		ignoreRestrictions = "yes"
+	}
+
+	override.IgnoreRestrictions, err = c.global.Asker.AskBool("Ignore restrictions for this instance (yes/no) [default="+ignoreRestrictions+"]: ", ignoreRestrictions)
 	if err != nil {
 		return err
 	}

--- a/internal/migration/instance_service.go
+++ b/internal/migration/instance_service.go
@@ -113,7 +113,8 @@ func (s instanceService) Update(ctx context.Context, instance *Instance) error {
 			return err
 		}
 
-		if !oldInstance.Overrides.DisableMigration {
+		// If the old instance could be migrated, make sure its not in a locked batch before changing, unless to disable migration manually.
+		if oldInstance.DisabledReason() == nil {
 			batches, err := s.repo.GetBatchesByUUID(ctx, instance.UUID)
 			if err != nil {
 				return err
@@ -153,7 +154,7 @@ func (s instanceService) DeleteByUUID(ctx context.Context, id uuid.UUID) error {
 			return err
 		}
 
-		if !oldInstance.Overrides.DisableMigration {
+		if oldInstance.DisabledReason() == nil {
 			batches, err := s.repo.GetBatchesByUUID(ctx, id)
 			if err != nil {
 				return err

--- a/internal/migration/instance_service_test.go
+++ b/internal/migration/instance_service_test.go
@@ -391,13 +391,13 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "success",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -408,14 +408,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "success - can edit if in a batch, but already disabled",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{DisableMigration: true, Comment: "edited instance"},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{DisableMigration: true},
 
 				Source: "one",
@@ -428,14 +428,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "success - can edit and enable if in a running batch, but already disabled",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{Comment: "edited instance"},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{DisableMigration: true},
 
 				Source: "one",
@@ -448,14 +448,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "success - can only disable if in non-running batches",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{DisableMigration: true},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -467,14 +467,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - cannot edit if in a running batch",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{Comment: "edited instance"},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -486,14 +486,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - cannot edit if in a non-running batch",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{Comment: "edited instance"},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -505,7 +505,7 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - invalid UUID",
 			instance: migration.Instance{
 				UUID:       uuid.Nil, // invalid
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -532,7 +532,7 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - invalid source",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "",
 			},
@@ -546,7 +546,7 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - repo.GetByUUID",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -558,13 +558,13 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - already assigned to batch",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -581,14 +581,14 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - can't disable, already assigned to running batch",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 				Overrides:  api.InstanceOverride{DisableMigration: true},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -604,13 +604,13 @@ func TestInstanceService_Update(t *testing.T) {
 			name: "error - repo.Update",
 			instance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
 			repoGetByUUIDInstance: migration.Instance{
 				UUID:       uuidA,
-				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path"},
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 
 				Source: "one",
 			},
@@ -693,7 +693,8 @@ func TestInstanceService_DeleteByUUID(t *testing.T) {
 			name:    "error - batch ID set, not modifiable",
 			uuidArg: uuidA,
 			repoGetByUUIDInstance: migration.Instance{
-				UUID: uuidA,
+				UUID:       uuidA,
+				Properties: api.InstanceProperties{Location: "/inventory/path", Name: "path", OS: "os", OSVersion: "os_version", BackgroundImport: true},
 			},
 			instanceSvcGetBatchesByUUID: migration.Batches{{}},
 

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -285,18 +285,6 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 			Properties:           *vmProps,
 		}
 
-		// Disqualify instances from migration if they don't meet optimal criteria.
-		if !inst.Properties.BackgroundImport {
-			inst.Overrides.DisableMigration = true
-		} else {
-			for _, d := range inst.Properties.Disks {
-				if !d.Supported {
-					inst.Overrides.DisableMigration = true
-					break
-				}
-			}
-		}
-
 		ret = append(ret, inst)
 	}
 

--- a/shared/api/instance_override.go
+++ b/shared/api/instance_override.go
@@ -20,5 +20,9 @@ type InstanceOverride struct {
 	// Example: true
 	DisableMigration bool `json:"disable_migration" yaml:"disable_migration"`
 
+	// If true, restrictions that put the VM in a blocked state, preventing migration, will be ignored.
+	// Example: true
+	IgnoreRestrictions bool `json:"ignore_restrictions" yaml:"ignore_restrictions"`
+
 	Properties InstancePropertiesConfigurable `json:"properties" yaml:"properties"`
 }


### PR DESCRIPTION
Before, we used to set `DisableMigration` if we deemed an instance unfit for migration by default, but this can cause issues if a re-sync fixes those issues, causing us to lose context of who actually set `DisableMigration`.

Instead, all the reasons that an instance can be omitted from migration are now handled by the `DisabledReason` method. 

If a user wants to ignore these restrictions, there is now an  `IgnoreRestrictions` instance override flag.  If set to true by the user, then the instance will be considered eligible for migration regardless of any internal restrictions like unsupported disks, or lack of background import. 

`IgnoreRestrictions` will not be able to bypass `DisableMigration` if set to true, which should now only happen explicitly by the user as well.