### PR TITLE
API sorting

### DIFF
--- a/cmd/migration-managerd/internal/api/api_instance.go
+++ b/cmd/migration-managerd/internal/api/api_instance.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -167,6 +168,15 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 				result = append(result, instance.ToAPI())
 			}
 		}
+
+		// Sort the list by source, then location.
+		sort.Slice(result, func(i, j int) bool {
+			if result[i].Source == result[j].Source {
+				return result[i].Properties.Location < result[j].Properties.Location
+			}
+
+			return result[i].Source < result[j].Source
+		})
 
 		return response.SyncResponse(true, result)
 	}

--- a/cmd/migration-managerd/internal/api/api_queue.go
+++ b/cmd/migration-managerd/internal/api/api_queue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -234,6 +235,15 @@ func queueRootGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if recursion == 1 {
+		// Sort the queue list by batch, then instance name.
+		sort.Slice(result, func(i, j int) bool {
+			if result[i].BatchName == result[j].BatchName {
+				return result[i].InstanceName < result[j].InstanceName
+			}
+
+			return result[i].BatchName < result[j].BatchName
+		})
+
 		return response.SyncResponse(true, result)
 	}
 

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -17,7 +17,7 @@ type Instance struct {
 	ID   int64
 	UUID uuid.UUID `db:"primary=yes"`
 
-	Source               string         `db:"join=sources.name"`
+	Source               string         `db:"join=sources.name&order=yes"`
 	SourceType           api.SourceType `db:"join=sources.source_type&omit=create,update"`
 	LastUpdateFromSource time.Time
 

--- a/internal/migration/repo/sqlite/entities/instance.mapper.go
+++ b/internal/migration/repo/sqlite/entities/instance.mapper.go
@@ -17,7 +17,7 @@ var instanceObjects = RegisterStmt(`
 SELECT instances.id, instances.uuid, sources.name AS source, sources.source_type AS source_type, instances.last_update_from_source, instances.overrides, instances.properties
   FROM instances
   JOIN sources ON instances.source_id = sources.id
-  ORDER BY instances.uuid
+  ORDER BY sources.id
 `)
 
 var instanceObjectsByID = RegisterStmt(`
@@ -25,7 +25,7 @@ SELECT instances.id, instances.uuid, sources.name AS source, sources.source_type
   FROM instances
   JOIN sources ON instances.source_id = sources.id
   WHERE ( instances.id = ? )
-  ORDER BY instances.uuid
+  ORDER BY sources.id
 `)
 
 var instanceObjectsByUUID = RegisterStmt(`
@@ -33,7 +33,7 @@ SELECT instances.id, instances.uuid, sources.name AS source, sources.source_type
   FROM instances
   JOIN sources ON instances.source_id = sources.id
   WHERE ( instances.uuid = ? )
-  ORDER BY instances.uuid
+  ORDER BY sources.id
 `)
 
 var instanceObjectsBySource = RegisterStmt(`
@@ -41,7 +41,7 @@ SELECT instances.id, instances.uuid, sources.name AS source, sources.source_type
   FROM instances
   JOIN sources ON instances.source_id = sources.id
   WHERE ( source = ? )
-  ORDER BY instances.uuid
+  ORDER BY sources.id
 `)
 
 var instanceNames = RegisterStmt(`


### PR DESCRIPTION
Closes #286 

We can't do this at the DB level, since for instances the secondary field we want to sort on is in a json blob, and for queue entries, is not in the db at all.