### PR TITLE
Fix Incus OS Proxy

### DIFF
--- a/cmd/migration-managerd/internal/api/api.go
+++ b/cmd/migration-managerd/internal/api/api.go
@@ -109,6 +109,8 @@ func restServer(d *Daemon) *http.Server {
 		d.createCmd(router, "1.0", c)
 	}
 
+	d.createCmd(router, "os/", incusOSProxyCmd)
+
 	return &http.Server{
 		Handler:     router,
 		ConnContext: request.SaveConnectionInContext,

--- a/cmd/migration-managerd/internal/api/api_1.0.go
+++ b/cmd/migration-managerd/internal/api/api_1.0.go
@@ -19,7 +19,6 @@ var api10 = []APIEndpoint{
 	batchStartCmd,
 	batchStopCmd,
 	batchesCmd,
-	incusOSProxyCmd,
 	instanceCmd,
 	instanceOverrideCmd,
 	instancesCmd,

--- a/cmd/migration-managerd/internal/api/api_incus_os.go
+++ b/cmd/migration-managerd/internal/api/api_incus_os.go
@@ -13,8 +13,6 @@ import (
 )
 
 var incusOSProxyCmd = APIEndpoint{
-	Path: "{name:.*}",
-
 	Patch:  APIEndpointAction{Handler: apiOSProxy, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
 	Put:    APIEndpointAction{Handler: apiOSProxy, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
 	Get:    APIEndpointAction{Handler: apiOSProxy, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},


### PR DESCRIPTION
Migration Manager uses http.ServeMux which panics with wildcard paths.