### PR TITLE
Keep track of initial power state

### DIFF
--- a/cmd/migration-managerd/internal/api/sync.go
+++ b/cmd/migration-managerd/internal/api/sync.go
@@ -736,6 +736,11 @@ func syncInstancesFromSource(ctx context.Context, sourceName string, i migration
 			instanceUpdated = true
 		}
 
+		if inst.Properties.Running != srcInst.Properties.Running {
+			inst.Properties.Running = srcInst.Properties.Running
+			instanceUpdated = true
+		}
+
 		if instanceUpdated {
 			log.Info("Syncing changes to instance from source")
 			inst.LastUpdateFromSource = srcInst.LastUpdateFromSource

--- a/internal/properties/instance_properties.yaml
+++ b/internal/properties/instance_properties.yaml
@@ -153,6 +153,14 @@
               type: config
               key: image.architecture
 
+- name: running
+  description: running state of the instance
+  source:
+      vmware:
+          8.0:
+              type: property
+              key: summary.runtime.powerState
+
 - name: disks
   description: disk device
   source:

--- a/internal/properties/names.go
+++ b/internal/properties/names.go
@@ -38,6 +38,8 @@ const (
 	InstanceBackgroundImport
 	// InstanceArchitecture is the property name for the architecture of the instance.
 	InstanceArchitecture
+	// InstanceRunning is the property name for the running state of the instance.
+	InstanceRunning
 	// InstanceConfig is the property name for generic instance config.
 	InstanceConfig
 	// InstanceNICHardwareAddress is the property name for an instance nic's hardware address.
@@ -107,6 +109,8 @@ func (n Name) String() string {
 		return "snapshots"
 	case InstanceSnapshotName:
 		return "name"
+	case InstanceRunning:
+		return "running"
 	case InstanceDisks:
 		return "disks"
 	case InstanceDiskCapacity:
@@ -153,6 +157,8 @@ func ParseInstanceProperty(s string) (Name, error) {
 		return InstanceSecureBoot, nil
 	case InstanceSnapshots.String():
 		return InstanceSnapshots, nil
+	case InstanceRunning.String():
+		return InstanceRunning, nil
 	case InstanceTPM.String():
 		return InstanceTPM, nil
 	case InstanceUUID.String():
@@ -222,6 +228,7 @@ func allInstanceProperties() []Name {
 		InstanceDescription,
 		InstanceBackgroundImport,
 		InstanceArchitecture,
+		InstanceRunning,
 		InstanceConfig,
 	}
 }

--- a/internal/source/properties_test.go
+++ b/internal/source/properties_test.go
@@ -59,6 +59,7 @@ func TestGetProperties(t *testing.T) {
 		expectedMemory           int32
 		expectedTPM              bool
 		expectedSecureBoot       bool
+		expectedRunning          bool
 
 		expectedDiskName     string
 		expectedDiskShared   string
@@ -95,6 +96,37 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
+			expectedTPM:              true,
+			expectedSecureBoot:       true,
+			expectedSnapshotName:     "snap0",
+
+			numDisks:     3,
+			numNICs:      3,
+			numSnapshots: 3,
+
+			archProperty: expectedArch,
+		},
+		{
+			name:      "success - powered off",
+			expectErr: false,
+
+			expectedUUID:             expectedUUID.String(),
+			expectedLocation:         "/path/to/vm",
+			expectedDescription:      "description",
+			expectedFirmware:         string(types.GuestOsDescriptorFirmwareTypeBios),
+			expectedName:             "vm",
+			expectedBackgroundImport: true,
+			expectedGuestDetails:     "architecture='Arm' bitness='64' distroName='os' prettyName='os version'",
+			expectedCPUs:             4,
+			expectedDiskName:         "diskName.vmdk",
+			expectedDiskShared:       string(types.VirtualDiskSharingSharingMultiWriter),
+			expectedDiskCapacity:     2147483648,
+			expectedNetwork:          "network",
+			expectedNetworkID:        "network-123",
+			expectedMac:              "mac",
+			expectedMemory:           2048,
+			expectedRunning:          false,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -124,6 +156,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -153,6 +186,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -182,6 +216,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -210,6 +245,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -239,6 +275,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -268,6 +305,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -300,6 +338,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -328,6 +367,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -356,6 +396,7 @@ func TestGetProperties(t *testing.T) {
 			expectedNetworkID:        "network-123",
 			expectedMac:              "mac",
 			expectedMemory:           2048,
+			expectedRunning:          true,
 			expectedTPM:              true,
 			expectedSecureBoot:       true,
 			expectedSnapshotName:     "snap0",
@@ -371,6 +412,11 @@ func TestGetProperties(t *testing.T) {
 
 	for i, c := range cases {
 		t.Logf("Case %d: %s", i, c.name)
+
+		state := types.VirtualMachinePowerStatePoweredOff
+		if c.expectedRunning {
+			state = types.VirtualMachinePowerStatePoweredOn
+		}
 
 		vmInfo := &object.VirtualMachine{Common: object.Common{InventoryPath: c.expectedLocation}}
 		vmProps := mo.VirtualMachine{
@@ -391,6 +437,7 @@ func TestGetProperties(t *testing.T) {
 					TpmPresent:   ptr.To(c.expectedTPM),
 					InstanceUuid: c.expectedUUID,
 				},
+				Runtime: types.VirtualMachineRuntimeInfo{PowerState: state},
 			},
 			Capability: types.VirtualMachineCapability{
 				SecureBootSupported: ptr.To(c.expectedSecureBoot),
@@ -486,6 +533,7 @@ func TestGetProperties(t *testing.T) {
 			require.Equal(t, c.expectedUUID, props.UUID.String())
 			require.Equal(t, c.expectedName, props.Name)
 			require.Equal(t, c.expectedTPM, props.TPM)
+			require.Equal(t, c.expectedRunning, props.Running)
 			require.Equal(t, c.expectedFirmware == string(types.GuestOsDescriptorFirmwareTypeBios), props.LegacyBoot)
 			require.Equal(t, c.expectedBackgroundImport, props.BackgroundImport)
 			require.Equal(t, c.expectedSecureBoot, props.SecureBoot)

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -999,6 +999,13 @@ func parseValue(propName properties.Name, value any) (any, error) {
 		}
 
 		return strings.ReplaceAll(strVal, " ", "_"), nil
+	case properties.InstanceRunning:
+		strVal, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("%q value %v must be a string", propName.String(), value)
+		}
+
+		return strVal == string(types.VirtualMachinePowerStatePoweredOn), nil
 	default:
 		return value, nil
 	}

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -355,9 +355,12 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(ctx context.Context, i mi
 		return fmt.Errorf("Failed to wait for update to instance %q on target %q: %w", i.Properties.Name, t.GetName(), err)
 	}
 
-	err = t.StartVM(ctx, i.Properties.Name)
-	if err != nil {
-		return fmt.Errorf("Failed to start instance %q on target %q: %w", i.Properties.Name, t.GetName(), err)
+	// Only start the VM if it was initially running.
+	if i.Properties.Running {
+		err := t.StartVM(ctx, i.Properties.Name)
+		if err != nil {
+			return fmt.Errorf("Failed to start instance %q on target %q: %w", i.Properties.Name, t.GetName(), err)
+		}
 	}
 
 	return nil

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -753,6 +753,9 @@ func (t *InternalIncusTarget) CheckIncusAgent(ctx context.Context, instanceName 
 		if err == nil {
 			return nil
 		}
+
+		// Sleep 1s to avoid spamming the agent.
+		time.Sleep(time.Second)
 	}
 
 	// If we got here, then Exec still did not complete successfully, so return the error.

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -16,6 +16,7 @@ type InstanceProperties struct {
 	SecureBoot       bool      `json:"secure_boot"       yaml:"secure_boot"       expr:"secure_boot"`
 	LegacyBoot       bool      `json:"legacy_boot"       yaml:"legacy_boot"       expr:"legacy_boot"`
 	TPM              bool      `json:"tpm"               yaml:"tpm"               expr:"tpm"`
+	Running          bool      `json:"running"           yaml:"running"           expr:"running"`
 	BackgroundImport bool      `json:"background_import" yaml:"background_import" expr:"background_import"`
 	Architecture     string    `json:"architecture"      yaml:"architecture"      expr:"architecture"`
 


### PR DESCRIPTION
* Source VM will only be restarted if its last source sync state was running.

* Target VM will only be started upon completion if its last source sync state was running.

* Adds a 1s sleep to the incus agent ready check