### PR TITLE
internal/migration: Send 404 if all windows expired

### DIFF
--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -3,11 +3,13 @@ package migration
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	incusAPI "github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/validate"
 
 	internalAPI "github.com/FuturFusion/migration-manager/internal/api"
@@ -246,7 +248,7 @@ func (ws MigrationWindows) GetEarliest() (*MigrationWindow, error) {
 	}
 
 	if earliestWindow == nil {
-		return nil, fmt.Errorf("No valid migration window found")
+		return nil, incusAPI.StatusErrorf(http.StatusNotFound, "No valid migration window found")
 	}
 
 	return earliestWindow, nil


### PR DESCRIPTION
Fixes the 500 error when listing queue entries with expired migration windows.

This will get caught by the API and skipped, so we won't assign a migration window. 

The side-effect here is that if all migration windows have expired, queue entries will continue waiting forever. I think this is fine since in the future we plan to allow appending migration windows to running batches.