### PR TITLE
Add resource pools to VM properties

### DIFF
--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -278,6 +278,19 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 					vmProps.Config[prefix] = vmProps.Config[prefix] + "," + tag.Name
 				}
 			}
+
+			vmResourcePool, err := vm.ResourcePool(ctx)
+			if err != nil {
+				slog.Error("Failed determine resource pool for VM", slog.String("location", vm.InventoryPath), slog.String("source", s.Name), slog.Any("error", err))
+			} else {
+				poolName, err := vmResourcePool.ObjectName(ctx)
+				if err != nil {
+					slog.Error("Failed determine resource pool name for VM", slog.String("location", vm.InventoryPath), slog.String("source", s.Name), slog.Any("error", err))
+				} else {
+					resourcePoolKey := fmt.Sprintf("%s.resource_pool", s.SourceType)
+					vmProps.Config[resourcePoolKey] = poolName
+				}
+			}
 		}
 
 		inst := migration.Instance{

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -298,7 +298,15 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(ctx context.Context, i mi
 
 		// Fixup the OS name.
 		apiDef.Config[osInfo.Key] = apiDef.Config["user.migration.os"]
-		apiDef.Config["user.migration.os"] = ""
+	}
+
+	if !util.InTestingMode() {
+		// Unset user.migration keys.
+		for k := range apiDef.Config {
+			if strings.HasPrefix(k, "user.migration.") {
+				apiDef.Config[k] = ""
+			}
+		}
 	}
 
 	// Handle RHEL (and derivative) specific completion steps.


### PR DESCRIPTION
Closes #302 

Since this is highly VMware specific, the property is added as the key `vmware.resource_pool` to `properties.config`. 

It appears VM resource pools have their own full location paths: `/DC0/host/DC0_C0/Resources`. I have not supported this directly  yet, instead just appending the suffix (pool name) to the `vmware.resource_pool` key. 

My assumption for now is the datacenter will be the same as the VM, and thus can be deduced from the VM's location path anyway. It would be odd to me if you can place VMs from datacenter 1 in resource pools from datacenter 2, but I suppose we'll see if this is a possibility down the line. 

Resource pools are only supported on vcenter (not ESXI) sources, and if any errors are encountered, they will be logged and the VM will be recorded without its resource pool.