### PR TITLE
Properly set default config when no config file exists

### DIFF
--- a/cmd/migration-managerd/internal/config/config.go
+++ b/cmd/migration-managerd/internal/config/config.go
@@ -15,20 +15,20 @@ import (
 )
 
 func LoadConfig() (*api.SystemConfig, error) {
-	contents, err := os.ReadFile(util.VarPath("config.yml"))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &api.SystemConfig{}, nil
-		}
-
-		return nil, err
-	}
-
 	// Set the default port for a fresh config.
 	c := &api.SystemConfig{
 		Network: api.ConfigNetwork{
 			Port: ports.HTTPSDefaultPort,
 		},
+	}
+
+	contents, err := os.ReadFile(util.VarPath("config.yml"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return c, nil
+		}
+
+		return nil, err
 	}
 
 	err = yaml.Unmarshal(contents, c)


### PR DESCRIPTION
If the config file doesn't exist, we were returning a totally empty config which then failed the server port check at startup.