### PR TITLE
Batch instance restriction overrides

### DIFF
--- a/cmd/migration-managerd/internal/api/api_batch.go
+++ b/cmd/migration-managerd/internal/api/api_batch.go
@@ -790,7 +790,7 @@ func batchStartPost(d *Daemon, r *http.Request) response.Response {
 
 			status := api.MIGRATIONSTATUS_WAITING
 			message := "Preparing for migration"
-			err = inst.DisabledReason()
+			err = inst.DisabledReason(batch.RestrictionOverrides)
 			if err != nil {
 				status = api.MIGRATIONSTATUS_BLOCKED
 				message = err.Error()

--- a/cmd/migration-managerd/internal/api/api_batch.go
+++ b/cmd/migration-managerd/internal/api/api_batch.go
@@ -270,6 +270,7 @@ func batchesPost(d *Daemon, r *http.Request) response.Response {
 		DefaultTargetProject: apiBatch.DefaultTargetProject,
 		PostMigrationRetries: apiBatch.PostMigrationRetries,
 		Constraints:          constraints,
+		RestrictionOverrides: apiBatch.RestrictionOverrides,
 	}
 
 	_, err = d.batch.Create(ctx, batch)
@@ -528,6 +529,7 @@ func batchPut(d *Daemon, r *http.Request) response.Response {
 		DefaultStoragePool:   batch.DefaultStoragePool,
 		Constraints:          constraints,
 		PostMigrationRetries: batch.PostMigrationRetries,
+		RestrictionOverrides: batch.RestrictionOverrides,
 	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating batch %q: %w", batch.Name, err))

--- a/cmd/migration-managerd/internal/api/migration_test.go
+++ b/cmd/migration-managerd/internal/api/migration_test.go
@@ -689,7 +689,7 @@ def placement(instance, batch):
 				require.NoError(t, err)
 
 				state := api.MIGRATIONSTATUS_WAITING
-				if i.DisabledReason() != nil {
+				if i.DisabledReason(batch.RestrictionOverrides) != nil {
 					state = api.MIGRATIONSTATUS_BLOCKED
 				}
 

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -118,6 +118,35 @@ var updates = map[int]schema.Update{
 	11: updateFromV10,
 	12: updateFromV11,
 	13: updateFromV12,
+	14: updateFromV13,
+}
+
+func updateFromV13(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `CREATE TABLE batches_new (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name                   TEXT NOT NULL,
+    default_target         TEXT NOT NULL,
+    default_target_project TEXT NOT NULL,
+    status                 TEXT NOT NULL,
+    status_message         TEXT NOT NULL,
+    default_storage_pool   TEXT NOT NULL,
+    include_expression     TEXT NOT NULL,
+    constraints            TEXT NOT NULL,
+    start_date             DATETIME NOT NULL,
+    post_migration_retries INTEGER NOT NULL,
+		rerun_scriptlets       INTEGER NOT NULL,
+    placement_scriptlet    TEXT NOT NULL,
+		restriction_overrides  TEXT NOT NULL,
+    UNIQUE (name)
+);
+
+		INSERT INTO batches_new (id, name, default_target, default_target_project, status, status_message, default_storage_pool, include_expression, constraints, start_date, post_migration_retries, rerun_scriptlets, placement_scriptlet, restriction_overrides)
+		SELECT batches.id, batches.name, batches.default_target, batches.default_target_project, batches.status, batches.status_message, batches.default_storage_pool, batches.include_expression, batches.constraints, batches.start_date, batches.post_migration_retries, batches.rerun_scriptlets, batches.placement_scriptlet, '{}' FROM batches;
+DROP TABLE batches;
+ALTER TABLE batches_new RENAME TO batches;
+`)
+
+	return err
 }
 
 func updateFromV12(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -33,7 +33,8 @@ type Batch struct {
 	PlacementScriptlet string
 
 	PostMigrationRetries int
-	Constraints          []BatchConstraint `db:"marshal=json"`
+	Constraints          []BatchConstraint               `db:"marshal=json"`
+	RestrictionOverrides api.InstanceRestrictionOverride `db:"marshal=json"`
 }
 
 type BatchConstraint struct {
@@ -416,6 +417,7 @@ func (b Batch) ToAPI(windows MigrationWindows) api.Batch {
 			PostMigrationRetries: b.PostMigrationRetries,
 			RerunScriptlets:      b.RerunScriptlets,
 			PlacementScriptlet:   b.PlacementScriptlet,
+			RestrictionOverrides: b.RestrictionOverrides,
 		},
 		Status:        b.Status,
 		StatusMessage: b.StatusMessage,

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -301,7 +301,7 @@ func (s *InternalVMwareSource) GetAllVMs(ctx context.Context) (migration.Instanc
 			Properties:           *vmProps,
 		}
 
-		err = inst.DisabledReason()
+		err = inst.DisabledReason(api.InstanceRestrictionOverride{})
 		if err != nil {
 			warnings = append(warnings, migration.NewSyncWarning(api.InstanceCannotMigrate, s.Name, fmt.Sprintf("%q: %v", inst.Properties.Location, err.Error())))
 		}

--- a/shared/api/batch.go
+++ b/shared/api/batch.go
@@ -95,6 +95,9 @@ type BatchPut struct {
 
 	// Time in UTC when the batch was started.
 	StartDate time.Time `json:"start_date" yaml:"start_date"`
+
+	// Overrides to allow migrating instances that are otherwise restricted.
+	RestrictionOverrides InstanceRestrictionOverride `json:"instance_restriction_overrides" yaml:"instance_restriction_overrides"`
 }
 
 // MigrationWindow defines the scheduling of a batch migration.
@@ -125,4 +128,10 @@ type BatchConstraint struct {
 
 	// Minimum amount of time required for an instance to boot after initial disk import. Migration window duration must be at least this much.
 	MinInstanceBootTime string `json:"min_instance_boot_time" yaml:"min_instance_boot_time"`
+}
+
+type InstanceRestrictionOverride struct {
+	AllowUnknownOS          bool `json:"allow_unknown_os" yaml:"allow_unknown_os"`
+	AllowNoIPv4             bool `json:"allow_no_ipv4" yaml:"allow_no_ipv4"`
+	AllowNoBackgroundImport bool `json:"allow_no_background_import" yaml:"allow_no_background_import"`
 }


### PR DESCRIPTION

Adds a set of overrides to how we determine if an instance is restricted (migration is disabled) per batch.

* `allow_unknown_os`: In case the guest agent is missing or the OS type is otherwise unknown to migration manager
* `allow_no_ipv4`: In case the guest agent is missing, or no IPv4 address could be determined for any NIC
* `allow_no_background_import`: In case change tracking appears to be missing
