### PR TITLE
Update and reset running batches

### DIFF
--- a/cmd/migration-managerd/internal/api/api_1.0.go
+++ b/cmd/migration-managerd/internal/api/api_1.0.go
@@ -20,6 +20,7 @@ var api10 = []APIEndpoint{
 	artifactFileCmd,
 	batchCmd,
 	batchInstancesCmd,
+	batchResetCmd,
 	batchStartCmd,
 	batchStopCmd,
 	batchesCmd,

--- a/cmd/migration-managerd/internal/api/api_batch.go
+++ b/cmd/migration-managerd/internal/api/api_batch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/server/auth"
 	"github.com/FuturFusion/migration-manager/internal/server/response"
 	"github.com/FuturFusion/migration-manager/internal/server/util"
+	"github.com/FuturFusion/migration-manager/internal/target"
 	"github.com/FuturFusion/migration-manager/internal/transaction"
 	"github.com/FuturFusion/migration-manager/shared/api"
 )
@@ -51,6 +52,12 @@ var batchStopCmd = APIEndpoint{
 	Path: "batches/{name}/stop",
 
 	Post: APIEndpointAction{Handler: batchStopPost, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanDelete)},
+}
+
+var batchResetCmd = APIEndpoint{
+	Path: "batches/{name}/reset",
+
+	Post: APIEndpointAction{Handler: batchResetPost, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanDelete)},
 }
 
 // swagger:operation GET /1.0/batches batches batches_get
@@ -841,6 +848,99 @@ func batchStopPost(d *Daemon, r *http.Request) response.Response {
 	name := r.PathValue("name")
 
 	err := d.batch.StopBatchByName(r.Context(), name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, nil)
+}
+
+// swagger:operation POST /1.0/batches/{name}/reset batches batches_reset_post
+//
+//	Reset a batch
+//
+//	Resets a batch, removes all queue entries, and cleans up incomplete target VMs and volumes.
+//
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func batchResetPost(d *Daemon, r *http.Request) response.Response {
+	name := r.PathValue("name")
+	err := transaction.Do(r.Context(), func(ctx context.Context) error {
+		// Get a record of all queue entries before we wipe the records.
+		entries, err := d.queue.GetAllByBatch(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		err = d.batch.ResetBatchByName(ctx, name, d.queue, d.source, d.target)
+		if err != nil {
+			return err
+		}
+
+		// Get the list of VMs to to clean up.
+		instances, err := d.instance.GetAllQueued(ctx, entries)
+		if err != nil {
+			return err
+		}
+
+		instMap := make(map[uuid.UUID]migration.Instance, len(instances))
+		for _, inst := range instances {
+			instMap[inst.UUID] = inst
+		}
+
+		// Get the list of targets for the VMs to clean up according to the queue entry placement.
+		targets, err := d.target.GetAll(ctx)
+		if err != nil {
+			return err
+		}
+
+		targetMap := make(map[string]migration.Target, len(targets))
+		for _, t := range targets {
+			targetMap[t.Name] = t
+		}
+
+		for _, q := range entries {
+			inst := instMap[q.InstanceUUID]
+			t, ok := targetMap[q.Placement.TargetName]
+			if !ok {
+				continue
+			}
+
+			it, err := target.NewTarget(t.ToAPI())
+			if err != nil {
+				return err
+			}
+
+			err = it.Connect(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = it.SetProject(q.Placement.TargetProject)
+			if err != nil {
+				return err
+			}
+
+			// Only remove VMs with a worker volume,
+			// in case we are resetting a completed or errored batch where some VMs have already completed migration.
+			err = it.CleanupVM(ctx, inst.Properties.Name, true)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -617,7 +617,7 @@ func (d *Daemon) resetQueueEntry(ctx context.Context, instUUID uuid.UUID, state 
 		resetState = api.MIGRATIONSTATUS_WAITING
 		resetImportStage = migration.IMPORTSTAGE_BACKGROUND
 		log.Warn("Cleaning up target instance due to migration window deadline")
-		err := it.CleanupVM(timeoutCtx, state.Instances[instUUID].Properties.Name)
+		err := it.CleanupVM(timeoutCtx, state.Instances[instUUID].Properties.Name, false)
 		if err != nil {
 			return fmt.Errorf("Failed to clean up instance %q due to migration window deadline: %w", state.Instances[instUUID].Properties.Location, err)
 		}

--- a/internal/migration/batch_model.go
+++ b/internal/migration/batch_model.go
@@ -371,18 +371,6 @@ func (b Batch) HasValidWindow(windows []MigrationWindow) error {
 	return nil
 }
 
-func (b Batch) CanBeModified() bool {
-	switch b.Status {
-	case api.BATCHSTATUS_DEFINED,
-		api.BATCHSTATUS_STOPPED,
-		api.BATCHSTATUS_FINISHED,
-		api.BATCHSTATUS_ERROR:
-		return true
-	default:
-		return false
-	}
-}
-
 type Batches []Batch
 
 // ToAPI returns the API representation of a batch.

--- a/internal/migration/batch_ports.go
+++ b/internal/migration/batch_ports.go
@@ -17,7 +17,7 @@ type BatchService interface {
 	GetAllNames(ctx context.Context) ([]string, error)
 	GetAllNamesByState(ctx context.Context, status api.BatchStatusType) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Batch, error)
-	Update(ctx context.Context, name string, batch *Batch) error
+	Update(ctx context.Context, queueSvc QueueService, name string, batch *Batch) error
 	UpdateStatusByName(ctx context.Context, name string, status api.BatchStatusType, statusMessage string) (*Batch, error)
 	Rename(ctx context.Context, oldName string, newName string) error
 	DeleteByName(ctx context.Context, name string) error
@@ -26,7 +26,7 @@ type BatchService interface {
 	ResetBatchByName(ctx context.Context, name string, queueSvc QueueService, sourceSvc SourceService, targetSvc TargetService) error
 
 	AssignMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error
-	ChangeMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error
+	ChangeMigrationWindows(ctx context.Context, queueSvc QueueService, batch string, newWindows MigrationWindows) error
 
 	GetMigrationWindows(ctx context.Context, batch string) (MigrationWindows, error)
 	GetMigrationWindow(ctx context.Context, windowID int64) (*MigrationWindow, error)

--- a/internal/migration/batch_ports.go
+++ b/internal/migration/batch_ports.go
@@ -23,6 +23,7 @@ type BatchService interface {
 	DeleteByName(ctx context.Context, name string) error
 	StartBatchByName(ctx context.Context, name string) error
 	StopBatchByName(ctx context.Context, name string) error
+	ResetBatchByName(ctx context.Context, name string, queueSvc QueueService, sourceSvc SourceService, targetSvc TargetService) error
 
 	AssignMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error
 	ChangeMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error

--- a/internal/migration/batch_ports.go
+++ b/internal/migration/batch_ports.go
@@ -56,4 +56,5 @@ type BatchRepo interface {
 	GetMigrationWindow(ctx context.Context, windowID int64) (*MigrationWindow, error)
 	AssignMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error
 	UnassignMigrationWindows(ctx context.Context, batch string) error
+	UpdateMigrationWindows(ctx context.Context, batch string, windows MigrationWindows) error
 }

--- a/internal/migration/batch_service.go
+++ b/internal/migration/batch_service.go
@@ -158,7 +158,7 @@ func (s batchService) UpdateStatusByName(ctx context.Context, name string, statu
 }
 
 func (s batchService) UpdateInstancesAssignedToBatch(ctx context.Context, batch Batch) error {
-	if !batch.CanBeModified() {
+	if batch.Status == api.BATCHSTATUS_RUNNING {
 		return fmt.Errorf("Cannot update batch %q: Currently in a migration phase: %w", batch.Name, ErrOperationNotPermitted)
 	}
 
@@ -237,7 +237,7 @@ func (s batchService) DeleteByName(ctx context.Context, name string) error {
 			return err
 		}
 
-		if !oldBatch.CanBeModified() {
+		if oldBatch.Status == api.BATCHSTATUS_RUNNING {
 			return fmt.Errorf("Cannot delete batch %q: Currently in a migration phase: %w", name, ErrOperationNotPermitted)
 		}
 

--- a/internal/migration/instance_service.go
+++ b/internal/migration/instance_service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/FuturFusion/migration-manager/internal/transaction"
 	"github.com/FuturFusion/migration-manager/internal/util"
+	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
 type instanceService struct {
@@ -141,7 +142,7 @@ func (s instanceService) Update(ctx context.Context, instance *Instance) error {
 			for _, b := range batches {
 				if oldInstance.DisabledReason(b.RestrictionOverrides) == nil {
 					unrestrictedForBatch = true
-					inRunningBatch = !b.CanBeModified()
+					inRunningBatch = b.Status == api.BATCHSTATUS_RUNNING
 					break
 				}
 			}

--- a/internal/migration/repo/middleware/batch_slog_gen.go
+++ b/internal/migration/repo/middleware/batch_slog_gen.go
@@ -322,3 +322,23 @@ func (_d BatchRepoWithSlog) Update(ctx context.Context, name string, batch _sour
 	}()
 	return _d._base.Update(ctx, name, batch)
 }
+
+// UpdateMigrationWindows implements _sourceMigration.BatchRepo
+func (_d BatchRepoWithSlog) UpdateMigrationWindows(ctx context.Context, batch string, windows _sourceMigration.MigrationWindows) (err error) {
+	_d._log.With(
+		slog.Any("ctx", ctx),
+		slog.String("batch", batch),
+		slog.Any("windows", windows),
+	).Debug("BatchRepoWithSlog: calling UpdateMigrationWindows")
+	defer func() {
+		log := _d._log.With(
+			slog.Any("err", err),
+		)
+		if err != nil {
+			log.Error("BatchRepoWithSlog: method UpdateMigrationWindows returned an error")
+		} else {
+			log.Debug("BatchRepoWithSlog: method UpdateMigrationWindows finished")
+		}
+	}()
+	return _d._base.UpdateMigrationWindows(ctx, batch, windows)
+}

--- a/internal/migration/source_service.go
+++ b/internal/migration/source_service.go
@@ -151,8 +151,8 @@ func (s sourceService) canBeModified(ctx context.Context, sourceName string, ins
 
 		if len(batches) > 0 {
 			for _, b := range batches {
-				if !b.CanBeModified() {
-					return nil, fmt.Errorf("Instance %q cannot be modified because it is part of a batch", instanceUUID)
+				if b.Status == api.BATCHSTATUS_RUNNING {
+					return nil, fmt.Errorf("Instance %q cannot be modified because it is part of a running batch", instanceUUID)
 				}
 			}
 		}

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -533,7 +533,7 @@ func (t *InternalIncusTarget) CreateNewVM(ctx context.Context, instDef migration
 	}
 
 	reverter.Add(func() {
-		_, _ = t.incusClient.DeleteInstance(apiDef.Name)
+		_ = t.CleanupVM(ctx, apiDef.Name, true)
 	})
 
 	err = op.WaitContext(ctx)
@@ -565,10 +565,6 @@ func (t *InternalIncusTarget) CreateNewVM(ctx context.Context, instDef migration
 			defaultDiskDef["pool"] = storagePool
 			diskKey := fmt.Sprintf("disk%d", i+1)
 			diskName := apiDef.Name + "-" + diskKey
-			reverter.Add(func() {
-				_ = tgtClient.DeleteStoragePoolVolume(storagePool, "custom", diskName)
-			})
-
 			err := tgtClient.CreateStoragePoolVolume(storagePool, incusAPI.StorageVolumesPost{
 				StorageVolumePut: incusAPI.StorageVolumePut{
 					Description: fmt.Sprintf("Migrated disk (%s)", disk.Name),
@@ -612,7 +608,7 @@ func (t *InternalIncusTarget) CreateNewVM(ctx context.Context, instDef migration
 }
 
 // CleanupVM fully deletes the VM and all of its volumes.
-func (t *InternalIncusTarget) CleanupVM(ctx context.Context, name string) error {
+func (t *InternalIncusTarget) CleanupVM(ctx context.Context, name string, requireWorkerVolume bool) error {
 	err := t.StopVM(ctx, name, true)
 	if err != nil {
 		return fmt.Errorf("Failed to stop target instance %q: %w", name, err)
@@ -621,6 +617,16 @@ func (t *InternalIncusTarget) CleanupVM(ctx context.Context, name string) error 
 	instInfo, _, err := t.GetInstance(name)
 	if err != nil {
 		return fmt.Errorf("Failed to get target instance %q config: %w", name, err)
+	}
+
+	// If the VM doesn't have the config key `user.migration_source` then assume it is not managed by Migration Manager.
+	if instInfo.Config["user.migration_source"] == "" {
+		return nil
+	}
+
+	// If requireWorkerVolume is set, ensure the worker volume is attached to the VM before attempting to delete it.
+	if requireWorkerVolume && instInfo.Devices[util.WorkerVolume()] == nil {
+		return nil
 	}
 
 	op, err := t.incusClient.DeleteInstance(name)

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -116,8 +116,8 @@ type Target interface {
 	// CheckIncusAgent repeatedly calls Exec on the instance until the context errors out, or the exec succeeds.
 	CheckIncusAgent(ctx context.Context, instanceName string) error
 
-	// CleanupVM fully deletes the VM and all of its volumes.
-	CleanupVM(ctx context.Context, name string) error
+	// CleanupVM fully deletes the VM and all of its volumes. If requireWorkerVolume is true, the worker volume must be present for the VM to be cleaned up.
+	CleanupVM(ctx context.Context, name string, requireWorkerVolume bool) error
 
 	// GetDetails fetches top-level details about the entities that exist on the target.
 	GetDetails(ctx context.Context) (*IncusDetails, error)

--- a/internal/target/mock_gen.go
+++ b/internal/target/mock_gen.go
@@ -28,7 +28,7 @@ var _ Target = &TargetMock{}
 //			CheckIncusAgentFunc: func(ctx context.Context, instanceName string) error {
 //				panic("mock out the CheckIncusAgent method")
 //			},
-//			CleanupVMFunc: func(ctx context.Context, name string) error {
+//			CleanupVMFunc: func(ctx context.Context, name string, requireWorkerVolume bool) error {
 //				panic("mock out the CleanupVM method")
 //			},
 //			ConnectFunc: func(ctx context.Context) error {
@@ -117,7 +117,7 @@ type TargetMock struct {
 	CheckIncusAgentFunc func(ctx context.Context, instanceName string) error
 
 	// CleanupVMFunc mocks the CleanupVM method.
-	CleanupVMFunc func(ctx context.Context, name string) error
+	CleanupVMFunc func(ctx context.Context, name string, requireWorkerVolume bool) error
 
 	// ConnectFunc mocks the Connect method.
 	ConnectFunc func(ctx context.Context) error
@@ -209,6 +209,8 @@ type TargetMock struct {
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+			// RequireWorkerVolume is the requireWorkerVolume argument value.
+			RequireWorkerVolume bool
 		}
 		// Connect holds details about calls to the Connect method.
 		Connect []struct {
@@ -438,21 +440,23 @@ func (mock *TargetMock) CheckIncusAgentCalls() []struct {
 }
 
 // CleanupVM calls CleanupVMFunc.
-func (mock *TargetMock) CleanupVM(ctx context.Context, name string) error {
+func (mock *TargetMock) CleanupVM(ctx context.Context, name string, requireWorkerVolume bool) error {
 	if mock.CleanupVMFunc == nil {
 		panic("TargetMock.CleanupVMFunc: method is nil but Target.CleanupVM was just called")
 	}
 	callInfo := struct {
-		Ctx  context.Context
-		Name string
+		Ctx                 context.Context
+		Name                string
+		RequireWorkerVolume bool
 	}{
-		Ctx:  ctx,
-		Name: name,
+		Ctx:                 ctx,
+		Name:                name,
+		RequireWorkerVolume: requireWorkerVolume,
 	}
 	mock.lockCleanupVM.Lock()
 	mock.calls.CleanupVM = append(mock.calls.CleanupVM, callInfo)
 	mock.lockCleanupVM.Unlock()
-	return mock.CleanupVMFunc(ctx, name)
+	return mock.CleanupVMFunc(ctx, name, requireWorkerVolume)
 }
 
 // CleanupVMCalls gets all the calls that were made to CleanupVM.
@@ -460,12 +464,14 @@ func (mock *TargetMock) CleanupVM(ctx context.Context, name string) error {
 //
 //	len(mockedTarget.CleanupVMCalls())
 func (mock *TargetMock) CleanupVMCalls() []struct {
-	Ctx  context.Context
-	Name string
+	Ctx                 context.Context
+	Name                string
+	RequireWorkerVolume bool
 } {
 	var calls []struct {
-		Ctx  context.Context
-		Name string
+		Ctx                 context.Context
+		Name                string
+		RequireWorkerVolume bool
 	}
 	mock.lockCleanupVM.RLock()
 	calls = mock.calls.CleanupVM


### PR DESCRIPTION
* Updates CleanupVM to check for either the worker volume or `user.migration_source` depending on when it's called, so we don't remove VMs from the target unexpectedly.

* Adds the internal concept of a "committed" queue entry, which maps to states that occur after a request is initiated to power the source VM off.

* Adds `/1.0/batches/{name}/reset` to return a batch to `DEFINED` state and clean up all VMs currently being created or undergoing background sync. This is only possible if no queue entries in the batch are currently "committed". 

* Allows modifying batch parameters while the batch is running:
  * Placement and assigned instances cannot be changed
  * New migration windows can be appended, but existing windows cannot be modified
  * Constraints that do not match any queue entry that is currently "committed" can be modified or removed. New constraints can be added as long as they also do not map to any currently "committed" queue entries.