### PR TITLE
Artifact changes

### DIFF
--- a/cmd/migration-manager-worker/worker_test.go
+++ b/cmd/migration-manager-worker/worker_test.go
@@ -394,7 +394,7 @@ func TestRun(t *testing.T) {
 					err := response.SyncResponse(true, []api.Artifact{{
 						ArtifactPost: api.ArtifactPost{
 							Type:       api.ARTIFACTTYPE_SDK,
-							Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE},
+							Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE},
 						},
 						UUID:  sdkArtifactUUID,
 						Files: []string{"vmware-sdk.tar.gz"},

--- a/cmd/migration-manager/internal/cmds/artifacts.go
+++ b/cmd/migration-manager/internal/cmds/artifacts.go
@@ -256,7 +256,7 @@ func (c *cmdArtifactUpload) Run(cmd *cobra.Command, args []string) error {
 
 	data := api.ArtifactPost{
 		Type:       artType,
-		Properties: api.ArtifactProperties{},
+		Properties: api.ArtifactPut{},
 	}
 
 	if data.Type == api.ARTIFACTTYPE_OSIMAGE || data.Type == api.ARTIFACTTYPE_DRIVER {

--- a/cmd/migration-managerd/internal/api/api_artifacts.go
+++ b/cmd/migration-managerd/internal/api/api_artifacts.go
@@ -144,21 +144,11 @@ func artifactFilesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// If no explicit file name is given, use the default file name that we expect.
-	fileName := r.FormValue("name")
-	if fileName == "" {
-		fileName = defaultFileName
-	}
-
-	if fileName != defaultFileName {
-		return response.SmartError(fmt.Errorf("File %q not supported", fileName))
-	}
-
 	// lock the artifact for writing.
 	artifactLock.Lock()
 	defer artifactLock.Unlock()
 
-	err = d.artifact.WriteFile(art.UUID, fileName, r.Body)
+	err = d.artifact.WriteFile(art.UUID, defaultFileName, r.Body)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/cmd/migration-managerd/internal/api/api_artifacts.go
+++ b/cmd/migration-managerd/internal/api/api_artifacts.go
@@ -103,7 +103,7 @@ func artifactPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	var apiArtifact api.ArtifactProperties
+	var apiArtifact api.ArtifactPut
 	err = json.NewDecoder(r.Body).Decode(&apiArtifact)
 	if err != nil {
 		return response.BadRequest(err)

--- a/cmd/migration-managerd/internal/api/migration_test.go
+++ b/cmd/migration-managerd/internal/api/migration_test.go
@@ -626,7 +626,7 @@ def placement(instance, batch):
 			require.NoError(t, os.WriteFile(filepath.Join(d.os.CacheDir, util.RawWorkerImage()), nil, 0o660))
 
 			if tc.hasVMwareSDK {
-				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}}
+				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}
 				_, err := d.artifact.Create(d.ShutdownCtx, art)
 				require.NoError(t, err)
 
@@ -635,7 +635,7 @@ def placement(instance, batch):
 			}
 
 			if tc.hasWindowsDriversArches != nil {
-				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: tc.hasWindowsDriversArches}}
+				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: tc.hasWindowsDriversArches}}
 				_, err := d.artifact.Create(d.ShutdownCtx, art)
 				require.NoError(t, err)
 				require.NoError(t, os.MkdirAll(d.artifact.FileDirectory(art.UUID), 0o755))
@@ -643,7 +643,7 @@ def placement(instance, batch):
 			}
 
 			if tc.hasFortigateImageArches != nil {
-				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: tc.hasFortigateImageArches, Versions: []string{"7.4"}}}
+				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: tc.hasFortigateImageArches, Versions: []string{"7.4"}}}
 				_, err := d.artifact.Create(d.ShutdownCtx, art)
 				require.NoError(t, err)
 				require.NoError(t, os.MkdirAll(d.artifact.FileDirectory(art.UUID), 0o755))

--- a/internal/migration/artifact_model.go
+++ b/internal/migration/artifact_model.go
@@ -16,7 +16,7 @@ type Artifact struct {
 
 	Type api.ArtifactType
 
-	Properties api.ArtifactProperties `db:"marshal=json"`
+	Properties api.ArtifactPut `db:"marshal=json"`
 
 	Files []string `db:"ignore"`
 }

--- a/internal/migration/artifact_service_test.go
+++ b/internal/migration/artifact_service_test.go
@@ -26,7 +26,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_SDK,
-				Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE},
+				Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE},
 			},
 			assertErr: require.NoError,
 		},
@@ -35,7 +35,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_DRIVER,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}},
 			},
 			assertErr: require.NoError,
 		},
@@ -44,7 +44,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"7.4"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"7.4"}},
 			},
 			assertErr: require.NoError,
 		},
@@ -53,7 +53,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_SDK,
-				Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE, Versions: []string{"1.0"}},
+				Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE, Versions: []string{"1.0"}},
 			},
 			assertErr: require.Error,
 		},
@@ -62,7 +62,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_SDK,
-				Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE, Architectures: []string{"x86_64"}},
+				Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE, Architectures: []string{"x86_64"}},
 			},
 			assertErr: require.Error,
 		},
@@ -79,7 +79,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}},
 			},
 			assertErr: require.Error,
 		},
@@ -88,7 +88,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_DRIVER,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"7.4"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"7.4"}},
 			},
 			assertErr: require.Error,
 		},
@@ -105,7 +105,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}},
 			},
 			assertErr: require.Error,
 		},
@@ -114,7 +114,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"version1"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}, Versions: []string{"version1"}},
 			},
 			assertErr: require.Error,
 		},
@@ -123,7 +123,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Versions: []string{"1.0"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Versions: []string{"1.0"}},
 			},
 			assertErr: require.Error,
 		},
@@ -132,7 +132,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_OSIMAGE,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Versions: []string{"1.0"}, Architectures: []string{"fake-arch"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Versions: []string{"1.0"}, Architectures: []string{"fake-arch"}},
 			},
 			assertErr: require.Error,
 		},
@@ -141,7 +141,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_DRIVER,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"fake-arch"}},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"fake-arch"}},
 			},
 			assertErr: require.Error,
 		},
@@ -150,7 +150,7 @@ func TestArtifact_Create(t *testing.T) {
 			artifact: migration.Artifact{
 				UUID:       uuid.New(),
 				Type:       api.ARTIFACTTYPE_DRIVER,
-				Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS},
+				Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS},
 			},
 			assertErr: require.Error,
 		},
@@ -187,7 +187,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "success - linux from vmware (sdk)",
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{{
-				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 				Files:        []string{"vmware-sdk.tar.gz"},
 			}},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE},
@@ -197,11 +197,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -212,11 +212,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -230,7 +230,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -244,11 +244,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -261,8 +261,8 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - fortigate from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}}},
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}}},
 			},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE, Properties: api.InstanceProperties{
 				InstancePropertiesConfigurable: api.InstancePropertiesConfigurable{Description: "FortiGate"},
@@ -274,7 +274,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -285,11 +285,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -305,8 +305,8 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - windows from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}}},
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactProperties{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}}},
 			},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE, Properties: api.InstanceProperties{OS: "Windows", Architecture: "x86_64"}},
 		},
@@ -320,7 +320,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - linux from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{{
-				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactProperties{SourceType: api.SOURCETYPE_VMWARE}},
+				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 			}},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE},
 		},

--- a/shared/api/artifacts.go
+++ b/shared/api/artifacts.go
@@ -25,10 +25,10 @@ type Artifact struct {
 type ArtifactPost struct {
 	Type ArtifactType `json:"type" yaml:"type"`
 
-	Properties ArtifactProperties `json:"properties" yaml:"properties"`
+	Properties ArtifactPut `json:"properties" yaml:"properties"`
 }
 
-type ArtifactProperties struct {
+type ArtifactPut struct {
 	// Description of the artifact.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 


### PR DESCRIPTION
* Renames `ArtifactProperties` to `ArtifactPut` to make it clear this is what should be used on the `PUT` endpoint.
* Removes the `name` query parameter on the upload API for now because we only support one pre-defined filename at the moment. This can be added back once we need to consider handling multiple files per artifact.