### PR TITLE
Add `last_updated` to artifacts

### DIFF
--- a/cmd/migration-manager-worker/internal/worker/worker.go
+++ b/cmd/migration-manager-worker/internal/worker/worker.go
@@ -596,7 +596,7 @@ func (w *Worker) getArtifact(artifactType api.ArtifactType, cmd api.WorkerComman
 func (w *Worker) matchSourceArtifact(artifacts []api.Artifact, cmd api.WorkerCommand) (*api.Artifact, error) {
 	var artifact *api.Artifact
 	for _, a := range artifacts {
-		if a.Type == api.ARTIFACTTYPE_SDK && a.Properties.SourceType == cmd.SourceType {
+		if a.Type == api.ARTIFACTTYPE_SDK && a.SourceType == cmd.SourceType {
 			artifact = &a
 			break
 		}
@@ -612,7 +612,7 @@ func (w *Worker) matchSourceArtifact(artifacts []api.Artifact, cmd api.WorkerCom
 func (w *Worker) matchDriverArtifact(artifacts []api.Artifact, cmd api.WorkerCommand) (*api.Artifact, error) {
 	var artifact *api.Artifact
 	for _, a := range artifacts {
-		match := a.Type == api.ARTIFACTTYPE_DRIVER && a.Properties.OS == cmd.OSType && slices.Contains(a.Properties.Architectures, cmd.Architecture)
+		match := a.Type == api.ARTIFACTTYPE_DRIVER && a.OS == cmd.OSType && slices.Contains(a.Architectures, cmd.Architecture)
 		if match {
 			artifact = &a
 			break
@@ -629,14 +629,14 @@ func (w *Worker) matchDriverArtifact(artifacts []api.Artifact, cmd api.WorkerCom
 func (w *Worker) matchImageArtifact(artifacts []api.Artifact, cmd api.WorkerCommand, osVersion string) (*api.Artifact, error) {
 	var artifact *api.Artifact
 	for _, a := range artifacts {
-		match := a.Type == api.ARTIFACTTYPE_OSIMAGE && a.Properties.OS == cmd.OSType && slices.Contains(a.Properties.Architectures, cmd.Architecture)
+		match := a.Type == api.ARTIFACTTYPE_OSIMAGE && a.OS == cmd.OSType && slices.Contains(a.Architectures, cmd.Architecture)
 		expected := semver.Canonical("v" + osVersion)
 		if expected == "" {
 			return nil, fmt.Errorf("Invalid OS version %q", osVersion)
 		}
 
 		var versionsMatch bool
-		for _, v := range a.Properties.Versions {
+		for _, v := range a.Versions {
 			if semver.Compare(semver.MajorMinor("v"+v), semver.MajorMinor(expected)) == 0 {
 				versionsMatch = true
 				break

--- a/cmd/migration-manager-worker/worker_test.go
+++ b/cmd/migration-manager-worker/worker_test.go
@@ -393,8 +393,8 @@ func TestRun(t *testing.T) {
 
 					err := response.SyncResponse(true, []api.Artifact{{
 						ArtifactPost: api.ArtifactPost{
-							Type:       api.ARTIFACTTYPE_SDK,
-							Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE},
+							Type:        api.ARTIFACTTYPE_SDK,
+							ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE},
 						},
 						UUID:  sdkArtifactUUID,
 						Files: []string{"vmware-sdk.tar.gz"},

--- a/cmd/migration-manager/internal/cmds/artifacts.go
+++ b/cmd/migration-manager/internal/cmds/artifacts.go
@@ -255,8 +255,8 @@ func (c *cmdArtifactUpload) Run(cmd *cobra.Command, args []string) error {
 	filePath := args[2]
 
 	data := api.ArtifactPost{
-		Type:       artType,
-		Properties: api.ArtifactPut{},
+		Type:        artType,
+		ArtifactPut: api.ArtifactPut{},
 	}
 
 	if data.Type == api.ARTIFACTTYPE_OSIMAGE || data.Type == api.ARTIFACTTYPE_DRIVER {
@@ -265,10 +265,10 @@ func (c *cmdArtifactUpload) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		data.Properties.OS = api.OSType(args[1])
-		data.Properties.Architectures = strings.Split(args[3], ",")
+		data.OS = api.OSType(args[1])
+		data.Architectures = strings.Split(args[3], ",")
 		if len(args) == 5 {
-			data.Properties.Versions = strings.Split(args[4], ",")
+			data.Versions = strings.Split(args[4], ",")
 		}
 	} else {
 		exit, err := c.global.CheckArgs(cmd, args, 3, 3)
@@ -276,7 +276,7 @@ func (c *cmdArtifactUpload) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		data.Properties.SourceType = api.SourceType(args[1])
+		data.SourceType = api.SourceType(args[1])
 	}
 
 	b, err := json.Marshal(data)

--- a/cmd/migration-managerd/internal/api/api_artifacts.go
+++ b/cmd/migration-managerd/internal/api/api_artifacts.go
@@ -70,7 +70,7 @@ func artifactsPost(d *Daemon, r *http.Request) response.Response {
 	art := migration.Artifact{
 		UUID:       uuid.New(),
 		Type:       apiArtifact.Type,
-		Properties: apiArtifact.Properties,
+		Properties: apiArtifact.ArtifactPut,
 	}
 
 	_, err = d.artifact.Create(r.Context(), art)

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -120,6 +120,26 @@ var updates = map[int]schema.Update{
 	13: updateFromV12,
 	14: updateFromV13,
 	15: updateFromV14,
+	16: updateFromV15,
+}
+
+func updateFromV15(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `CREATE TABLE artifacts_new (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    uuid         TEXT NOT NULL,
+    type         TEXT NOT NULL,
+    properties   TEXT NOT NULL,
+    last_updated DATETIME NOT NULL,
+    UNIQUE (uuid)
+  );
+
+INSERT INTO artifacts_new (id, uuid, type, properties, last_updated)
+SELECT id, uuid, type, properties, ? FROM artifacts;
+DROP TABLE artifacts;
+ALTER TABLE artifacts_new RENAME TO artifacts;
+`, time.Now().UTC())
+
+	return err
 }
 
 func updateFromV14(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/artifact_model.go
+++ b/internal/migration/artifact_model.go
@@ -118,8 +118,8 @@ func (a Artifact) Validate() error {
 func (a Artifact) ToAPI() api.Artifact {
 	return api.Artifact{
 		ArtifactPost: api.ArtifactPost{
-			Type:       a.Type,
-			Properties: a.Properties,
+			ArtifactPut: a.Properties,
+			Type:        a.Type,
 		},
 		UUID:  a.UUID,
 		Files: a.Files,

--- a/internal/migration/artifact_model.go
+++ b/internal/migration/artifact_model.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lxc/incus/v6/shared/osarch"
@@ -14,7 +15,8 @@ type Artifact struct {
 	ID   int64
 	UUID uuid.UUID `db:"primary=yes"`
 
-	Type api.ArtifactType
+	Type        api.ArtifactType
+	LastUpdated time.Time `db:"update_timestamp"`
 
 	Properties api.ArtifactPut `db:"marshal=json"`
 
@@ -121,7 +123,8 @@ func (a Artifact) ToAPI() api.Artifact {
 			ArtifactPut: a.Properties,
 			Type:        a.Type,
 		},
-		UUID:  a.UUID,
-		Files: a.Files,
+		UUID:        a.UUID,
+		LastUpdated: a.LastUpdated,
+		Files:       a.Files,
 	}
 }

--- a/internal/migration/artifact_service_test.go
+++ b/internal/migration/artifact_service_test.go
@@ -187,7 +187,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "success - linux from vmware (sdk)",
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{{
-				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 				Files:        []string{"vmware-sdk.tar.gz"},
 			}},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE},
@@ -197,11 +197,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -212,11 +212,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.NoError,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -230,7 +230,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -244,11 +244,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}},
 					Files:        []string{"fortigate.qcow2"},
 				},
 			},
@@ -261,8 +261,8 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - fortigate from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_FORTIGATE, Architectures: []string{"x86_64"}}}},
 			},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE, Properties: api.InstanceProperties{
 				InstancePropertiesConfigurable: api.InstancePropertiesConfigurable{Description: "FortiGate"},
@@ -274,7 +274,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -285,11 +285,11 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 					Files:        []string{"vmware-sdk.tar.gz"},
 				},
 				{
-					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
+					ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_DRIVER, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}},
 					Files:        []string{"virtio-win.iso"},
 				},
 			},
@@ -305,8 +305,8 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - windows from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
-				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, Properties: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}},
+				{ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_OSIMAGE, ArtifactPut: api.ArtifactPut{OS: api.OSTYPE_WINDOWS, Architectures: []string{"x86_64"}}}},
 			},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE, Properties: api.InstanceProperties{InstancePropertiesConfigurable: api.InstancePropertiesConfigurable{OS: "Windows"}, Architecture: "x86_64"}},
 		},
@@ -320,7 +320,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 			name:      "error - linux from vmware (empty matching artifacts)",
 			assertErr: require.Error,
 			artifacts: []api.Artifact{{
-				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
+				ArtifactPost: api.ArtifactPost{Type: api.ARTIFACTTYPE_SDK, ArtifactPut: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}},
 			}},
 			instance: migration.Instance{SourceType: api.SOURCETYPE_VMWARE},
 		},
@@ -338,7 +338,7 @@ func TestArtifact_HasRequiredArtifactsForInstance(t *testing.T) {
 				art := migration.Artifact{
 					UUID:       uuid.New(),
 					Type:       a.Type,
-					Properties: a.Properties,
+					Properties: a.ArtifactPut,
 					Files:      a.Files,
 				}
 

--- a/shared/api/artifacts.go
+++ b/shared/api/artifacts.go
@@ -15,7 +15,7 @@ const (
 )
 
 type Artifact struct {
-	ArtifactPost
+	ArtifactPost `yaml:",inline"`
 
 	UUID uuid.UUID `json:"uuid" yaml:"uuid"`
 
@@ -23,9 +23,9 @@ type Artifact struct {
 }
 
 type ArtifactPost struct {
-	Type ArtifactType `json:"type" yaml:"type"`
+	ArtifactPut `yaml:",inline"`
 
-	Properties ArtifactPut `json:"properties" yaml:"properties"`
+	Type ArtifactType `json:"type" yaml:"type"`
 }
 
 type ArtifactPut struct {
@@ -49,30 +49,30 @@ type ArtifactPut struct {
 func (a Artifact) DefaultArtifactFile() (string, error) {
 	switch a.Type {
 	case ARTIFACTTYPE_DRIVER:
-		switch a.Properties.OS {
+		switch a.OS {
 		case OSTYPE_WINDOWS:
 			// Windows expects the VirtIO drivers ISO.
 			return "virtio-win.iso", nil
 		default:
-			return "", fmt.Errorf("Unknown artifact OS %q", a.Properties.OS)
+			return "", fmt.Errorf("Unknown artifact OS %q", a.OS)
 		}
 
 	case ARTIFACTTYPE_OSIMAGE:
-		switch a.Properties.OS {
+		switch a.OS {
 		case OSTYPE_FORTIGATE:
 			// Fortigate expects a qcow2 image containing a KVM build.
 			return "fortigate.qcow2", nil
 		default:
-			return "", fmt.Errorf("Unknown artifact OS %q", a.Properties.OS)
+			return "", fmt.Errorf("Unknown artifact OS %q", a.OS)
 		}
 
 	case ARTIFACTTYPE_SDK:
-		switch a.Properties.SourceType {
+		switch a.SourceType {
 		case SOURCETYPE_VMWARE:
 			// VMware expects the VMware disklib SDK tarball.
 			return string(SOURCETYPE_VMWARE) + "-sdk.tar.gz", nil
 		default:
-			return "", fmt.Errorf("Unknown artifact source type %q", a.Properties.SourceType)
+			return "", fmt.Errorf("Unknown artifact source type %q", a.SourceType)
 		}
 
 	default:

--- a/shared/api/artifacts.go
+++ b/shared/api/artifacts.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -17,7 +18,8 @@ const (
 type Artifact struct {
 	ArtifactPost `yaml:",inline"`
 
-	UUID uuid.UUID `json:"uuid" yaml:"uuid"`
+	UUID        uuid.UUID `json:"uuid" yaml:"uuid"`
+	LastUpdated time.Time `json:"last_updated" yaml:"last_updated"`
 
 	Files []string `json:"files" yaml:"files"`
 }


### PR DESCRIPTION
Closes #332 

* Moves `properties` inline with the main `ArtifactPost` struct to make things consistent with other APIs

* Adds `last_updated` field to Artifact object returned from API. It's updated on each database write via`Create` or `Update`.

* Worker no longer re-imports artifact files each time it receives a new command. It now keeps an in-memory record of each UUID's `last_updated` date, and only re-imports the artifact file if no local file is found, or if the cached last_updated value for a particular UUID does not match the value returned from the API. Since we don't perform cleanup in between commands anymore, cleanup is executed whenever the worker starts or stops.

@presztak The UI should be updated for the new `POST` payload, and objects returned from `GET`. 