### PR TITLE
IncusOS worker image handling

### DIFF
--- a/cmd/migration-managerd/internal/api/migration_test.go
+++ b/cmd/migration-managerd/internal/api/migration_test.go
@@ -593,7 +593,7 @@ def placement(instance, batch):
 
 						return tc.vmStartErr[instanceName]
 					},
-					CreateStoragePoolVolumeFromBackupFunc: func(poolName, backupFilePath string) ([]incus.Operation, error) {
+					CreateStoragePoolVolumeFromBackupFunc: func(poolName, backupFilePath string, volumeName string) ([]incus.Operation, error) {
 						return []incus.Operation{}, tc.backupCreateErr
 					},
 					CreateVMDefinitionFunc: func(instanceDef migration.Instance, usedNetworks migration.Networks, q migration.QueueEntry, fingerprint, endpoint string) (incusAPI.InstancesPost, error) {
@@ -614,7 +614,7 @@ def placement(instance, batch):
 					},
 					GetStoragePoolVolumeNamesFunc: func(pool string) ([]string, error) {
 						if tc.hasWorkerVolume {
-							return []string{"custom/" + util.WorkerVolume()}, nil
+							return []string{"custom/" + util.WorkerVolume("x86_64")}, nil
 						}
 
 						return []string{}, nil
@@ -623,7 +623,7 @@ def placement(instance, batch):
 			}
 
 			// Always write the worker image and drivers ISO so that we don't reach out to GitHub.
-			require.NoError(t, os.WriteFile(filepath.Join(d.os.CacheDir, util.RawWorkerImage()), nil, 0o660))
+			require.NoError(t, os.WriteFile(filepath.Join(d.os.CacheDir, util.RawWorkerImage("x86_64")), nil, 0o660))
 
 			if tc.hasVMwareSDK {
 				art := migration.Artifact{UUID: uuid.New(), Type: api.ARTIFACTTYPE_SDK, Properties: api.ArtifactPut{SourceType: api.SOURCETYPE_VMWARE}}

--- a/cmd/migration-managerd/main.go
+++ b/cmd/migration-managerd/main.go
@@ -37,7 +37,17 @@ func main() {
 	sysInfo := sys.DefaultOS()
 
 	// Make sure expected directories exist and create them if missing.
-	for _, dir := range []string{sysInfo.CacheDir, sysInfo.LogDir, sysInfo.RunDir, sysInfo.VarDir, sysInfo.UsrDir, sysInfo.ShareDir, sysInfo.LocalDatabaseDir(), sysInfo.ArtifactDir} {
+	for _, dir := range []string{
+		sysInfo.CacheDir,
+		sysInfo.LogDir,
+		sysInfo.RunDir,
+		sysInfo.VarDir,
+		sysInfo.UsrDir,
+		sysInfo.ShareDir,
+		sysInfo.LocalDatabaseDir(),
+		sysInfo.ArtifactDir,
+		sysInfo.ImageDir,
+	} {
 		if !util.PathExists(dir) {
 			err := os.MkdirAll(dir, 0o755)
 			if err != nil {

--- a/internal/server/sys/os.go
+++ b/internal/server/sys/os.go
@@ -24,20 +24,21 @@ type OS struct {
 	UsrDir   string // Static directory (e.g. /usr/lib/migration-manager/).
 
 	ArtifactDir string // Location of user-supplied files (e.g. /var/lib/migration-manager/artifacts/).
+	ImageDir    string // Location of the worker images (e.g. /usr/share/migration-manager/images/).
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
 func DefaultOS() *OS {
 	newOS := &OS{
-		CacheDir: util.CachePath(),
-		LogDir:   util.LogPath(),
-		RunDir:   util.RunPath(),
-		VarDir:   util.VarPath(),
-		UsrDir:   util.UsrPath(),
-		ShareDir: util.SharePath(),
+		CacheDir:    util.CachePath(),
+		LogDir:      util.LogPath(),
+		RunDir:      util.RunPath(),
+		VarDir:      util.VarPath(),
+		UsrDir:      util.UsrPath(),
+		ShareDir:    util.SharePath(),
+		ArtifactDir: util.VarPath("artifacts"),
+		ImageDir:    util.SharePath("images"),
 	}
-
-	newOS.ArtifactDir = filepath.Join(newOS.VarDir, "artifacts")
 
 	return newOS
 }

--- a/internal/target/interface.go
+++ b/internal/target/interface.go
@@ -108,7 +108,7 @@ type Target interface {
 	GetStoragePoolVolumeNames(pool string) ([]string, error)
 
 	// Wrapper around Incus' CreateStoragePoolVolumeFromBackup.
-	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) ([]incus.Operation, error)
+	CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string, volumeName string) ([]incus.Operation, error)
 
 	// Wrapper around Incus' CreateStoragePoolVolumeFromISO.
 	CreateStoragePoolVolumeFromISO(pool string, isoFilePath string) ([]incus.Operation, error)

--- a/internal/target/mock_gen.go
+++ b/internal/target/mock_gen.go
@@ -37,7 +37,7 @@ var _ Target = &TargetMock{}
 //			CreateNewVMFunc: func(ctx context.Context, instDef migration.Instance, apiDef incusAPI.InstancesPost, placement api.Placement, bootISOImage string) (func(), error) {
 //				panic("mock out the CreateNewVM method")
 //			},
-//			CreateStoragePoolVolumeFromBackupFunc: func(poolName string, backupFilePath string) ([]incus.Operation, error) {
+//			CreateStoragePoolVolumeFromBackupFunc: func(poolName string, backupFilePath string, volumeName string) ([]incus.Operation, error) {
 //				panic("mock out the CreateStoragePoolVolumeFromBackup method")
 //			},
 //			CreateStoragePoolVolumeFromISOFunc: func(pool string, isoFilePath string) ([]incus.Operation, error) {
@@ -126,7 +126,7 @@ type TargetMock struct {
 	CreateNewVMFunc func(ctx context.Context, instDef migration.Instance, apiDef incusAPI.InstancesPost, placement api.Placement, bootISOImage string) (func(), error)
 
 	// CreateStoragePoolVolumeFromBackupFunc mocks the CreateStoragePoolVolumeFromBackup method.
-	CreateStoragePoolVolumeFromBackupFunc func(poolName string, backupFilePath string) ([]incus.Operation, error)
+	CreateStoragePoolVolumeFromBackupFunc func(poolName string, backupFilePath string, volumeName string) ([]incus.Operation, error)
 
 	// CreateStoragePoolVolumeFromISOFunc mocks the CreateStoragePoolVolumeFromISO method.
 	CreateStoragePoolVolumeFromISOFunc func(pool string, isoFilePath string) ([]incus.Operation, error)
@@ -236,6 +236,8 @@ type TargetMock struct {
 			PoolName string
 			// BackupFilePath is the backupFilePath argument value.
 			BackupFilePath string
+			// VolumeName is the volumeName argument value.
+			VolumeName string
 		}
 		// CreateStoragePoolVolumeFromISO holds details about calls to the CreateStoragePoolVolumeFromISO method.
 		CreateStoragePoolVolumeFromISO []struct {
@@ -560,21 +562,23 @@ func (mock *TargetMock) CreateNewVMCalls() []struct {
 }
 
 // CreateStoragePoolVolumeFromBackup calls CreateStoragePoolVolumeFromBackupFunc.
-func (mock *TargetMock) CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string) ([]incus.Operation, error) {
+func (mock *TargetMock) CreateStoragePoolVolumeFromBackup(poolName string, backupFilePath string, volumeName string) ([]incus.Operation, error) {
 	if mock.CreateStoragePoolVolumeFromBackupFunc == nil {
 		panic("TargetMock.CreateStoragePoolVolumeFromBackupFunc: method is nil but Target.CreateStoragePoolVolumeFromBackup was just called")
 	}
 	callInfo := struct {
 		PoolName       string
 		BackupFilePath string
+		VolumeName     string
 	}{
 		PoolName:       poolName,
 		BackupFilePath: backupFilePath,
+		VolumeName:     volumeName,
 	}
 	mock.lockCreateStoragePoolVolumeFromBackup.Lock()
 	mock.calls.CreateStoragePoolVolumeFromBackup = append(mock.calls.CreateStoragePoolVolumeFromBackup, callInfo)
 	mock.lockCreateStoragePoolVolumeFromBackup.Unlock()
-	return mock.CreateStoragePoolVolumeFromBackupFunc(poolName, backupFilePath)
+	return mock.CreateStoragePoolVolumeFromBackupFunc(poolName, backupFilePath, volumeName)
 }
 
 // CreateStoragePoolVolumeFromBackupCalls gets all the calls that were made to CreateStoragePoolVolumeFromBackup.
@@ -584,10 +588,12 @@ func (mock *TargetMock) CreateStoragePoolVolumeFromBackup(poolName string, backu
 func (mock *TargetMock) CreateStoragePoolVolumeFromBackupCalls() []struct {
 	PoolName       string
 	BackupFilePath string
+	VolumeName     string
 } {
 	var calls []struct {
 		PoolName       string
 		BackupFilePath string
+		VolumeName     string
 	}
 	mock.lockCreateStoragePoolVolumeFromBackup.RLock()
 	calls = mock.calls.CreateStoragePoolVolumeFromBackup

--- a/internal/util/paths.go
+++ b/internal/util/paths.go
@@ -8,13 +8,18 @@ import (
 )
 
 // WorkerVolume represents the name of the storage volume containing the migration worker.
-func WorkerVolume() string {
-	return "migration-worker-" + version.GoVersion()
+func WorkerVolume(arch string) string {
+	return "migration-worker-" + arch + "-" + version.GoVersion()
 }
 
 // RawWorkerImage represents the raw worker image supplied to an Incus target.
-func RawWorkerImage() string {
-	return WorkerVolume() + ".img"
+func RawWorkerImage(arch string) string {
+	prefix := "worker-" + arch
+	if !IsIncusOS() {
+		prefix = prefix + "-" + version.GoVersion()
+	}
+
+	return prefix + ".img"
 }
 
 // CachePath returns the directory that migration manager should use for caching assets. If MIGRATION_MANAGER_DIR is


### PR DESCRIPTION
* Adds architecture to worker image file name

* Adds IncusOS specific handling for the worker image path
  * On IncusOS, the image will be bundled with the application and as such will live in `/usr/share/migration-manager/images/worker-{arch}.img`
  * Otherwise, we continue to import from the Github release according to the daemon version, which corresponds to the version tag. The file will be expected in `/var/cache/migration-manager/worker-{arch}-{version}.img`
  
The created target volume still needs to be version-specific to handle re-using a target across Migration Manager updates, and as such will be named `migration-worker-{arch}-{version}`. 