### PR TITLE
Fix remove command typo

### DIFF
--- a/cmd/migration-manager/internal/cmds/artifacts.go
+++ b/cmd/migration-manager/internal/cmds/artifacts.go
@@ -199,7 +199,7 @@ type cmdArtifactRemove struct {
 
 func (c *cmdArtifactRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = "export <uuid> <file-name>"
+	cmd.Use = "remove <uuid> <file-name>"
 	cmd.Short = "Remove an artifact file"
 
 	cmd.RunE = c.Run


### PR DESCRIPTION
The `remove` command was displaying as `export`:

Before:
```
migration-manager artifact --help

Available Commands:
  export      Export an artifact by its UUID
  export      Remove an artifact file
  list        List artifacts
  show        Show an artifact by its UUID
  upload      Upload an artifact file
```
After:
```
migration-manager artifact --help

Available Commands:
  export      Export an artifact by its UUID
  list        List artifacts
  remove      Remove an artifact file
  show        Show an artifact by its UUID
  upload      Upload an artifact file
```