### PR TITLE
client/oidc: More restrictive permissions for oidc tokens file

### DIFF
--- a/internal/client/oidc/oidc.go
+++ b/internal/client/oidc/oidc.go
@@ -122,7 +122,7 @@ func saveTokensToFile(tokensFile string, tokens *oidc.Tokens[*oidc.IDTokenClaims
 		return err
 	}
 
-	return os.WriteFile(tokensFile, contents, 0o644)
+	return os.WriteFile(tokensFile, contents, 0o600)
 }
 
 // GetAccessToken returns the Access Token from the OidcClient's tokens, or an empty string if no tokens are present.


### PR DESCRIPTION
I stumbled over this, while working on https://github.com/FuturFusion/operations-center/issues/306 since I reused the implementation from migration manager also in operations center. Since the tokens file contains the refresh tokens, which grant access on the user's behalf, I think the permissions should be more restrictive.