### PR TITLE
internal/source: Properly parse architecture from vmware

### DIFF
--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -896,14 +896,18 @@ func parseArchitecture(archName string, archBits string) (string, error) {
 	archID := osarch.ARCH_UNKNOWN
 	switch archName {
 	case "X86":
-		if archBits == "32" {
+		switch archBits {
+		case "64":
+			archID = osarch.ARCH_64BIT_INTEL_X86
+		case "32":
 			archID = osarch.ARCH_32BIT_INTEL_X86
 		}
 
 	case "Arm":
-		if archBits == "64" {
+		switch archBits {
+		case "64":
 			archID = osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN
-		} else {
+		case "32":
 			archID = osarch.ARCH_32BIT_ARMV8_LITTLE_ENDIAN
 		}
 	}


### PR DESCRIPTION
It seems we never actually explicitly looked for `x86_64` architecture, and instead only ever used it as a fallback. When the architecture override functionality was added, the fallback logic became less aggressive and so most VMs ended up with no default architecture until their next sync.