### PR TITLE
ui: Fix issue with deleting environment variables

### DIFF
--- a/ui/src/components/SystemSecurityForm.tsx
+++ b/ui/src/components/SystemSecurityForm.tsx
@@ -47,6 +47,12 @@ const SystemCertForm: FC<Props> = ({ security, onSubmit }) => {
           values.trusted_tls_client_cert_fingerprints.filter(
             (s) => s.trim() !== "",
           ),
+        acme: {
+          ...values.acme,
+          provider_environment: values.acme.provider_environment.filter(
+            (s) => s.trim() !== "",
+          ),
+        },
       });
     },
   });


### PR DESCRIPTION
There is an issue when removing added ACME environment variables where the form submits an array with an empty string. This PR fixes the bug.