### PR TITLE
internal/worker/scripts: Fix call to break in first-boot.ps1

### DIFF
--- a/internal/worker/scripts/first-boot.ps1
+++ b/internal/worker/scripts/first-boot.ps1
@@ -7,9 +7,9 @@ reg delete "hklm\system\currentcontrolset\services\migrationmanagerfirstboot" /f
 remove-item "C:\migration-manager-first-boot.ps1"
 
 # Run the Incus agent if present.
-get-psdrive -psprovider filesystem | foreach-object {
-  if (test-path "$($_.Root)\incus-agent") {
-    start-process powershell.exe -argumentlist "-file `"$($_.Root)\install.ps1`"" -wait
+foreach ($drive in get-psdrive -psprovider filesystem) {
+  if (test-path "$($drive.Root)\incus-agent") {
+    start-process powershell.exe -argumentlist "-file `"$($drive.Root)\install.ps1`"" -wait
     break
   }
 }


### PR DESCRIPTION
Seems that in powershell, calling `break` in a foreach-object just exits the whole script....