### PR TITLE
Windows script logging

### DIFF
--- a/internal/worker/scripts/first-boot.ps1
+++ b/internal/worker/scripts/first-boot.ps1
@@ -21,6 +21,7 @@ if (test-path "C:\migration-manager-virtio-assign-diskcfg.ps1") {
 
 # Run network config reassignment if present.
 if (test-path "C:\migration-manager-virtio-assign-netcfg.ps1") {
-  start-process powershell.exe -argumentlist "-file `"C:\migration-manager-virtio-assign-netcfg.ps1`"" -wait
+  $cmd = '-command "& ''C:\migration-manager-virtio-assign-netcfg.ps1'' *> ''C:\migration-manager-net.log''"'
+  start-process powershell.exe -argumentlist $cmd -wait
 }
 

--- a/internal/worker/windows.go
+++ b/internal/worker/windows.go
@@ -230,7 +230,9 @@ func WindowsInjectDrivers(ctx context.Context, osVersion string, osArchitecture,
 			return err
 		}
 
-		hwAddrs = strings.Split(string(out), " ")
+		if string(out) != "not found" {
+			hwAddrs = strings.Split(string(out), " ")
+		}
 	}
 
 	// Mount the virtio drivers image.


### PR DESCRIPTION
* Uses a WARN log instead of an ERROR log for unknown disk types
* Populates `C:\migration-manager-net.log` with messages from the network reassignment script