### PR TITLE
ui: Batch and queue improvements

### DIFF
--- a/ui/src/api/batches.tsx
+++ b/ui/src/api/batches.tsx
@@ -85,9 +85,19 @@ export const stopBatch = (name: string): Promise<APIResponse<null>> => {
   });
 };
 
-export const resetBatch = (name: string): Promise<APIResponse<null>> => {
+export const resetBatch = (
+  name: string,
+  force: boolean,
+): Promise<APIResponse<null>> => {
+  const params = new URLSearchParams();
+  if (force) {
+    params.set("force", "1");
+  }
+
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/batches/${name}/:reset`, { method: "POST" })
+    fetch(`/1.0/batches/${name}/:reset?${params.toString()}`, {
+      method: "POST",
+    })
       .then((response) => response.json())
       .then(resolve)
       .catch(reject);

--- a/ui/src/api/queue.tsx
+++ b/ui/src/api/queue.tsx
@@ -30,9 +30,31 @@ export const deleteQueue = (uuid: string): Promise<APIResponse<object>> => {
   });
 };
 
-export const cancelQueue = (uuid: string): Promise<APIResponse<null>> => {
+export const cancelQueue = (
+  uuid: string,
+  force: boolean,
+  cleanup: boolean,
+): Promise<APIResponse<null>> => {
+  const params = new URLSearchParams();
+  if (force) {
+    params.set("force", "1");
+  }
+
+  if (cleanup) {
+    params.set("cleanup", "1");
+  }
+
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/queue/${uuid}/:cancel`, { method: "POST" })
+    fetch(`/1.0/queue/${uuid}/:cancel?${params.toString()}`, { method: "POST" })
+      .then((response) => response.json())
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const resolveQueue = (uuid: string): Promise<APIResponse<null>> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/queue/${uuid}/:resolve`, { method: "POST" })
       .then((response) => response.json())
       .then(resolve)
       .catch(reject);

--- a/ui/src/components/BatchActions.tsx
+++ b/ui/src/components/BatchActions.tsx
@@ -5,15 +5,13 @@ import {
   MdOutlinePlayCircle,
   MdOutlineStopCircle,
 } from "react-icons/md";
-import { RiResetLeftLine } from "react-icons/ri";
 import BatchDeleteModal from "components/BatchDeleteModal";
+import BatchResetBtn from "components/BatchResetBtn";
 import { useNotification } from "context/notificationContext";
 import { Batch } from "types/batch";
 import {
-  canResetBatch,
   canStartBatch,
   canStopBatch,
-  handleResetBatch,
   handleStartBatch,
   handleStopBatch,
 } from "util/batch";
@@ -70,27 +68,6 @@ const BatchActions: FC<Props> = ({ batch }) => {
     );
   };
 
-  const onReset = () => {
-    if (!canResetBatch(batch) || opInprogress) {
-      return;
-    }
-
-    setOpInprogress(true);
-
-    handleResetBatch(
-      batch.name,
-      (message) => {
-        setOpInprogress(false);
-        void queryClient.invalidateQueries({ queryKey: ["batches"] });
-        notify.success(message);
-      },
-      (message) => {
-        setOpInprogress(false);
-        notify.error(message);
-      },
-    );
-  };
-
   const startStyle = {
     cursor: "pointer",
     color: canStartBatch(batch) && !opInprogress ? "grey" : "lightgrey",
@@ -99,11 +76,6 @@ const BatchActions: FC<Props> = ({ batch }) => {
   const stopStyle = {
     cursor: "pointer",
     color: canStopBatch(batch) && !opInprogress ? "grey" : "lightgrey",
-  };
-
-  const resetStyle = {
-    cursor: "pointer",
-    color: canResetBatch(batch) && !opInprogress ? "grey" : "lightgrey",
   };
 
   const buttonStyle = {
@@ -131,13 +103,7 @@ const BatchActions: FC<Props> = ({ batch }) => {
           onStop();
         }}
       />
-      <RiResetLeftLine
-        size={22}
-        style={resetStyle}
-        onClick={() => {
-          onReset();
-        }}
-      />
+      <BatchResetBtn batch={batch} />
       <MdOutlineDelete
         size={25}
         style={buttonStyle}

--- a/ui/src/components/BatchForm.test.tsx
+++ b/ui/src/components/BatchForm.test.tsx
@@ -72,6 +72,7 @@ test("renders and submit BatchForm", async () => {
         target: "t1",
         target_project: "default",
       },
+      force_conflict_resolution: false,
     },
   });
 });

--- a/ui/src/components/BatchForm.tsx
+++ b/ui/src/components/BatchForm.tsx
@@ -137,6 +137,7 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
         target_project: "default",
       },
       migration_network: [],
+      force_conflict_resolution: false,
     },
   };
 
@@ -181,6 +182,7 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
           target_project: batch.defaults.placement.target_project,
         },
         migration_network: batch.defaults.migration_network,
+        force_conflict_resolution: batch.defaults.force_conflict_resolution,
       },
     };
   }
@@ -585,6 +587,30 @@ const BatchForm: FC<Props> = ({ batch, onSubmit }) => {
                     onChange={formik.handleChange}
                     onBlur={formik.handleBlur}
                   />
+                </Form.Group>
+                <Form.Group
+                  className="mb-3"
+                  controlId="force_conflict_resolution"
+                >
+                  <Form.Label>Force conflict resolution</Form.Label>
+                  <Form.Select
+                    name="defaults.force_conflict_resolution"
+                    value={
+                      formik.values.defaults.force_conflict_resolution
+                        ? "true"
+                        : "false"
+                    }
+                    onChange={(e) =>
+                      formik.setFieldValue(
+                        "defaults.force_conflict_resolution",
+                        e.target.value === "true",
+                      )
+                    }
+                    onBlur={formik.handleBlur}
+                  >
+                    <option value="false">no</option>
+                    <option value="true">yes</option>
+                  </Form.Select>
                 </Form.Group>
               </div>
             )}

--- a/ui/src/components/BatchOverview.tsx
+++ b/ui/src/components/BatchOverview.tsx
@@ -131,6 +131,14 @@ const BatchOverview = () => {
         </div>
       </div>
       <div className="row">
+        <div className="col-2 detail-table-header">
+          Force conflict resolution
+        </div>
+        <div className="col-10 detail-table-cell">
+          {batch?.defaults.force_conflict_resolution ? "Yes" : "No"}
+        </div>
+      </div>
+      <div className="row">
         <div className="col-2 detail-table-header">Migration windows</div>
         <div className="col-10 detail-table-cell">
           <Table borderless size="sm">

--- a/ui/src/components/BatchResetBtn.tsx
+++ b/ui/src/components/BatchResetBtn.tsx
@@ -1,0 +1,93 @@
+import { FC, useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import { RiResetLeftLine } from "react-icons/ri";
+import { useQueryClient } from "@tanstack/react-query";
+import ModalWindow from "components/ModalWindow";
+import { useNotification } from "context/notificationContext";
+import { Batch } from "types/batch";
+import { canResetBatch, handleResetBatch } from "util/batch";
+
+interface Props {
+  batch: Batch;
+}
+
+const BatchResetBtn: FC<Props> = ({ batch }) => {
+  const [showModal, setShowModal] = useState(false);
+  const [opInprogress, setOpInprogress] = useState(false);
+  const [forceReset, setForceReset] = useState(false);
+  const { notify } = useNotification();
+  const queryClient = useQueryClient();
+
+  const resetStyle = {
+    cursor: "pointer",
+    color: canResetBatch(batch) && !opInprogress ? "grey" : "lightgrey",
+  };
+
+  const handleReset = () => {
+    if (!canResetBatch(batch) || opInprogress) {
+      return;
+    }
+
+    setOpInprogress(true);
+
+    handleResetBatch(
+      batch.name,
+      forceReset,
+      (message) => {
+        setOpInprogress(false);
+        void queryClient.invalidateQueries({ queryKey: ["batches"] });
+        setShowModal(false);
+        notify.success(message);
+      },
+      (message) => {
+        setOpInprogress(false);
+        setShowModal(false);
+        notify.error(message);
+      },
+    );
+  };
+
+  return (
+    <>
+      <RiResetLeftLine
+        size={22}
+        style={resetStyle}
+        onClick={() => {
+          setShowModal(true);
+        }}
+      />
+      <ModalWindow
+        show={showModal}
+        handleClose={() => setShowModal(false)}
+        title="Reset batch"
+        footer={
+          <>
+            <Button variant="danger" onClick={handleReset}>
+              Confirm
+            </Button>
+          </>
+        }
+      >
+        <p>
+          Are you sure you want to reset the batch "{batch.name}"?
+          <br />
+          This action cannot be undone.
+        </p>
+        <div className="my-3">
+          <Form.Group controlId="force">
+            <Form.Check
+              type="checkbox"
+              label="Force"
+              name="force"
+              checked={forceReset}
+              onChange={(e) => setForceReset(e.currentTarget.checked)}
+              disabled={opInprogress}
+            />
+          </Form.Group>
+        </div>
+      </ModalWindow>
+    </>
+  );
+};
+
+export default BatchResetBtn;

--- a/ui/src/components/QueueActions.tsx
+++ b/ui/src/components/QueueActions.tsx
@@ -1,16 +1,17 @@
 import { FC, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { MdOutlineDelete, MdOutlineStopCircle, MdSync } from "react-icons/md";
+import { MdBuildCircle, MdOutlineDelete, MdSync } from "react-icons/md";
 import { RiResetLeftLine } from "react-icons/ri";
 import { Button } from "react-bootstrap";
 import { resetBackgroundImport } from "api/instances";
-import { cancelQueue, deleteQueue, retryQueue } from "api/queue";
+import { deleteQueue, resolveQueue, retryQueue } from "api/queue";
 import ModalWindow from "components/ModalWindow";
+import QueueCancelBtn from "components/QueueCancelBtn";
 import { useNotification } from "context/notificationContext";
 import { QueueEntry } from "types/queue";
 import {
-  canCancelQueueEntry,
   canDeleteQueueEntry,
+  canResolveQueueEntry,
   canRetryQueueEntry,
 } from "util/queue";
 
@@ -23,12 +24,6 @@ const QueueActions: FC<Props> = ({ queueEntry }) => {
   const [opInprogress, setOpInprogress] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { notify } = useNotification();
-
-  const cancelStyle = {
-    cursor: "pointer",
-    color:
-      canCancelQueueEntry(queueEntry) && !opInprogress ? "grey" : "lightgrey",
-  };
 
   const deleteStyle = {
     cursor: "pointer",
@@ -47,26 +42,10 @@ const QueueActions: FC<Props> = ({ queueEntry }) => {
     color: !opInprogress ? "grey" : "lightgrey",
   };
 
-  const onCancel = () => {
-    if (!canCancelQueueEntry(queueEntry) || opInprogress) {
-      return;
-    }
-
-    setOpInprogress(true);
-    cancelQueue(queueEntry.instance_uuid)
-      .then((response) => {
-        setOpInprogress(false);
-        if (response.error_code == 0) {
-          notify.success(`Queue entry ${queueEntry.instance_uuid} canceled`);
-          queryClient.invalidateQueries({ queryKey: ["queue"] });
-          return;
-        }
-        notify.error(response.error);
-      })
-      .catch((e) => {
-        setOpInprogress(false);
-        notify.error(`Error during queue entry cancelation: ${e}`);
-      });
+  const resolveStyle = {
+    cursor: "pointer",
+    color:
+      canResolveQueueEntry(queueEntry) && !opInprogress ? "grey" : "lightgrey",
   };
 
   const onDelete = () => {
@@ -88,6 +67,28 @@ const QueueActions: FC<Props> = ({ queueEntry }) => {
       .catch((e) => {
         setOpInprogress(false);
         notify.error(`Error during queue entry deletion: ${e}`);
+      });
+  };
+
+  const onResolve = () => {
+    if (!canResolveQueueEntry(queueEntry) || opInprogress) {
+      return;
+    }
+
+    setOpInprogress(true);
+    resolveQueue(queueEntry.instance_uuid)
+      .then((response) => {
+        setOpInprogress(false);
+        if (response.error_code == 0) {
+          notify.success(`Queue entry ${queueEntry.instance_uuid} resolved`);
+          queryClient.invalidateQueries({ queryKey: ["queue"] });
+          return;
+        }
+        notify.error(response.error);
+      })
+      .catch((e) => {
+        setOpInprogress(false);
+        notify.error(`Error during queue entry resolve: ${e}`);
       });
   };
 
@@ -137,14 +138,7 @@ const QueueActions: FC<Props> = ({ queueEntry }) => {
 
   return (
     <div>
-      <MdOutlineStopCircle
-        title="Cancel"
-        size={25}
-        style={cancelStyle}
-        onClick={() => {
-          onCancel();
-        }}
-      />
+      <QueueCancelBtn queueEntry={queueEntry} />
       <RiResetLeftLine
         title="Retry"
         size={22}
@@ -171,6 +165,14 @@ const QueueActions: FC<Props> = ({ queueEntry }) => {
         style={resetStyle}
         onClick={() => {
           onResetBackgroundImport();
+        }}
+      />
+      <MdBuildCircle
+        title="Resolve"
+        size={25}
+        style={resolveStyle}
+        onClick={() => {
+          onResolve();
         }}
       />
       <ModalWindow

--- a/ui/src/components/QueueCancelBtn.tsx
+++ b/ui/src/components/QueueCancelBtn.tsx
@@ -1,0 +1,110 @@
+import { FC, useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import { MdOutlineStopCircle } from "react-icons/md";
+import { useQueryClient } from "@tanstack/react-query";
+import { cancelQueue } from "api/queue";
+import ModalWindow from "components/ModalWindow";
+import { useNotification } from "context/notificationContext";
+import { QueueEntry } from "types/queue";
+import { canCancelQueueEntry } from "util/queue";
+
+interface Props {
+  queueEntry: QueueEntry;
+}
+
+const QueueCancelBtn: FC<Props> = ({ queueEntry }) => {
+  const [showModal, setShowModal] = useState(false);
+  const [opInprogress, setOpInprogress] = useState(false);
+  const [forceCancel, setForceCancel] = useState(false);
+  const [cleanupCancel, setCleanupCancel] = useState(false);
+  const { notify } = useNotification();
+  const queryClient = useQueryClient();
+
+  const cancelStyle = {
+    cursor: "pointer",
+    color:
+      canCancelQueueEntry(queueEntry) && !opInprogress ? "grey" : "lightgrey",
+  };
+
+  const handleCancel = () => {
+    if (!canCancelQueueEntry(queueEntry) || opInprogress) {
+      return;
+    }
+
+    setOpInprogress(true);
+    cancelQueue(queueEntry.instance_uuid, forceCancel, cleanupCancel)
+      .then((response) => {
+        setOpInprogress(false);
+        setShowModal(false);
+        if (response.error_code == 0) {
+          notify.success(`Queue entry ${queueEntry.instance_uuid} canceled`);
+          queryClient.invalidateQueries({ queryKey: ["queue"] });
+          return;
+        }
+        notify.error(response.error);
+      })
+      .catch((e) => {
+        setOpInprogress(false);
+        setShowModal(false);
+        notify.error(`Error during queue entry cancelation: ${e}`);
+      });
+  };
+
+  return (
+    <>
+      <MdOutlineStopCircle
+        title="Cancel"
+        size={25}
+        style={cancelStyle}
+        onClick={() => {
+          setShowModal(true);
+        }}
+      />
+      <ModalWindow
+        show={showModal}
+        handleClose={() => setShowModal(false)}
+        title="Cancel queue entry"
+        footer={
+          <>
+            <Button variant="danger" onClick={handleCancel}>
+              Confirm
+            </Button>
+          </>
+        }
+      >
+        <p>
+          Are you sure you want to cancel the queue entry "
+          {queueEntry.instance_uuid}"?
+          <br />
+          This action cannot be undone.
+        </p>
+        <div className="my-3">
+          <Form.Group controlId="force">
+            <Form.Check
+              type="checkbox"
+              label="Force"
+              name="force"
+              checked={forceCancel}
+              onChange={(e) => setForceCancel(e.currentTarget.checked)}
+              disabled={opInprogress}
+            />
+          </Form.Group>
+        </div>
+        <div className="my-3">
+          <Form.Group controlId="cleanup">
+            <Form.Check
+              type="checkbox"
+              label="Cleanup"
+              name="cleanup"
+              checked={cleanupCancel}
+              onChange={(e) => setCleanupCancel(e.currentTarget.checked)}
+              disabled={opInprogress}
+            />
+          </Form.Group>
+        </div>
+      </ModalWindow>
+    </>
+  );
+};
+
+export default QueueCancelBtn;

--- a/ui/src/pages/Source.tsx
+++ b/ui/src/pages/Source.tsx
@@ -27,12 +27,14 @@ const Source = () => {
     "Endpoint",
     "Connectivity status",
     "Username",
+    "Syncing",
     "Actions",
   ];
   const rows = sources.map((item) => {
     let connStatus = undefined;
     let endpoint = "";
     let username = "";
+    const syncing = item.syncing ? "Yes" : "No";
 
     if (item.source_type == SourceType.VMware) {
       const props = item.properties as VMwareProperties;
@@ -74,6 +76,10 @@ const Source = () => {
         {
           content: username,
           sortKey: username,
+        },
+        {
+          content: syncing,
+          sortKey: syncing,
         },
         {
           content: <SourceActions source={item} />,

--- a/ui/src/pages/SourceOverview.tsx
+++ b/ui/src/pages/SourceOverview.tsx
@@ -53,6 +53,12 @@ const SourceOverview = () => {
         </div>
       </div>
       <div className="row">
+        <div className="col-2 detail-table-header">Syncing</div>
+        <div className="col-10 detail-table-cell">
+          {source?.syncing ? "Yes" : "No"}
+        </div>
+      </div>
+      <div className="row">
         <div className="col-2 detail-table-header">
           Trusted server certificate fingerprint
         </div>

--- a/ui/src/types/batch.d.ts
+++ b/ui/src/types/batch.d.ts
@@ -29,6 +29,7 @@ export interface MigrationNetworkPlacement extends NetworkPlacement {
 export interface BatchDefaults {
   placement: BatchPlacement;
   migration_network: MigrationNetworkPlacement[];
+  force_conflict_resolution: boolean;
 }
 
 export interface BatchConstraint {

--- a/ui/src/types/source.d.ts
+++ b/ui/src/types/source.d.ts
@@ -26,6 +26,7 @@ export interface Source {
   name: string;
   source_type: SourceType;
   properties: VMwareProperties | NSXProperties;
+  syncing?: boolean;
 }
 
 export interface SourceFormValues {

--- a/ui/src/util/batch.ts
+++ b/ui/src/util/batch.ts
@@ -80,10 +80,11 @@ export const handleStopBatch = (
 
 export const handleResetBatch = (
   batchName: string,
+  force: boolean,
   onSuccess: (message: string) => void,
   onError: (message: string) => void,
 ) => {
-  void resetBatch(batchName)
+  void resetBatch(batchName, force)
     .then((response) => {
       if (response.error_code === 0) {
         onSuccess(`Batch ${batchName} reset successfully`);

--- a/ui/src/util/queue.ts
+++ b/ui/src/util/queue.ts
@@ -8,9 +8,11 @@ export enum MigrationStatus {
   Idle = "Idle",
   FinalImport = "Performing final import tasks",
   PostImport = "Performing post-import tasks",
+  WorkerDone = "Worker tasks complete",
   Finished = "Finished",
   Error = "Error",
   Canceled = "Canceled",
+  Conflict = "Conflict",
 }
 
 export const canDeleteQueueEntry = (queueEntry: QueueEntry) => {
@@ -25,6 +27,15 @@ export const canDeleteQueueEntry = (queueEntry: QueueEntry) => {
 export const canCancelQueueEntry = (queueEntry: QueueEntry) => {
   const status = queueEntry.migration_status;
   if (status != MigrationStatus.Canceled) {
+    return true;
+  }
+
+  return false;
+};
+
+export const canResolveQueueEntry = (queueEntry: QueueEntry) => {
+  const status = queueEntry.migration_status;
+  if (status === MigrationStatus.Conflict) {
     return true;
   }
 


### PR DESCRIPTION
- Include source `syncing` field in sources list
- Add a button for the POST `/1.0/queue/{uuid}/:resolve` endpoint, if the queue entry is in state Conflict
- Add option for `force_conflict_resolution` in batch defaults
- Support for the force/cleanup query params on POST `/1.0/queue/{uuid}/:cancel` and the force query param on POST `/1.0/batches/{name}/:reset`

Related to: #495  