### PR TITLE
Relax SELinux permissions on older RHEL derivatives

### DIFF
--- a/internal/worker/scripts/add-incus-agent-override-for-old-systemd.sh
+++ b/internal/worker/scripts/add-incus-agent-override-for-old-systemd.sh
@@ -12,3 +12,14 @@ WorkingDirectory=
 ExecStart=
 ExecStart=/bin/sh -c "cd /run/incus_agent/; exec ./incus-agent"
 EOF
+
+# Older SELinux causes errors with Type=notify, so make systemd_notify_t more permissive.
+# The abstract unix socket is also unlabeled, so we need to allow initrc communication explicitly.
+if getenforce >/dev/null 2>&1 ; then
+  cat > /tmp/incus_agent.cil << EOF
+(allow systemd_notify_t kernel_t (unix_dgram_socket (sendto)))
+(allow initrc_t unlabeled_t (socket (getopt read write ioctl)))
+EOF
+
+  semodule -i /tmp/incus_agent.cil
+fi


### PR DESCRIPTION
I noticed the incus agent wasn't working on older RHEL, we fixed this at some point by just turning off SELinux, but we have since turned it back on since we got it working for newer versions.

This adds a workaround for RHEL <= 7 which seems to have issues with the abstract vsock and systemd_notify