### PR TITLE
Fix static analysis issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - worker/mkosi.output
 formatters:
   enable:
     - gci
@@ -192,3 +193,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - worker/mkosi.output

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ DETECTED_LIBNBD_VERSION = $(shell dpkg-query --showformat='$${Version}' -W libnb
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
 
+# TODO: remove after moving to jsonv2
+export GOEXPERIMENT=nojsonv2
+
 default: build
 
 .PHONY: build

--- a/scripts/lint/newline-after-block.sh
+++ b/scripts/lint/newline-after-block.sh
@@ -3,7 +3,7 @@
 echo "Checking that functional blocks are followed by newlines..."
 
 # Check all .go files except the protobuf bindings (.pb.go), migratekit and generated code ending on (_gen.go).
-files=$(git ls-files --cached --modified --others '*.go' ':!:*.pb.go' ':!:internal/migratekit/*.go' ':!:*_gen.go' ':!:*_gen_test.go' | sort | uniq)
+files=$(git ls-files --cached --modified --others --exclude-standard '*.go' ':!:*.pb.go' ':!:internal/migratekit/*.go' ':!:*_gen.go' ':!:*_gen_test.go' | sort | uniq)
 
 exit_code=0
 for file in $files


### PR DESCRIPTION
Currently, the static analysis check is failing primarily due to the move to encoding/json/v2 in Go 1.27.
This PR temporarily disables it.

The migration to jsonv2 can be properly done when phasing out Go 1.25.x support.

Two minor annoyances for local development workflow were also handled.
- omission of `mkosi.output` directory from lint. 
- omission of gitignored files from the newline-after-block check.