### PR TITLE
Stats page

### DIFF
--- a/cmd/migration-managerd/internal/api/api_1.0.go
+++ b/cmd/migration-managerd/internal/api/api_1.0.go
@@ -45,6 +45,7 @@ var api10 = []APIEndpoint{
 	sourceDumpCmd,
 	sourceSyncCmd,
 	sourcesCmd,
+	statsCmd,
 	systemBackupCmd,
 	systemCertificateCmd,
 	systemNetworkCmd,

--- a/cmd/migration-managerd/internal/api/api_stats.go
+++ b/cmd/migration-managerd/internal/api/api_stats.go
@@ -305,7 +305,7 @@ func (s *statsSnapshot) blockedReason(queueEntry migration.QueueEntry) string {
 }
 
 // nextBatchWindow returns the batch's soonest migration window that hasn't ended, nil if it has none.
-func nextBatchWindow(windows migration.Windows) *api.BatchWindow {
+func nextBatchWindow(windows migration.Windows) *api.MigrationWindow {
 	var next *migration.Window
 	for _, window := range windows {
 		if window.Ended() {
@@ -321,11 +321,9 @@ func nextBatchWindow(windows migration.Windows) *api.BatchWindow {
 		return nil
 	}
 
-	return &api.BatchWindow{
-		Name:  next.Name,
-		Start: next.Start,
-		End:   next.End,
-	}
+	apiWindow := next.ToAPI()
+
+	return &apiWindow
 }
 
 // sourcesOverview computes the system-wide source totals and the per-source breakdown.

--- a/cmd/migration-managerd/internal/api/api_stats.go
+++ b/cmd/migration-managerd/internal/api/api_stats.go
@@ -1,0 +1,528 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/internal/server/auth"
+	"github.com/FuturFusion/migration-manager/internal/server/response"
+	"github.com/FuturFusion/migration-manager/internal/transaction"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+var statsCmd = APIEndpoint{
+	Path: "stats",
+
+	Get: APIEndpointAction{Handler: statsGet, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanView)},
+}
+
+// swagger:operation GET /1.0/stats stats stats_get
+//
+//	Get a high-level overview of migration manager
+//
+//	Returns a summary of batches, instances, and disk usage.
+//
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Migration manager stats overview
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StatsOverview"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func statsGet(d *Daemon, r *http.Request) response.Response {
+	var result api.StatsOverview
+	err := transaction.Do(r.Context(), func(ctx context.Context) error {
+		snapshot, err := loadStatsSnapshot(ctx, d)
+		if err != nil {
+			return err
+		}
+
+		result = api.StatsOverview{
+			Sources: snapshot.sourcesOverview(),
+			Batches: snapshot.batchesOverview(),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, result)
+}
+
+// statsSnapshot is a consistent point-in-time view of the state the stats are derived from.
+type statsSnapshot struct {
+	sources   migration.Sources
+	batches   migration.Batches
+	instances migration.Instances
+
+	instancesByBatch     map[string]migration.Instances
+	instanceByUUID       map[uuid.UUID]migration.Instance
+	batchByName          map[string]migration.Batch
+	queueEntryByInstance map[uuid.UUID]migration.QueueEntry
+	windowsByBatch       map[string]migration.Windows
+	syncWarningsBySource map[string]map[api.WarningType]bool
+}
+
+// loadStatsSnapshot reads everything the stats are derived from, and indexes it for lookup.
+func loadStatsSnapshot(ctx context.Context, d *Daemon) (*statsSnapshot, error) {
+	snapshot := &statsSnapshot{}
+
+	var err error
+	snapshot.sources, err = d.source.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot.batches, err = d.batch.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot.instances, err = d.instance.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot.instanceByUUID = make(map[uuid.UUID]migration.Instance, len(snapshot.instances))
+	for _, instance := range snapshot.instances {
+		snapshot.instanceByUUID[instance.UUID] = instance
+	}
+
+	snapshot.batchByName = make(map[string]migration.Batch, len(snapshot.batches))
+	for _, batch := range snapshot.batches {
+		snapshot.batchByName[batch.Name] = batch
+	}
+
+	// Instances may be assigned to a batch before a queue entry exists, so they're looked up per batch.
+	snapshot.instancesByBatch = make(map[string]migration.Instances, len(snapshot.batches))
+	for _, batch := range snapshot.batches {
+		snapshot.instancesByBatch[batch.Name], err = d.instance.GetAllByBatch(ctx, batch.Name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	queueEntries, err := d.queue.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot.queueEntryByInstance = make(map[uuid.UUID]migration.QueueEntry, len(queueEntries))
+	for _, queueEntry := range queueEntries {
+		snapshot.queueEntryByInstance[queueEntry.InstanceUUID] = queueEntry
+	}
+
+	windows, err := d.window.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot.windowsByBatch = make(map[string]migration.Windows, len(windows))
+	for _, window := range windows {
+		snapshot.windowsByBatch[window.Batch] = append(snapshot.windowsByBatch[window.Batch], window)
+	}
+
+	warnings, err := d.warning.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// A sync warning is deleted once a clean sync stops reporting it, so any that remain describe the latest sync.
+	syncScope := api.WarningScopeSync()
+	snapshot.syncWarningsBySource = make(map[string]map[api.WarningType]bool)
+	for _, warning := range warnings {
+		if !syncScope.Match(warning.ToAPI()) {
+			continue
+		}
+
+		if snapshot.syncWarningsBySource[warning.Entity] == nil {
+			snapshot.syncWarningsBySource[warning.Entity] = map[api.WarningType]bool{}
+		}
+
+		snapshot.syncWarningsBySource[warning.Entity][warning.Type] = true
+	}
+
+	return snapshot, nil
+}
+
+// batchesOverview computes the system-wide batch totals and the per-batch breakdown.
+func (s *statsSnapshot) batchesOverview() api.BatchesOverview {
+	overview := api.BatchesOverview{
+		Items: make([]api.BatchSummary, 0, len(s.batches)),
+	}
+
+	overviewBlockedReasonInstances := make(map[string][]api.InstanceRef)
+
+	// An instance may be assigned to several batches, so only count it once towards the totals.
+	counted := make(map[uuid.UUID]bool)
+
+	for _, batch := range s.batches {
+		batchInstances := s.instancesByBatch[batch.Name]
+
+		stats := api.BatchSummary{
+			Name:           batch.Name,
+			Status:         batch.Status,
+			TotalInstances: len(batchInstances),
+		}
+
+		blockedReasonInstances := make(map[string][]api.InstanceRef)
+
+		for _, instance := range batchInstances {
+			var diskSize int64
+			for _, disk := range instance.Properties.Disks {
+				diskSize += disk.Capacity
+			}
+
+			stats.TotalDiskSize += diskSize
+
+			queueEntry, queued := s.queueEntryByInstance[instance.UUID]
+
+			// Once background import completes the disk is on the target, even if the migration hasn't finished.
+			transferred := queued && queueEntry.ImportStage != migration.IMPORTSTAGE_BACKGROUND
+			migrated := queued && queueEntry.MigrationStatus == api.MIGRATIONSTATUS_FINISHED
+			blocked := queued && queueEntry.MigrationStatus == api.MIGRATIONSTATUS_BLOCKED
+
+			// An instance has a single queue entry, owned by whichever batch took control of it first.
+			if queued && queueEntry.BatchName == batch.Name {
+				if transferred {
+					stats.MigratedDiskSize += diskSize
+				}
+
+				if migrated {
+					stats.MigratedInstances++
+				}
+
+				if blocked {
+					stats.BlockedInstances++
+					blockedReason := s.blockedReason(queueEntry)
+					blockedReasonInstances[blockedReason] = append(blockedReasonInstances[blockedReason], instanceRef(instance))
+				}
+			}
+
+			if !counted[instance.UUID] {
+				counted[instance.UUID] = true
+
+				overview.TotalInstances++
+				overview.TotalDiskSize += diskSize
+
+				if transferred {
+					overview.MigratedDiskSize += diskSize
+				}
+
+				if migrated {
+					overview.MigratedInstances++
+				}
+
+				if blocked {
+					overview.BlockedInstances++
+					blockedReason := s.blockedReason(queueEntry)
+					overviewBlockedReasonInstances[blockedReason] = append(overviewBlockedReasonInstances[blockedReason], instanceRef(instance))
+				}
+			}
+		}
+
+		// Migration windows only take effect once a batch is actually running.
+		if batch.Status == api.BATCHSTATUS_RUNNING {
+			stats.NextWindow = nextBatchWindow(s.windowsByBatch[batch.Name])
+		}
+
+		stats.BlockedReasons = reasonInstances(blockedReasonInstances)
+		overview.Items = append(overview.Items, stats)
+	}
+
+	overview.BlockedReasons = reasonInstances(overviewBlockedReasonInstances)
+
+	sort.Slice(overview.Items, func(i, j int) bool {
+		return overview.Items[i].Name < overview.Items[j].Name
+	})
+
+	return overview
+}
+
+// overridingBatch returns the name of the first batch whose overrides waive the instance's restriction.
+func overridingBatch(instance migration.Instance, batches []migration.Batch) string {
+	for _, batch := range batches {
+		if instance.DisabledReason(batch.Config.RestrictionOverrides) == nil {
+			return batch.Name
+		}
+	}
+
+	return ""
+}
+
+// blockedReason categorises a blocked queue entry, preferring the recorded message over the restriction check.
+func (s *statsSnapshot) blockedReason(queueEntry migration.QueueEntry) string {
+	for _, prefix := range []string{blockedReasonArtifact, blockedReasonFilesystem, blockedReasonPlacement} {
+		if strings.HasPrefix(queueEntry.MigrationStatusMessage, prefix+":") {
+			return prefix
+		}
+	}
+
+	instance, ok := s.instanceByUUID[queueEntry.InstanceUUID]
+	if ok {
+		var overrides api.InstanceRestrictionOverride
+		batch, ok := s.batchByName[queueEntry.BatchName]
+		if ok {
+			overrides = batch.Config.RestrictionOverrides
+		}
+
+		var disabledErr migration.ErrDisabled
+		if errors.As(instance.DisabledReason(overrides), &disabledErr) {
+			return string(disabledErr.Reason())
+		}
+	}
+
+	return blockedReasonUnknown
+}
+
+// nextBatchWindow returns the batch's soonest migration window that hasn't ended, nil if it has none.
+func nextBatchWindow(windows migration.Windows) *api.BatchWindow {
+	var next *migration.Window
+	for _, window := range windows {
+		if window.Ended() {
+			continue
+		}
+
+		if next == nil || window.Start.Before(next.Start) {
+			next = &window
+		}
+	}
+
+	if next == nil {
+		return nil
+	}
+
+	return &api.BatchWindow{
+		Name:  next.Name,
+		Start: next.Start,
+		End:   next.End,
+	}
+}
+
+// sourcesOverview computes the system-wide source totals and the per-source breakdown.
+func (s *statsSnapshot) sourcesOverview() api.SourcesOverview {
+	overview := api.SourcesOverview{
+		TotalInstances:      len(s.instances),
+		OverriddenInstances: []api.OverriddenInstance{},
+		BlockedImports:      []api.InstanceRef{},
+		FailedImports:       []api.InstanceRef{},
+		PartialImports:      []api.InstanceRef{},
+	}
+
+	summaryBySource := make(map[string]*api.SourceSummary, len(s.sources))
+	ineligibleReasonInstancesBySource := make(map[string]map[string][]api.InstanceRef, len(s.sources))
+	for _, source := range s.sources {
+		summaryBySource[source.Name] = &api.SourceSummary{
+			Name:                source.Name,
+			ConnectivityStatus:  source.GetExternalConnectivityStatus(),
+			OverriddenInstances: []api.OverriddenInstance{},
+			BlockedImports:      []api.InstanceRef{},
+			FailedImports:       []api.InstanceRef{},
+			PartialImports:      []api.InstanceRef{},
+		}
+
+		ineligibleReasonInstancesBySource[source.Name] = make(map[string][]api.InstanceRef)
+	}
+
+	overviewIneligibleReasonInstances := make(map[string][]api.InstanceRef)
+	notImportedBySource := make(map[string]int, len(s.sources))
+	notImported := 0
+
+	// Overrides are reported as a subset of the ineligible count, so the count itself stays batch agnostic.
+	batchesByInstance := make(map[uuid.UUID][]migration.Batch)
+	for _, batch := range s.batches {
+		for _, instance := range s.instancesByBatch[batch.Name] {
+			batchesByInstance[instance.UUID] = append(batchesByInstance[instance.UUID], batch)
+		}
+	}
+
+	for _, instance := range s.instances {
+		// Nil when the instance's source has since been removed, leaving it counted only in the totals.
+		summary := summaryBySource[instance.Source]
+		if summary != nil {
+			summary.TotalInstances++
+		}
+
+		queueEntry, queued := s.queueEntryByInstance[instance.UUID]
+		migrated := queued && queueEntry.MigrationStatus == api.MIGRATIONSTATUS_FINISHED
+
+		// Eligibility is a property of the instance itself, so batch overrides don't apply; migrating is what clears it.
+		if !migrated {
+			var disabledErr migration.ErrDisabled
+			if errors.As(instance.DisabledReason(api.InstanceRestrictionOverride{}), &disabledErr) {
+				reason := string(disabledErr.Reason())
+
+				overview.IneligibleInstances++
+				overviewIneligibleReasonInstances[reason] = append(overviewIneligibleReasonInstances[reason], instanceRef(instance))
+
+				if summary != nil {
+					summary.IneligibleInstances++
+					ineligibleReasonInstancesBySource[instance.Source][reason] = append(ineligibleReasonInstancesBySource[instance.Source][reason], instanceRef(instance))
+				}
+
+				// A full sync counts as a successful import, so only the remainder can be blocked by a warning.
+				if unreadableProperty(disabledErr.Reason()) {
+					reported := s.syncWarningsBySource[instance.Source]
+					ref := instanceRef(instance)
+
+					if reported[api.SourceUnavailable] {
+						overview.BlockedImports = append(overview.BlockedImports, ref)
+
+						if summary != nil {
+							summary.BlockedImports = append(summary.BlockedImports, ref)
+						}
+					}
+
+					if reported[api.InstanceImportFailed] {
+						overview.FailedImports = append(overview.FailedImports, ref)
+
+						if summary != nil {
+							summary.FailedImports = append(summary.FailedImports, ref)
+						}
+					}
+
+					if reported[api.InstanceIncomplete] {
+						overview.PartialImports = append(overview.PartialImports, ref)
+
+						if summary != nil {
+							summary.PartialImports = append(summary.PartialImports, ref)
+						}
+					}
+
+					// The warnings overlap, so an instance only drops out of the imported count once.
+					if reported[api.SourceUnavailable] || reported[api.InstanceImportFailed] || reported[api.InstanceIncomplete] {
+						notImported++
+						notImportedBySource[instance.Source]++
+					}
+				}
+
+				batchName := overridingBatch(instance, batchesByInstance[instance.UUID])
+				if batchName != "" {
+					overridden := api.OverriddenInstance{InstanceRef: instanceRef(instance), Batch: batchName}
+
+					overview.OverriddenInstances = append(overview.OverriddenInstances, overridden)
+
+					if summary != nil {
+						summary.OverriddenInstances = append(summary.OverriddenInstances, overridden)
+					}
+				}
+			}
+		}
+
+		if !queued {
+			continue
+		}
+
+		if queueEntry.MigrationStatus == api.MIGRATIONSTATUS_FINISHED {
+			overview.MigratedInstances++
+
+			if summary != nil {
+				summary.MigratedInstances++
+			}
+		}
+	}
+
+	overview.IneligibleReasons = reasonInstances(overviewIneligibleReasonInstances)
+	sortOverriddenInstances(overview.OverriddenInstances)
+	sortInstanceRefs(overview.BlockedImports)
+	sortInstanceRefs(overview.FailedImports)
+	sortInstanceRefs(overview.PartialImports)
+	overview.ImportedInstances = overview.TotalInstances - notImported
+
+	overview.Items = make([]api.SourceSummary, 0, len(summaryBySource))
+	for name, summary := range summaryBySource {
+		summary.IneligibleReasons = reasonInstances(ineligibleReasonInstancesBySource[name])
+		sortOverriddenInstances(summary.OverriddenInstances)
+		sortInstanceRefs(summary.BlockedImports)
+		sortInstanceRefs(summary.FailedImports)
+		sortInstanceRefs(summary.PartialImports)
+		summary.ImportedInstances = summary.TotalInstances - notImportedBySource[name]
+		overview.Items = append(overview.Items, *summary)
+	}
+
+	sort.Slice(overview.Items, func(i, j int) bool {
+		return overview.Items[i].Name < overview.Items[j].Name
+	})
+
+	return overview
+}
+
+// instanceRef identifies an instance for display and linking.
+func instanceRef(instance migration.Instance) api.InstanceRef {
+	return api.InstanceRef{UUID: instance.UUID, Location: instance.Properties.Location}
+}
+
+// sortInstanceRefs orders instance references by location so the response is stable.
+func sortInstanceRefs(refs []api.InstanceRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].Location < refs[j].Location
+	})
+}
+
+// unreadableProperty reports whether a disabled reason means the source couldn't report a property.
+func unreadableProperty(reason migration.DisabledReason) bool {
+	switch reason {
+	case migration.DISABLEDREASON_UNKNOWN_OS,
+		migration.DISABLEDREASON_UNKNOWN_ARCHITECTURE,
+		migration.DISABLEDREASON_UNKNOWN_IP_ADDRESS:
+		return true
+	default:
+		return false
+	}
+}
+
+// sortOverriddenInstances orders overridden instances by location so the response is stable.
+func sortOverriddenInstances(instances []api.OverriddenInstance) {
+	sort.Slice(instances, func(i, j int) bool {
+		return instances[i].Location < instances[j].Location
+	})
+}
+
+// reasonInstances converts a reason-to-instances map into a slice sorted by instance count, then reason.
+func reasonInstances(byReason map[string][]api.InstanceRef) []api.ReasonInstances {
+	stats := make([]api.ReasonInstances, 0, len(byReason))
+	for reason, instances := range byReason {
+		sortInstanceRefs(instances)
+
+		stats = append(stats, api.ReasonInstances{Reason: reason, Instances: instances})
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		if len(stats[i].Instances) != len(stats[j].Instances) {
+			return len(stats[i].Instances) > len(stats[j].Instances)
+		}
+
+		return stats[i].Reason < stats[j].Reason
+	})
+
+	return stats
+}

--- a/cmd/migration-managerd/internal/api/api_stats_test.go
+++ b/cmd/migration-managerd/internal/api/api_stats_test.go
@@ -1,0 +1,332 @@
+package api
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/internal/migration/endpoint/mock"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+func TestStatsAPI_get(t *testing.T) {
+	d := daemonSetup(t)
+	client, srvURL := startTestDaemon(t, d, []APIEndpoint{statsCmd}, nil)
+
+	u := uuidCache{}
+
+	defaultSourceEndpointFunc := func(api.Source) (migration.SourceEndpoint, error) {
+		return &mock.SourceEndpointMock{
+			ConnectFunc: func(ctx context.Context) error { return nil },
+			DoBasicConnectivityCheckFunc: func() (api.ExternalConnectivityStatus, *x509.Certificate) {
+				return api.EXTERNALCONNECTIVITYSTATUS_OK, nil
+			},
+		}, nil
+	}
+
+	for _, name := range []string{"src1", "src2"} {
+		_, err := d.source.Create(t.Context(), migration.Source{
+			Name:         name,
+			SourceType:   api.SOURCETYPE_VMWARE,
+			Properties:   json.RawMessage(`{"endpoint": "bar", "username":"u", "password":"p"}`),
+			EndpointFunc: defaultSourceEndpointFunc,
+		})
+		require.NoError(t, err)
+	}
+
+	// src1 reports two warnings at once, so its unsynced instances appear under both.
+	syncWarnings := migration.Warnings{
+		migration.NewSyncWarning(api.SourceUnavailable, "src1", `status: "Cannot connect"`),
+		migration.NewSyncWarning(api.InstanceIncomplete, "src1", "vm-f has incomplete properties"),
+		migration.NewSyncWarning(api.InstanceImportFailed, "src2", "Failed to fetch instances"),
+	}
+
+	for _, w := range syncWarnings {
+		_, err := d.warning.Emit(t.Context(), w)
+		require.NoError(t, err)
+	}
+
+	// Instance with a single 1 GiB disk, imported but not yet migrated.
+	instA := u.newTestInstance("vm-a", map[int]bool{0: true}, map[int]string{}, api.OSTYPE_LINUX, false)
+	instA.Source = "src1"
+	_, err := d.instance.Create(t.Context(), instA)
+	require.NoError(t, err)
+
+	// Instance with two 1 GiB disks and no IPv4, fully migrated, so it no longer counts as ineligible.
+	instB := u.newTestInstance("vm-b", map[int]bool{0: true, 1: true}, map[int]string{0: ""}, api.OSTYPE_LINUX, false)
+	instB.Source = "src1"
+	_, err = d.instance.Create(t.Context(), instB)
+	require.NoError(t, err)
+
+	// Manually disabled instance, blocked from migrating.
+	instD := u.newTestInstance("vm-d", map[int]bool{}, map[int]string{}, api.OSTYPE_LINUX, false)
+	instD.Source = "src1"
+	instD.Overrides.DisableMigration = true
+	_, err = d.instance.Create(t.Context(), instD)
+	require.NoError(t, err)
+
+	// Instance with no known IP address, blocked from migrating.
+	instE := u.newTestInstance("vm-e", map[int]bool{}, map[int]string{0: ""}, api.OSTYPE_LINUX, false)
+	instE.Source = "src2"
+	_, err = d.instance.Create(t.Context(), instE)
+	require.NoError(t, err)
+
+	// Batch created after vm-a, vm-b, vm-d and vm-e already exist, so they all get auto-assigned.
+	batch := migration.Batch{
+		Name: "b1",
+		Defaults: api.BatchDefaults{
+			Placement: api.BatchPlacement{Target: "default", TargetProject: "default", StoragePool: "default"},
+		},
+		Status:            api.BATCHSTATUS_DEFINED,
+		IncludeExpression: "true",
+		Config: api.BatchConfig{
+			BackgroundSyncInterval:   api.AsDuration(10 * time.Minute),
+			FinalBackgroundSyncLimit: api.AsDuration(10 * time.Minute),
+		},
+	}
+
+	_, err = d.batch.Create(t.Context(), batch)
+	require.NoError(t, err)
+
+	// Instance with five 1 GiB disks, from a different source, created after the batch so it stays unassigned.
+	instC := u.newTestInstance("vm-c", map[int]bool{0: true, 1: true, 2: true, 3: true, 4: true}, map[int]string{}, api.OSTYPE_LINUX, false)
+	instC.Source = "src2"
+	_, err = d.instance.Create(t.Context(), instC)
+	require.NoError(t, err)
+
+	// vm-a: background import has finished, but the final sync hasn't, so it should count as imported but not migrated.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:    instA.UUID,
+		BatchName:       "b1",
+		MigrationStatus: api.MIGRATIONSTATUS_IDLE,
+		ImportStage:     migration.IMPORTSTAGE_FINAL,
+		SecretToken:     uuid.New(),
+		Placement:       api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	// vm-b: fully migrated.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:    instB.UUID,
+		BatchName:       "b1",
+		MigrationStatus: api.MIGRATIONSTATUS_FINISHED,
+		ImportStage:     migration.IMPORTSTAGE_COMPLETE,
+		SecretToken:     uuid.New(),
+		Placement:       api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	// vm-c is left without a queue entry, and unassigned to any batch.
+
+	// vm-d is blocked by its instance restrictions.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:           instD.UUID,
+		BatchName:              "b1",
+		MigrationStatus:        api.MIGRATIONSTATUS_BLOCKED,
+		MigrationStatusMessage: "Instance is disabled",
+		ImportStage:            migration.IMPORTSTAGE_BACKGROUND,
+		SecretToken:            uuid.New(),
+		Placement:              api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	// vm-e also fails its restrictions, but was blocked on placement, so the recorded reason wins.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:           instE.UUID,
+		BatchName:              "b1",
+		MigrationStatus:        api.MIGRATIONSTATUS_BLOCKED,
+		MigrationStatusMessage: `Cannot place instance: Target network "incusbr0" has no free addresses`,
+		ImportStage:            migration.IMPORTSTAGE_BACKGROUND,
+		SecretToken:            uuid.New(),
+		Placement:              api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	_, err = d.batch.UpdateStatusByName(t.Context(), "b1", api.BATCHSTATUS_RUNNING, "")
+	require.NoError(t, err)
+
+	// vm-f and vm-g both lack an IPv4 address, and are assigned to a batch that waives that restriction.
+	instF := u.newTestInstance("vm-f", map[int]bool{0: true}, map[int]string{0: ""}, api.OSTYPE_LINUX, false)
+	instF.Source = "src1"
+	_, err = d.instance.Create(t.Context(), instF)
+	require.NoError(t, err)
+
+	instG := u.newTestInstance("vm-g", map[int]bool{}, map[int]string{0: ""}, api.OSTYPE_LINUX, false)
+	instG.Source = "src2"
+	_, err = d.instance.Create(t.Context(), instG)
+	require.NoError(t, err)
+
+	batch2 := migration.Batch{
+		Name: "b2",
+		Defaults: api.BatchDefaults{
+			Placement: api.BatchPlacement{Target: "default", TargetProject: "default", StoragePool: "default"},
+		},
+		Status:            api.BATCHSTATUS_DEFINED,
+		IncludeExpression: `location matches "vm-f" or location matches "vm-g"`,
+		Config: api.BatchConfig{
+			BackgroundSyncInterval:   api.AsDuration(10 * time.Minute),
+			FinalBackgroundSyncLimit: api.AsDuration(10 * time.Minute),
+			RestrictionOverrides:     api.InstanceRestrictionOverride{AllowNoIPv4: true},
+		},
+	}
+
+	_, err = d.batch.Create(t.Context(), batch2)
+	require.NoError(t, err)
+
+	_, err = d.batch.UpdateStatusByName(t.Context(), "b2", api.BATCHSTATUS_RUNNING, "")
+	require.NoError(t, err)
+
+	// vm-f is blocked on placement rather than a restriction. Its batch allows migrating without an
+	// IPv4 address, so the placement failure must be reported instead of the missing address.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:           instF.UUID,
+		BatchName:              "b2",
+		MigrationStatus:        api.MIGRATIONSTATUS_BLOCKED,
+		MigrationStatusMessage: `Cannot place instance: Target network "incusbr0" does not contain IP "10.103.1.120" in subnet "10.6.139.1/24"`,
+		ImportStage:            migration.IMPORTSTAGE_BACKGROUND,
+		SecretToken:            uuid.New(),
+		Placement:              api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	// vm-g is progressing under the waived restriction, so it counts as overridden rather than blocked.
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:           instG.UUID,
+		BatchName:              "b2",
+		MigrationStatus:        api.MIGRATIONSTATUS_IDLE,
+		MigrationStatusMessage: "Waiting for migration window",
+		ImportStage:            migration.IMPORTSTAGE_BACKGROUND,
+		SecretToken:            uuid.New(),
+		Placement:              api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	// vm-f is also assigned to b3, so it must only be counted once towards the batch totals.
+	batch3 := batch2
+	batch3.Name = "b3"
+	_, err = d.batch.Create(t.Context(), batch3)
+	require.NoError(t, err)
+
+	statusCode, body := probeAPI(t, client, http.MethodGet, srvURL+"/1.0/stats", nil, nil)
+	require.Equal(t, http.StatusOK, statusCode, "body: %s", body)
+
+	var resp struct {
+		Metadata api.StatsOverview `json:"metadata"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(body), &resp))
+	stats := resp.Metadata
+
+	const gib = 1024 * 1024 * 1024
+
+	ref := func(inst migration.Instance) api.InstanceRef {
+		return api.InstanceRef{UUID: inst.UUID, Location: inst.Properties.Location}
+	}
+
+	require.Equal(t, 7, stats.Sources.TotalInstances)
+
+	// vm-f is on src1, which reports both warnings, so it is listed under each.
+	require.Equal(t, []api.InstanceRef{ref(instF)}, stats.Sources.BlockedImports)
+	require.Equal(t, []api.InstanceRef{ref(instF)}, stats.Sources.PartialImports)
+	require.Equal(t, []api.InstanceRef{ref(instE), ref(instG)}, stats.Sources.FailedImports)
+
+	// vm-e, vm-f and vm-g are each unsynced, but vm-f only drops out of the imported count once.
+	require.Equal(t, 4, stats.Sources.ImportedInstances)
+	require.Equal(t, 1, stats.Sources.MigratedInstances)
+
+	// vm-b also fails the IPv4 restriction, but has migrated, so it drops out of the ineligible count.
+	require.Equal(t, 4, stats.Sources.IneligibleInstances)
+	require.Equal(t, []api.ReasonInstances{
+		{Reason: "Unknown IP address", Instances: []api.InstanceRef{ref(instE), ref(instF), ref(instG)}},
+		{Reason: "Manually disabled", Instances: []api.InstanceRef{ref(instD)}},
+	}, stats.Sources.IneligibleReasons)
+
+	// vm-f and vm-g are ineligible, but their batch waives the restriction.
+	require.Equal(t, []api.OverriddenInstance{
+		{InstanceRef: ref(instF), Batch: "b2"},
+		{InstanceRef: ref(instG), Batch: "b2"},
+	}, stats.Sources.OverriddenInstances)
+
+	require.Len(t, stats.Sources.Items, 2)
+	require.Equal(t, api.SourceSummary{
+		Name:                "src1",
+		ConnectivityStatus:  api.EXTERNALCONNECTIVITYSTATUS_OK,
+		TotalInstances:      4,
+		ImportedInstances:   3,
+		MigratedInstances:   1,
+		IneligibleInstances: 2, IneligibleReasons: []api.ReasonInstances{
+			{Reason: "Manually disabled", Instances: []api.InstanceRef{ref(instD)}},
+			{Reason: "Unknown IP address", Instances: []api.InstanceRef{ref(instF)}},
+		},
+		OverriddenInstances: []api.OverriddenInstance{{InstanceRef: ref(instF), Batch: "b2"}},
+		BlockedImports:      []api.InstanceRef{ref(instF)},
+		FailedImports:       []api.InstanceRef{},
+		PartialImports:      []api.InstanceRef{ref(instF)},
+	}, stats.Sources.Items[0])
+	require.Equal(t, api.SourceSummary{
+		Name:                "src2",
+		ConnectivityStatus:  api.EXTERNALCONNECTIVITYSTATUS_OK,
+		TotalInstances:      3,
+		ImportedInstances:   1,
+		MigratedInstances:   0,
+		IneligibleInstances: 2,
+		IneligibleReasons: []api.ReasonInstances{
+			{Reason: "Unknown IP address", Instances: []api.InstanceRef{ref(instE), ref(instG)}},
+		},
+		OverriddenInstances: []api.OverriddenInstance{{InstanceRef: ref(instG), Batch: "b2"}},
+		BlockedImports:      []api.InstanceRef{},
+		FailedImports:       []api.InstanceRef{ref(instE), ref(instG)},
+		PartialImports:      []api.InstanceRef{},
+	}, stats.Sources.Items[1])
+
+	// vm-f and vm-g are in both b2 and b3, but only count once towards the totals.
+	require.Equal(t, 6, stats.Batches.TotalInstances)
+	require.Equal(t, 1, stats.Batches.MigratedInstances)
+	require.Equal(t, int64(4*gib), stats.Batches.TotalDiskSize)
+	require.Equal(t, int64(3*gib), stats.Batches.MigratedDiskSize)
+	require.Equal(t, 3, stats.Batches.BlockedInstances)
+	require.Equal(t, []api.ReasonInstances{
+		{Reason: "Cannot place instance", Instances: []api.InstanceRef{ref(instE), ref(instF)}},
+		{Reason: "Manually disabled", Instances: []api.InstanceRef{ref(instD)}},
+	}, stats.Batches.BlockedReasons)
+
+	// vm-f is waived too, but it's blocked on placement.
+	require.Len(t, stats.Batches.Items, 3)
+	require.Equal(t, api.BatchSummary{
+		Name:              "b1",
+		Status:            api.BATCHSTATUS_RUNNING,
+		TotalInstances:    4,
+		MigratedInstances: 1,
+		TotalDiskSize:     3 * gib,
+		MigratedDiskSize:  3 * gib,
+		BlockedInstances:  2,
+		BlockedReasons: []api.ReasonInstances{
+			{Reason: "Cannot place instance", Instances: []api.InstanceRef{ref(instE)}},
+			{Reason: "Manually disabled", Instances: []api.InstanceRef{ref(instD)}},
+		},
+	}, stats.Batches.Items[0])
+	require.Equal(t, api.BatchSummary{
+		Name:             "b2",
+		Status:           api.BATCHSTATUS_RUNNING,
+		TotalInstances:   2,
+		TotalDiskSize:    gib,
+		BlockedInstances: 1,
+		BlockedReasons: []api.ReasonInstances{
+			{Reason: "Cannot place instance", Instances: []api.InstanceRef{ref(instF)}},
+		},
+	}, stats.Batches.Items[1])
+	require.Equal(t, api.BatchSummary{
+		Name:           "b3",
+		Status:         api.BATCHSTATUS_DEFINED,
+		TotalInstances: 2,
+		TotalDiskSize:  gib,
+		BlockedReasons: []api.ReasonInstances{},
+	}, stats.Batches.Items[2])
+}

--- a/cmd/migration-managerd/internal/api/api_target_test.go
+++ b/cmd/migration-managerd/internal/api/api_target_test.go
@@ -400,6 +400,7 @@ func daemonSetup(t *testing.T) *Daemon {
 	daemon.window = migration.NewWindowService(sqlite.NewMigrationWindow(tx))
 	daemon.queue = migration.NewQueueService(sqlite.NewQueue(tx), daemon.batch, daemon.instance, daemon.source, daemon.target, daemon.window)
 	daemon.network = migration.NewNetworkService(sqlite.NewNetwork(tx))
+	daemon.warning = migration.NewWarningService(sqlite.NewWarning(tx))
 	daemon.queueHandler = queue.NewMigrationHandler(daemon.batch, daemon.instance, daemon.network, daemon.source, daemon.target, daemon.queue, daemon.window)
 	daemon.errgroup = &errgroup.Group{}
 

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -37,8 +37,7 @@ const (
 	CacheCleanupTask Task = "cache-cleanup"
 )
 
-// Prefixes of the messages used when blocking a queue entry for a reason that isn't a
-// migration.DisabledReason. Only the message is persisted, so these double as the category reported by the stats API.
+// Message prefixes for blocks that aren't a migration.DisabledReason, which the stats API groups on.
 const (
 	blockedReasonArtifact   = "Artifact error"
 	blockedReasonFilesystem = "Filesystem error"

--- a/cmd/migration-managerd/internal/api/workers.go
+++ b/cmd/migration-managerd/internal/api/workers.go
@@ -37,6 +37,15 @@ const (
 	CacheCleanupTask Task = "cache-cleanup"
 )
 
+// Prefixes of the messages used when blocking a queue entry for a reason that isn't a
+// migration.DisabledReason. Only the message is persisted, so these double as the category reported by the stats API.
+const (
+	blockedReasonArtifact   = "Artifact error"
+	blockedReasonFilesystem = "Filesystem error"
+	blockedReasonPlacement  = "Cannot place instance"
+	blockedReasonUnknown    = "Unknown"
+)
+
 func (d *Daemon) runPeriodicTask(ctx context.Context, task Task, f func(context.Context) error, interval time.Duration) {
 	go func() {
 		for {
@@ -112,14 +121,14 @@ func (d *Daemon) reassessBlockedInstances(ctx context.Context) error {
 		err := d.artifact.HasRequiredArtifactsForInstance(artifacts, inst)
 		if err != nil {
 			slog.Error("Blocking queue entries due to artifact error", slog.Any("error", err))
-			blockedInstances[inst.UUID] = fmt.Sprintf("Artifact error: %v", err.Error())
+			blockedInstances[inst.UUID] = fmt.Sprintf("%s: %v", blockedReasonArtifact, err.Error())
 			continue
 		}
 
 		_, err = d.os.WorkerImageExists(inst.GetArchitecture())
 		if err != nil {
 			slog.Error("Blocking queue entries due to filesystem error", slog.Any("error", err))
-			blockedInstances[inst.UUID] = fmt.Sprintf("Filesystem error: %v", err.Error())
+			blockedInstances[inst.UUID] = fmt.Sprintf("%s: %v", blockedReasonFilesystem, err.Error())
 		}
 	}
 
@@ -369,7 +378,7 @@ func (d *Daemon) beginImports(ctx context.Context, cleanupInstances bool) error 
 				err, ok := placementErrs[instUUID]
 				if ok {
 					stateChanged = true
-					blockedMsg := fmt.Sprintf("Cannot place instance: %v", err.Error())
+					blockedMsg := fmt.Sprintf("%s: %v", blockedReasonPlacement, err.Error())
 					_, err := d.queue.UpdateStatusByUUID(ctx, q.InstanceUUID, api.MIGRATIONSTATUS_BLOCKED, blockedMsg, q.ImportStage, q.GetWindowName())
 					if err != nil {
 						return fmt.Errorf("Failed to unblock queue entry %q: %w", q.InstanceUUID, err)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -302,10 +302,110 @@ definitions:
     BatchStatusType:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    BatchSummary:
+        properties:
+            blocked_instances:
+                description: Number of instances in the batch whose migration is currently blocked
+                example: 2
+                format: int64
+                type: integer
+                x-go-name: BlockedInstances
+            blocked_reasons:
+                description: Breakdown of blocked instances in the batch by the reason their migration is blocked
+                items:
+                    $ref: '#/definitions/ReasonInstances'
+                type: array
+                x-go-name: BlockedReasons
+            migrated_disk_size:
+                description: Total disk size, in bytes, transferred to the target, counted once background import completes
+                example: 10737418240
+                format: int64
+                type: integer
+                x-go-name: MigratedDiskSize
+            migrated_instances:
+                description: Number of instances in the batch that have finished migrating
+                example: 5
+                format: int64
+                type: integer
+                x-go-name: MigratedInstances
+            name:
+                description: A human-friendly name for the batch
+                example: MyBatch
+                type: string
+                x-go-name: Name
+            next_window:
+                $ref: '#/definitions/MigrationWindow'
+            status:
+                $ref: '#/definitions/BatchStatusType'
+            total_disk_size:
+                description: Total disk size, in bytes, across all instances in the batch
+                example: 21474836480
+                format: int64
+                type: integer
+                x-go-name: TotalDiskSize
+            total_instances:
+                description: Number of instances assigned to the batch
+                example: 12
+                format: int64
+                type: integer
+                x-go-name: TotalInstances
+        title: BatchSummary provides a high-level summary of a single batch.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    BatchesOverview:
+        properties:
+            blocked_instances:
+                description: Number of queued instances whose migration is currently blocked
+                example: 2
+                format: int64
+                type: integer
+                x-go-name: BlockedInstances
+            blocked_reasons:
+                description: Breakdown of blocked instances by the reason their migration is blocked
+                items:
+                    $ref: '#/definitions/ReasonInstances'
+                type: array
+                x-go-name: BlockedReasons
+            items:
+                description: Per-batch statistics, one entry per defined batch
+                items:
+                    $ref: '#/definitions/BatchSummary'
+                type: array
+                x-go-name: Items
+            migrated_disk_size:
+                description: Total disk size, in bytes, that has been transferred to the target
+                example: 10737418240
+                format: int64
+                type: integer
+                x-go-name: MigratedDiskSize
+            migrated_instances:
+                description: Number of instances assigned to a batch that have finished migrating
+                example: 5
+                format: int64
+                type: integer
+                x-go-name: MigratedInstances
+            total_disk_size:
+                description: Total disk size, in bytes, across all instances assigned to a batch
+                example: 21474836480
+                format: int64
+                type: integer
+                x-go-name: TotalDiskSize
+            total_instances:
+                description: Number of instances assigned to a batch
+                example: 12
+                format: int64
+                type: integer
+                x-go-name: TotalInstances
+        title: BatchesOverview summarizes all batches, counting each instance once so totals aren't the sum across Items.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     Distro:
         title: Distro represents an OS distribution.
         type: string
         x-go-package: github.com/lxc/incus/v7/shared/osinfo
+    ExternalConnectivityStatus:
+        type: string
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     IncusNICType:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
@@ -740,6 +840,22 @@ definitions:
         title: InstancePropertiesSnapshot are all properties supported by snapshots.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    InstanceRef:
+        properties:
+            location:
+                description: The inventory path of the instance on its source
+                example: /SDDC-Datacenter/vm/MyVM
+                type: string
+                x-go-name: Location
+            uuid:
+                description: The UUID of the instance
+                example: 2ed700e6-45ca-4b1a-a1c3-0b0a4dd7b5d5
+                format: uuid
+                type: string
+                x-go-name: UUID
+        title: InstanceRef identifies an instance well enough to display and link to it.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     InstanceRestrictionOverride:
         properties:
             allow_no_background_import:
@@ -887,6 +1003,27 @@ definitions:
         title: OSType represents an OS type (windows, linux, macos, bsd).
         type: string
         x-go-package: github.com/lxc/incus/v7/shared/osinfo
+    OverriddenInstance:
+        properties:
+            batch:
+                description: The name of the batch whose overrides waive the restriction
+                example: batch1
+                type: string
+                x-go-name: Batch
+            location:
+                description: The inventory path of the instance on its source
+                example: /SDDC-Datacenter/vm/MyVM
+                type: string
+                x-go-name: Location
+            uuid:
+                description: The UUID of the instance
+                example: 2ed700e6-45ca-4b1a-a1c3-0b0a4dd7b5d5
+                format: uuid
+                type: string
+                x-go-name: UUID
+        title: OverriddenInstance is an ineligible instance whose restriction is waived by one of its batches.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     Placement:
         properties:
             networks:
@@ -959,6 +1096,22 @@ definitions:
             placement:
                 $ref: '#/definitions/Placement'
         title: QueueEntry provides a high-level status for an instance that is in a migration stage.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    ReasonInstances:
+        properties:
+            instances:
+                description: The instances affected by this reason
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: Instances
+            reason:
+                description: The reason the instances are ineligible or blocked
+                example: Unknown OS
+                type: string
+                x-go-name: Reason
+        title: ReasonInstances groups the instances that share a reason for being ineligible or blocked.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
     ServerPut:
@@ -1056,8 +1209,148 @@ definitions:
         title: SourcePut defines the configurable properties of Source.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    SourceSummary:
+        properties:
+            blocked_imports:
+                description: Instances from this source not fully synced because the source was unavailable
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: BlockedImports
+            connectivity_status:
+                $ref: '#/definitions/ExternalConnectivityStatus'
+            failed_imports:
+                description: Instances from this source not fully synced because it reported an import failure
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: FailedImports
+            imported_instances:
+                description: Number of instances from this source whose properties were fully read, plus any already migrated
+                example: 15
+                format: int64
+                type: integer
+                x-go-name: ImportedInstances
+            ineligible_instances:
+                description: Number of instances from this source that cannot be migrated as currently configured
+                example: 2
+                format: int64
+                type: integer
+                x-go-name: IneligibleInstances
+            ineligible_reasons:
+                description: Breakdown of ineligible instances from this source by the reason they cannot be migrated
+                items:
+                    $ref: '#/definitions/ReasonInstances'
+                type: array
+                x-go-name: IneligibleReasons
+            migrated_instances:
+                description: Number of instances from this source that have finished migrating
+                example: 5
+                format: int64
+                type: integer
+                x-go-name: MigratedInstances
+            name:
+                description: A human-friendly name for the source
+                example: MySource
+                type: string
+                x-go-name: Name
+            overridden_instances:
+                description: Ineligible instances from this source whose restriction is waived by a batch they are assigned to
+                items:
+                    $ref: '#/definitions/OverriddenInstance'
+                type: array
+                x-go-name: OverriddenInstances
+            partial_imports:
+                description: Instances from this source not fully synced because only some of their properties were reported
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: PartialImports
+            total_instances:
+                description: Number of instances known to migration manager from this source
+                example: 20
+                format: int64
+                type: integer
+                x-go-name: TotalInstances
+        title: SourceSummary provides a high-level summary of a single source.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     SourceType:
         type: string
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    SourcesOverview:
+        properties:
+            blocked_imports:
+                description: Instances not fully synced because their source was unavailable
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: BlockedImports
+            failed_imports:
+                description: Instances not fully synced because their source reported an import failure
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: FailedImports
+            imported_instances:
+                description: Number of instances whose properties were fully read from their source, plus any already migrated
+                example: 30
+                format: int64
+                type: integer
+                x-go-name: ImportedInstances
+            ineligible_instances:
+                description: Number of instances that cannot be migrated as currently configured, excluding those already migrated
+                example: 5
+                format: int64
+                type: integer
+                x-go-name: IneligibleInstances
+            ineligible_reasons:
+                description: Breakdown of ineligible instances by the reason they cannot be migrated
+                items:
+                    $ref: '#/definitions/ReasonInstances'
+                type: array
+                x-go-name: IneligibleReasons
+            items:
+                description: Per-source statistics, one entry per defined source
+                items:
+                    $ref: '#/definitions/SourceSummary'
+                type: array
+                x-go-name: Items
+            migrated_instances:
+                description: Number of instances that have finished migrating
+                example: 10
+                format: int64
+                type: integer
+                x-go-name: MigratedInstances
+            overridden_instances:
+                description: Ineligible instances whose restriction is waived by a batch they are assigned to
+                items:
+                    $ref: '#/definitions/OverriddenInstance'
+                type: array
+                x-go-name: OverriddenInstances
+            partial_imports:
+                description: Instances not fully synced because their source only reported some of their properties
+                items:
+                    $ref: '#/definitions/InstanceRef'
+                type: array
+                x-go-name: PartialImports
+            total_instances:
+                description: Number of source instances known to migration manager
+                example: 42
+                format: int64
+                type: integer
+                x-go-name: TotalInstances
+        title: SourcesOverview provides a high-level summary of all sources.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    StatsOverview:
+        properties:
+            batches:
+                $ref: '#/definitions/BatchesOverview'
+            sources:
+                $ref: '#/definitions/SourcesOverview'
+        title: StatsOverview provides a high-level summary of the state of migration manager.
+        type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
     SystemBackupPost:
         properties:
@@ -3092,6 +3385,40 @@ paths:
             summary: Get the sources
             tags:
                 - sources
+    /1.0/stats:
+        get:
+            description: Returns a summary of batches, instances, and disk usage.
+            operationId: stats_get
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Migration manager stats overview
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/StatsOverview'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get a high-level overview of migration manager
+            tags:
+                - stats
     /1.0/system/:backup:
         post:
             consumes:

--- a/internal/migration/errors.go
+++ b/internal/migration/errors.go
@@ -6,10 +6,8 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("Not found")
-
-	ErrConstraintViolation = errors.New("Constraint violation")
-
+	ErrNotFound              = errors.New("Not found")
+	ErrConstraintViolation   = errors.New("Constraint violation")
 	ErrOperationNotPermitted = errors.New("Operation not permitted")
 )
 
@@ -22,3 +20,46 @@ func NewValidationErrf(format string, a ...any) error {
 func (e ErrValidation) Error() string {
 	return string(e)
 }
+
+// ErrDisabled is returned when an instance is disabled.
+type ErrDisabled struct {
+	err    error
+	reason DisabledReason
+}
+
+// Error implements error.Error.
+func (e ErrDisabled) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped error, so errors.Is and errors.As can inspect it.
+func (e ErrDisabled) Unwrap() error {
+	return e.err
+}
+
+// Reason returns the underlying reason for the error.
+func (e ErrDisabled) Reason() DisabledReason {
+	return e.reason
+}
+
+// NewDisabledErrf creates a new error using the specified reason and format.
+func NewDisabledErrf(reason DisabledReason, format string, a ...any) error {
+	return ErrDisabled{
+		err:    fmt.Errorf(format, a...),
+		reason: reason,
+	}
+}
+
+// DisabledReason is the reason behind the error for a disabled instance.
+type DisabledReason string
+
+const (
+	DISABLEDREASON_MANUALLY_DISABLED             DisabledReason = "Manually disabled"
+	DISABLEDREASON_INVALID_HOSTNAME              DisabledReason = "Invalid hostname"
+	DISABLEDREASON_UNKNOWN_OS                    DisabledReason = "Unknown OS"
+	DISABLEDREASON_UNKNOWN_ARCHITECTURE          DisabledReason = "Unknown architecture"
+	DISABLEDREASON_UNKNOWN_IP_ADDRESS            DisabledReason = "Unknown IP address"
+	DISABLEDREASON_VERIFYING_BACKGROUND_IMPORT   DisabledReason = "Verifying background import"
+	DISABLEDREASON_UNSUPPORTED_BACKGROUND_IMPORT DisabledReason = "Unsupported background import"
+	DISABLEDREASON_UNSUPPORTED_DISK_SNAPSHOT     DisabledReason = "Unsupported disk snapshot"
+)

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -124,7 +124,7 @@ func (i Instance) Validate() error {
 // DisabledReason returns the underlying reason for why the instance is disabled.
 func (i Instance) DisabledReason(overrides api.InstanceRestrictionOverride) error {
 	if i.Overrides.DisableMigration {
-		return fmt.Errorf("Migration is manually disabled")
+		return NewDisabledErrf(DISABLEDREASON_MANUALLY_DISABLED, "Migration is manually disabled")
 	}
 
 	if i.Overrides.IgnoreRestrictions {
@@ -135,7 +135,7 @@ func (i Instance) DisabledReason(overrides api.InstanceRestrictionOverride) erro
 	props.Apply(i.Overrides.InstancePropertiesConfigurable)
 	err := validate.IsHostname(props.Name)
 	if err != nil {
-		return fmt.Errorf("Instance name %q is not a valid hostname: %w", props.Name, err)
+		return NewDisabledErrf(DISABLEDREASON_INVALID_HOSTNAME, "Instance name %q is not a valid hostname: %w", props.Name, err)
 	}
 
 	osType := i.GetOSType(false)
@@ -144,12 +144,12 @@ func (i Instance) DisabledReason(overrides api.InstanceRestrictionOverride) erro
 	if osType == api.OSTYPE_LINUX && distro == osinfo.OtherDistro {
 		osOverridden := i.Overrides.Distribution != "" || i.Overrides.OSType != ""
 		if !overrides.AllowUnknownOS && !osOverridden {
-			return fmt.Errorf("Could not determine instance OS, check if guest agent is running")
+			return NewDisabledErrf(DISABLEDREASON_UNKNOWN_OS, "Could not determine instance OS, check if guest agent is running")
 		}
 	}
 
 	if i.GetArchitecture() == "" {
-		return fmt.Errorf("Could not determine instance architecture, check if guest agent is running")
+		return NewDisabledErrf(DISABLEDREASON_UNKNOWN_ARCHITECTURE, "Could not determine instance architecture, check if guest agent is running")
 	}
 
 	ipRestrict := len(i.Properties.NICs) > 0
@@ -161,20 +161,20 @@ func (i Instance) DisabledReason(overrides api.InstanceRestrictionOverride) erro
 	}
 
 	if ipRestrict && !overrides.AllowNoIPv4 {
-		return fmt.Errorf("Could not determine instance IP, check if guest agent is running")
+		return NewDisabledErrf(DISABLEDREASON_UNKNOWN_IP_ADDRESS, "Could not determine instance IP, check if guest agent is running")
 	}
 
 	if !i.Properties.SupportsBackgroundImport() && !overrides.AllowNoBackgroundImport {
 		if i.Properties.BackgroundImport {
-			return fmt.Errorf("Verifying background import support")
+			return NewDisabledErrf(DISABLEDREASON_VERIFYING_BACKGROUND_IMPORT, "Verifying background import support")
 		}
 
-		return fmt.Errorf("Background import is not supported")
+		return NewDisabledErrf(DISABLEDREASON_UNSUPPORTED_BACKGROUND_IMPORT, "Background import is not supported")
 	}
 
 	for _, d := range i.Properties.Disks {
 		if !d.Supported {
-			return fmt.Errorf("Disk %q does not support snapshots", d.Name)
+			return NewDisabledErrf(DISABLEDREASON_UNSUPPORTED_DISK_SNAPSHOT, "Disk %q does not support snapshots", d.Name)
 		}
 	}
 

--- a/shared/api/stats.go
+++ b/shared/api/stats.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"time"
-
 	"github.com/google/uuid"
 )
 
@@ -123,22 +121,7 @@ type BatchSummary struct {
 	MigratedDiskSize int64 `json:"migrated_disk_size" yaml:"migrated_disk_size"`
 
 	// The next upcoming (or currently active) migration window for the batch, nil if none is scheduled
-	NextWindow *BatchWindow `json:"next_window,omitempty" yaml:"next_window,omitempty"`
-}
-
-// BatchWindow provides a high-level summary of a batch's upcoming migration window.
-//
-// swagger:model
-type BatchWindow struct {
-	// A human-friendly name for the migration window
-	// Example: MyWindow
-	Name string `json:"name" yaml:"name"`
-
-	// Time in UTC that the migration window starts
-	Start time.Time `json:"start" yaml:"start"`
-
-	// Time in UTC that the migration window ends
-	End time.Time `json:"end" yaml:"end"`
+	NextWindow *MigrationWindow `json:"next_window,omitempty" yaml:"next_window,omitempty"`
 }
 
 // SourceSummary provides a high-level summary of a single source.

--- a/shared/api/stats.go
+++ b/shared/api/stats.go
@@ -1,0 +1,222 @@
+package api
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StatsOverview provides a high-level summary of the state of migration manager.
+//
+// swagger:model
+type StatsOverview struct {
+	// Summary of sources
+	Sources SourcesOverview `json:"sources" yaml:"sources"`
+
+	// Summary of batches
+	Batches BatchesOverview `json:"batches" yaml:"batches"`
+}
+
+// SourcesOverview provides a high-level summary of all sources.
+//
+// swagger:model
+type SourcesOverview struct {
+	// Number of source instances known to migration manager
+	// Example: 42
+	TotalInstances int `json:"total_instances" yaml:"total_instances"`
+
+	// Number of instances whose properties were fully read from their source, plus any already migrated
+	// Example: 30
+	ImportedInstances int `json:"imported_instances" yaml:"imported_instances"`
+
+	// Number of instances that have finished migrating
+	// Example: 10
+	MigratedInstances int `json:"migrated_instances" yaml:"migrated_instances"`
+
+	// Number of instances that cannot be migrated as currently configured, excluding those already migrated
+	// Example: 5
+	IneligibleInstances int `json:"ineligible_instances" yaml:"ineligible_instances"`
+
+	// Breakdown of ineligible instances by the reason they cannot be migrated
+	IneligibleReasons []ReasonInstances `json:"ineligible_reasons" yaml:"ineligible_reasons"`
+
+	// Ineligible instances whose restriction is waived by a batch they are assigned to
+	OverriddenInstances []OverriddenInstance `json:"overridden_instances" yaml:"overridden_instances"`
+
+	// Instances not fully synced because their source was unavailable
+	BlockedImports []InstanceRef `json:"blocked_imports" yaml:"blocked_imports"`
+
+	// Instances not fully synced because their source reported an import failure
+	FailedImports []InstanceRef `json:"failed_imports" yaml:"failed_imports"`
+
+	// Instances not fully synced because their source only reported some of their properties
+	PartialImports []InstanceRef `json:"partial_imports" yaml:"partial_imports"`
+
+	// Per-source statistics, one entry per defined source
+	Items []SourceSummary `json:"items" yaml:"items"`
+}
+
+// BatchesOverview summarizes all batches, counting each instance once so totals aren't the sum across Items.
+//
+// swagger:model
+type BatchesOverview struct {
+	// Number of instances assigned to a batch
+	// Example: 12
+	TotalInstances int `json:"total_instances" yaml:"total_instances"`
+
+	// Number of instances assigned to a batch that have finished migrating
+	// Example: 5
+	MigratedInstances int `json:"migrated_instances" yaml:"migrated_instances"`
+
+	// Number of queued instances whose migration is currently blocked
+	// Example: 2
+	BlockedInstances int `json:"blocked_instances" yaml:"blocked_instances"`
+
+	// Breakdown of blocked instances by the reason their migration is blocked
+	BlockedReasons []ReasonInstances `json:"blocked_reasons" yaml:"blocked_reasons"`
+
+	// Total disk size, in bytes, across all instances assigned to a batch
+	// Example: 21474836480
+	TotalDiskSize int64 `json:"total_disk_size" yaml:"total_disk_size"`
+
+	// Total disk size, in bytes, that has been transferred to the target
+	// Example: 10737418240
+	MigratedDiskSize int64 `json:"migrated_disk_size" yaml:"migrated_disk_size"`
+
+	// Per-batch statistics, one entry per defined batch
+	Items []BatchSummary `json:"items" yaml:"items"`
+}
+
+// BatchSummary provides a high-level summary of a single batch.
+//
+// swagger:model
+type BatchSummary struct {
+	// A human-friendly name for the batch
+	// Example: MyBatch
+	Name string `json:"name" yaml:"name"`
+
+	// The status of the batch
+	// Example: Running
+	Status BatchStatusType `json:"status" yaml:"status"`
+
+	// Number of instances assigned to the batch
+	// Example: 12
+	TotalInstances int `json:"total_instances" yaml:"total_instances"`
+
+	// Number of instances in the batch that have finished migrating
+	// Example: 5
+	MigratedInstances int `json:"migrated_instances" yaml:"migrated_instances"`
+
+	// Number of instances in the batch whose migration is currently blocked
+	// Example: 2
+	BlockedInstances int `json:"blocked_instances" yaml:"blocked_instances"`
+
+	// Breakdown of blocked instances in the batch by the reason their migration is blocked
+	BlockedReasons []ReasonInstances `json:"blocked_reasons" yaml:"blocked_reasons"`
+
+	// Total disk size, in bytes, across all instances in the batch
+	// Example: 21474836480
+	TotalDiskSize int64 `json:"total_disk_size" yaml:"total_disk_size"`
+
+	// Total disk size, in bytes, transferred to the target, counted once background import completes
+	// Example: 10737418240
+	MigratedDiskSize int64 `json:"migrated_disk_size" yaml:"migrated_disk_size"`
+
+	// The next upcoming (or currently active) migration window for the batch, nil if none is scheduled
+	NextWindow *BatchWindow `json:"next_window,omitempty" yaml:"next_window,omitempty"`
+}
+
+// BatchWindow provides a high-level summary of a batch's upcoming migration window.
+//
+// swagger:model
+type BatchWindow struct {
+	// A human-friendly name for the migration window
+	// Example: MyWindow
+	Name string `json:"name" yaml:"name"`
+
+	// Time in UTC that the migration window starts
+	Start time.Time `json:"start" yaml:"start"`
+
+	// Time in UTC that the migration window ends
+	End time.Time `json:"end" yaml:"end"`
+}
+
+// SourceSummary provides a high-level summary of a single source.
+//
+// swagger:model
+type SourceSummary struct {
+	// A human-friendly name for the source
+	// Example: MySource
+	Name string `json:"name" yaml:"name"`
+
+	// The connectivity status of the source
+	// Example: OK
+	ConnectivityStatus ExternalConnectivityStatus `json:"connectivity_status" yaml:"connectivity_status"`
+
+	// Number of instances known to migration manager from this source
+	// Example: 20
+	TotalInstances int `json:"total_instances" yaml:"total_instances"`
+
+	// Number of instances from this source whose properties were fully read, plus any already migrated
+	// Example: 15
+	ImportedInstances int `json:"imported_instances" yaml:"imported_instances"`
+
+	// Number of instances from this source that have finished migrating
+	// Example: 5
+	MigratedInstances int `json:"migrated_instances" yaml:"migrated_instances"`
+
+	// Number of instances from this source that cannot be migrated as currently configured
+	// Example: 2
+	IneligibleInstances int `json:"ineligible_instances" yaml:"ineligible_instances"`
+
+	// Breakdown of ineligible instances from this source by the reason they cannot be migrated
+	IneligibleReasons []ReasonInstances `json:"ineligible_reasons" yaml:"ineligible_reasons"`
+
+	// Ineligible instances from this source whose restriction is waived by a batch they are assigned to
+	OverriddenInstances []OverriddenInstance `json:"overridden_instances" yaml:"overridden_instances"`
+
+	// Instances from this source not fully synced because the source was unavailable
+	BlockedImports []InstanceRef `json:"blocked_imports" yaml:"blocked_imports"`
+
+	// Instances from this source not fully synced because it reported an import failure
+	FailedImports []InstanceRef `json:"failed_imports" yaml:"failed_imports"`
+
+	// Instances from this source not fully synced because only some of their properties were reported
+	PartialImports []InstanceRef `json:"partial_imports" yaml:"partial_imports"`
+}
+
+// ReasonInstances groups the instances that share a reason for being ineligible or blocked.
+//
+// swagger:model
+type ReasonInstances struct {
+	// The reason the instances are ineligible or blocked
+	// Example: Unknown OS
+	Reason string `json:"reason" yaml:"reason"`
+
+	// The instances affected by this reason
+	Instances []InstanceRef `json:"instances" yaml:"instances"`
+}
+
+// InstanceRef identifies an instance well enough to display and link to it.
+//
+// swagger:model
+type InstanceRef struct {
+	// The UUID of the instance
+	// Example: 2ed700e6-45ca-4b1a-a1c3-0b0a4dd7b5d5
+	UUID uuid.UUID `json:"uuid" yaml:"uuid"`
+
+	// The inventory path of the instance on its source
+	// Example: /SDDC-Datacenter/vm/MyVM
+	Location string `json:"location" yaml:"location"`
+}
+
+// OverriddenInstance is an ineligible instance whose restriction is waived by one of its batches.
+//
+// swagger:model
+type OverriddenInstance struct {
+	InstanceRef `yaml:",inline"`
+
+	// The name of the batch whose overrides waive the restriction
+	// Example: batch1
+	Batch string `json:"batch" yaml:"batch"`
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ import Settings from "pages/Settings";
 import Source from "pages/Source";
 import SourceCreate from "pages/SourceCreate";
 import SourceDetail from "pages/SourceDetail";
+import Stats from "pages/Stats";
 import Target from "pages/Target";
 import TargetCreate from "pages/TargetCreate";
 import TargetDetail from "pages/TargetDetail";
@@ -55,6 +56,7 @@ function App() {
         >
           <Routes>
             <Route path="/ui" element={<Home />} />
+            <Route path="/ui/stats" element={<Stats />} />
             <Route path="/ui/settings" element={<Settings />} />
             <Route path="/ui/settings/:activeTab" element={<Settings />} />
             <Route path="/ui/settings/:activeTab/add" element={<Settings />} />

--- a/ui/src/api/stats.tsx
+++ b/ui/src/api/stats.tsx
@@ -1,0 +1,10 @@
+import { StatsOverview } from "types/stats";
+
+export const fetchStats = (): Promise<StatsOverview> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/stats`)
+      .then((response) => response.json())
+      .then((data) => resolve(data.metadata))
+      .catch(reject);
+  });
+};

--- a/ui/src/components/StatsBatchLinks.tsx
+++ b/ui/src/components/StatsBatchLinks.tsx
@@ -1,0 +1,23 @@
+import { FC } from "react";
+import { Link } from "react-router";
+import { BatchSummary } from "types/stats";
+
+interface Props {
+  batches: BatchSummary[];
+}
+
+// StatsBatchLinks renders a comma-separated list of links to the given batches.
+const StatsBatchLinks: FC<Props> = ({ batches }) => (
+  <>
+    {batches.map((batch, index) => (
+      <span key={batch.name}>
+        {index > 0 && ", "}
+        <Link to={`/ui/batches/${batch.name}`} className="data-table-link">
+          {batch.name}
+        </Link>
+      </span>
+    ))}
+  </>
+);
+
+export default StatsBatchLinks;

--- a/ui/src/components/StatsBatchListItem.tsx
+++ b/ui/src/components/StatsBatchListItem.tsx
@@ -1,0 +1,101 @@
+import { FC } from "react";
+import { Badge, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { MdWarningAmber } from "react-icons/md";
+import { Link } from "react-router";
+import { BatchSummary } from "types/stats";
+import StatsProgressRow from "components/StatsProgressRow";
+import StatsReasons from "components/StatsReasons";
+import { bytesToHumanReadable } from "util/instance";
+import { batchDisplayStatus, instanceCount, maxWidth } from "util/stats";
+
+interface Props {
+  batch: BatchSummary;
+  index: number;
+}
+
+// StatsBatchListItem renders a numbered batch entry with its status and progress.
+const StatsBatchListItem: FC<Props> = ({ batch, index }) => {
+  const displayStatus = batchDisplayStatus(batch);
+
+  return (
+    <div>
+      <div className="container" style={{ maxWidth }}>
+        <hr className="my-3" style={{ opacity: 0.1 }} />
+      </div>
+      <div className="container mt-3" style={{ maxWidth }}>
+        <div className="d-flex">
+          <div className="text-muted pt-2" style={{ minWidth: "2.5rem" }}>
+            {index + 1}.
+          </div>
+          <div className="flex-grow-1">
+            <div className="row mb-2">
+              <div className="col-4 detail-table-header">Batch</div>
+              <div className="col-8 detail-table-cell">
+                <Link
+                  to={`/ui/batches/${batch.name}`}
+                  className="data-table-link"
+                >
+                  {batch.name}
+                </Link>{" "}
+                <OverlayTrigger
+                  placement="top"
+                  overlay={
+                    <Tooltip id={`tooltip-batch-status-${batch.name}`}>
+                      {displayStatus.tooltip}
+                    </Tooltip>
+                  }
+                >
+                  <Badge bg={displayStatus.variant}>
+                    {displayStatus.label}
+                  </Badge>
+                </OverlayTrigger>
+              </div>
+            </div>
+            <StatsProgressRow
+              header="Migration progress"
+              tooltipId={`tooltip-batch-migration-${batch.name}`}
+              tooltip="Instances in this batch that have finished migrating"
+              now={batch.migrated_instances}
+              max={batch.total_instances}
+              valueLabel={`${instanceCount(batch.migrated_instances, batch.total_instances)} migrated`}
+            />
+            {batch.blocked_instances > 0 && (
+              <StatsProgressRow
+                header={
+                  <>
+                    Instances blocked{" "}
+                    <span className="text-warning">
+                      <MdWarningAmber />
+                    </span>
+                  </>
+                }
+                tooltipId={`tooltip-batch-blocked-${batch.name}`}
+                tooltip="Instances in this batch whose migration is currently blocked"
+                now={batch.blocked_instances}
+                max={batch.total_instances}
+                variant="warning"
+                valueLabel={`${instanceCount(batch.blocked_instances, batch.total_instances)} blocked`}
+                caption={
+                  <StatsReasons
+                    id={`reasons-batch-blocked-${batch.name}`}
+                    reasons={batch.blocked_reasons}
+                  />
+                }
+              />
+            )}
+            <StatsProgressRow
+              header="Disk size"
+              tooltipId={`tooltip-batch-disk-${batch.name}`}
+              tooltip="Disk size migrated so far out of this batch's total disk size"
+              now={batch.migrated_disk_size}
+              max={batch.total_disk_size}
+              valueLabel={`${bytesToHumanReadable(batch.migrated_disk_size)} of ${bytesToHumanReadable(batch.total_disk_size)} transferred`}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatsBatchListItem;

--- a/ui/src/components/StatsBatchOverviewRow.tsx
+++ b/ui/src/components/StatsBatchOverviewRow.tsx
@@ -1,0 +1,68 @@
+import { FC } from "react";
+import { Badge, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { BatchSummary } from "types/stats";
+import StatsBatchLinks from "components/StatsBatchLinks";
+import { BatchStatus } from "util/batch";
+import { formatCountdown } from "util/date";
+import {
+  batchStatusVariant,
+  nextWaitingBatches,
+  nextWindowTooltip,
+  pendingWindowStart,
+  runningBatches,
+} from "util/stats";
+
+interface Props {
+  batches: BatchSummary[];
+}
+
+// StatsBatchOverviewRow summarizes which batches are currently running or about to start.
+const StatsBatchOverviewRow: FC<Props> = ({ batches }) => {
+  const running = runningBatches(batches);
+  const waiting = nextWaitingBatches(batches);
+
+  if (running.length === 0 && waiting.length === 0) {
+    return <div>Idle</div>;
+  }
+
+  const waitingStart = waiting.length > 0 ? pendingWindowStart(waiting[0]) : "";
+
+  return (
+    <>
+      {running.length > 0 && (
+        <div>
+          <StatsBatchLinks batches={running} />{" "}
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip id="tooltip-batches-running">Batch status</Tooltip>
+            }
+          >
+            <Badge bg={batchStatusVariant(BatchStatus.Running)}>
+              {BatchStatus.Running}
+            </Badge>
+          </OverlayTrigger>
+        </div>
+      )}
+      {waiting.length > 0 && (
+        <div>
+          <StatsBatchLinks batches={waiting} />{" "}
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip id="tooltip-batches-next-window">
+                {nextWindowTooltip(waitingStart ?? "")}
+              </Tooltip>
+            }
+          >
+            <Badge bg={batchStatusVariant(BatchStatus.Running)}>
+              Starts in {formatCountdown(waitingStart)}
+            </Badge>
+          </OverlayTrigger>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default StatsBatchOverviewRow;

--- a/ui/src/components/StatsBatchesSummary.tsx
+++ b/ui/src/components/StatsBatchesSummary.tsx
@@ -1,0 +1,75 @@
+import { FC } from "react";
+import { MdWarningAmber } from "react-icons/md";
+import { BatchesOverview } from "types/stats";
+import StatsBatchOverviewRow from "components/StatsBatchOverviewRow";
+import StatsProgressRow from "components/StatsProgressRow";
+import StatsReasons from "components/StatsReasons";
+import { bytesToHumanReadable } from "util/instance";
+import { instanceCount, maxWidth } from "util/stats";
+
+interface Props {
+  batches: BatchesOverview;
+}
+
+const StatsBatchesSummary: FC<Props> = ({ batches }) => {
+  if (batches.items.length === 0) {
+    return (
+      <div className="container" style={{ maxWidth }}>
+        <div className="text-muted">No batches defined</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container" style={{ maxWidth }}>
+      <div className="row">
+        <div className="col-4 detail-table-header">Overview</div>
+        <div className="col-8 detail-table-cell">
+          <StatsBatchOverviewRow batches={batches.items} />
+        </div>
+      </div>
+      <StatsProgressRow
+        header="Overall migration progress"
+        tooltipId="tooltip-batches-migration"
+        tooltip="Instances across all batches that have finished migrating"
+        now={batches.migrated_instances}
+        max={batches.total_instances}
+        valueLabel={`${instanceCount(batches.migrated_instances, batches.total_instances)} migrated`}
+      />
+      {batches.blocked_instances > 0 && (
+        <StatsProgressRow
+          header={
+            <>
+              Total instances blocked{" "}
+              <span className="text-warning">
+                <MdWarningAmber />
+              </span>
+            </>
+          }
+          tooltipId="tooltip-batches-blocked"
+          tooltip="Instances across all batches whose migration is currently blocked"
+          now={batches.blocked_instances}
+          max={batches.total_instances}
+          variant="warning"
+          valueLabel={`${instanceCount(batches.blocked_instances, batches.total_instances)} blocked`}
+          caption={
+            <StatsReasons
+              id="reasons-batches-blocked"
+              reasons={batches.blocked_reasons}
+            />
+          }
+        />
+      )}
+      <StatsProgressRow
+        header="Total disk size"
+        tooltipId="tooltip-batches-disk"
+        tooltip="Disk size migrated so far out of the total disk size across all batches"
+        now={batches.migrated_disk_size}
+        max={batches.total_disk_size}
+        valueLabel={`${bytesToHumanReadable(batches.migrated_disk_size)} of ${bytesToHumanReadable(batches.total_disk_size)} transferred`}
+      />
+    </div>
+  );
+};
+
+export default StatsBatchesSummary;

--- a/ui/src/components/StatsCollapsibleList.tsx
+++ b/ui/src/components/StatsCollapsibleList.tsx
@@ -1,0 +1,49 @@
+import { FC, ReactNode, useState } from "react";
+import { Button, Collapse } from "react-bootstrap";
+import { MdExpandLess, MdExpandMore } from "react-icons/md";
+import { maxWidth } from "util/stats";
+
+interface Props {
+  count: number;
+  singular: string;
+  plural: string;
+  children: ReactNode;
+}
+
+// StatsCollapsibleList renders a "Show N items" toggle above a collapsible list.
+const StatsCollapsibleList: FC<Props> = ({
+  count,
+  singular,
+  plural,
+  children,
+}) => {
+  const [show, setShow] = useState(false);
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="container" style={{ maxWidth }}>
+        <Button
+          variant="link"
+          className="ps-0 mt-2 text-decoration-none"
+          onClick={() => setShow(!show)}
+          aria-expanded={show}
+        >
+          <small>
+            {show ? <MdExpandLess /> : <MdExpandMore />}{" "}
+            {show ? "Hide" : "Show"} {count} {count === 1 ? singular : plural}
+          </small>
+        </Button>
+      </div>
+
+      <Collapse in={show}>
+        <div>{children}</div>
+      </Collapse>
+    </>
+  );
+};
+
+export default StatsCollapsibleList;

--- a/ui/src/components/StatsImportIssueRow.tsx
+++ b/ui/src/components/StatsImportIssueRow.tsx
@@ -1,0 +1,49 @@
+import { FC } from "react";
+import { MdWarningAmber } from "react-icons/md";
+import { InstanceRef } from "types/stats";
+import StatsInstances from "components/StatsInstances";
+import StatsProgressRow from "components/StatsProgressRow";
+import { instanceCount } from "util/stats";
+
+interface Props {
+  id: string;
+  header: string;
+  tooltip: string;
+  instances: InstanceRef[];
+  total: number;
+}
+
+// StatsImportIssueRow renders the instances a single sync warning kept from importing.
+const StatsImportIssueRow: FC<Props> = ({
+  id,
+  header,
+  tooltip,
+  instances,
+  total,
+}) => {
+  if (instances.length === 0) {
+    return null;
+  }
+
+  return (
+    <StatsProgressRow
+      header={
+        <>
+          {header}{" "}
+          <span className="text-warning">
+            <MdWarningAmber />
+          </span>
+        </>
+      }
+      tooltipId={`tooltip-${id}`}
+      tooltip={tooltip}
+      now={instances.length}
+      max={total}
+      variant="warning"
+      valueLabel={instanceCount(instances.length, total)}
+      caption={<StatsInstances id={id} instances={instances} />}
+    />
+  );
+};
+
+export default StatsImportIssueRow;

--- a/ui/src/components/StatsInstances.tsx
+++ b/ui/src/components/StatsInstances.tsx
@@ -1,0 +1,72 @@
+import { FC, useState } from "react";
+import { Button, Collapse } from "react-bootstrap";
+import { MdExpandLess, MdExpandMore } from "react-icons/md";
+import { Link } from "react-router";
+import { InstanceRef, OverriddenInstance } from "types/stats";
+
+interface Props {
+  id: string;
+  instances: (InstanceRef | OverriddenInstance)[];
+}
+
+// StatsInstances renders a "Show N instances" toggle revealing one linked instance per row.
+const StatsInstances: FC<Props> = ({ id, instances }) => {
+  const [show, setShow] = useState(false);
+
+  if (instances.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        variant="link"
+        className="p-0 ms-2 align-baseline text-decoration-none"
+        onClick={() => setShow(!show)}
+        aria-expanded={show}
+        aria-controls={id}
+      >
+        <small>
+          {show ? <MdExpandLess /> : <MdExpandMore />} {show ? "Hide" : "Show"}{" "}
+          {instances.length} instance{instances.length === 1 ? "" : "s"}
+        </small>
+      </Button>
+
+      <Collapse in={show}>
+        <div id={id}>
+          <div className="stats-instance-list">
+            {instances.map((item) => (
+              <div key={item.uuid} className="ms-3">
+                <small>
+                  <Link
+                    to={`/ui/instances/${item.uuid}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="data-table-link"
+                  >
+                    {item.location}
+                  </Link>
+                  {"batch" in item && (
+                    <>
+                      <span className="text-muted"> by </span>
+                      <Link
+                        to={`/ui/batches/${item.batch}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="data-table-link"
+                      >
+                        {item.batch}
+                      </Link>
+                    </>
+                  )}
+                </small>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Collapse>
+    </>
+  );
+};
+
+export default StatsInstances;

--- a/ui/src/components/StatsProgressRow.tsx
+++ b/ui/src/components/StatsProgressRow.tsx
@@ -1,0 +1,49 @@
+import { FC, ReactNode } from "react";
+import { OverlayTrigger, ProgressBar, Tooltip } from "react-bootstrap";
+
+interface Props {
+  header: ReactNode;
+  tooltipId: string;
+  tooltip: ReactNode;
+  now: number;
+  max: number;
+  valueLabel?: ReactNode;
+  caption?: ReactNode;
+  variant?: string;
+}
+
+// StatsProgressRow renders a labelled progress bar row used throughout the stats page.
+const StatsProgressRow: FC<Props> = ({
+  header,
+  tooltipId,
+  tooltip,
+  now,
+  max,
+  valueLabel,
+  caption,
+  variant,
+}) => (
+  <div className="row">
+    <div className="col-4 detail-table-header">{header}</div>
+    <div className="col-8 detail-table-cell">
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id={tooltipId}>{tooltip}</Tooltip>}
+      >
+        <div>
+          <ProgressBar
+            now={now}
+            // Guards against a zero total rendering as a full bar.
+            max={Math.max(1, max)}
+            variant={variant}
+            className="rounded-0"
+          />
+        </div>
+      </OverlayTrigger>
+      {valueLabel && <small className="text-muted">{valueLabel}</small>}
+      {caption}
+    </div>
+  </div>
+);
+
+export default StatsProgressRow;

--- a/ui/src/components/StatsReasons.tsx
+++ b/ui/src/components/StatsReasons.tsx
@@ -1,0 +1,62 @@
+import { FC, useState } from "react";
+import { Button, Collapse } from "react-bootstrap";
+import { MdExpandLess, MdExpandMore, MdInfoOutline } from "react-icons/md";
+import { OverriddenInstance, ReasonInstances } from "types/stats";
+import StatsInstances from "components/StatsInstances";
+
+interface Props {
+  id: string;
+  reasons: ReasonInstances[];
+  overridden?: OverriddenInstance[];
+}
+
+// StatsReasons renders a "Show N reasons" toggle revealing one reason per row.
+const StatsReasons: FC<Props> = ({ id, reasons, overridden }) => {
+  const [show, setShow] = useState(false);
+
+  if (reasons.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        variant="link"
+        className="p-0 ms-2 align-baseline text-decoration-none"
+        onClick={() => setShow(!show)}
+        aria-expanded={show}
+        aria-controls={id}
+      >
+        <small>
+          {show ? <MdExpandLess /> : <MdExpandMore />} {show ? "Hide" : "Show"}{" "}
+          {reasons.length} reason{reasons.length === 1 ? "" : "s"}
+        </small>
+      </Button>
+
+      <Collapse in={show}>
+        <div id={id} className="ms-3">
+          {reasons.map((item) => (
+            <div key={item.reason}>
+              <small className="text-muted">{item.reason}</small>
+              <StatsInstances
+                id={`${id}-${item.reason}`}
+                instances={item.instances}
+              />
+            </div>
+          ))}
+          {overridden && overridden.length > 0 && (
+            <div>
+              <small className="text-muted fst-italic">
+                <MdInfoOutline size="1.15em" className="align-text-bottom" />{" "}
+                Possibly unblocked by batch overrides
+              </small>
+              <StatsInstances id={`${id}-overridden`} instances={overridden} />
+            </div>
+          )}
+        </div>
+      </Collapse>
+    </>
+  );
+};
+
+export default StatsReasons;

--- a/ui/src/components/StatsSourceListItem.tsx
+++ b/ui/src/components/StatsSourceListItem.tsx
@@ -1,0 +1,121 @@
+import { FC } from "react";
+import { Badge, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { MdWarningAmber } from "react-icons/md";
+import { Link } from "react-router";
+import { SourceSummary } from "types/stats";
+import StatsImportIssueRow from "components/StatsImportIssueRow";
+import StatsProgressRow from "components/StatsProgressRow";
+import StatsReasons from "components/StatsReasons";
+import { connectivityStatusVariant, instanceCount, maxWidth } from "util/stats";
+
+interface Props {
+  source: SourceSummary;
+  index: number;
+}
+
+// StatsSourceListItem renders a numbered source entry with its connectivity and progress.
+const StatsSourceListItem: FC<Props> = ({ source, index }) => (
+  <div>
+    <div className="container" style={{ maxWidth }}>
+      <hr className="my-3" style={{ opacity: 0.1 }} />
+    </div>
+    <div className="container mt-3" style={{ maxWidth }}>
+      <div className="d-flex">
+        <div className="text-muted pt-2" style={{ minWidth: "2.5rem" }}>
+          {index + 1}.
+        </div>
+        <div className="flex-grow-1">
+          <div className="row mb-2">
+            <div className="col-4 detail-table-header">Source</div>
+            <div className="col-8 detail-table-cell">
+              <Link
+                to={`/ui/sources/${source.name}`}
+                className="data-table-link"
+              >
+                {source.name}
+              </Link>{" "}
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id={`tooltip-source-status-${source.name}`}>
+                    Connectivity status
+                  </Tooltip>
+                }
+              >
+                <Badge
+                  bg={connectivityStatusVariant(source.connectivity_status)}
+                >
+                  {source.connectivity_status}
+                </Badge>
+              </OverlayTrigger>
+            </div>
+          </div>
+          <StatsProgressRow
+            header="Imported"
+            tooltipId={`tooltip-source-imported-${source.name}`}
+            tooltip="Instances from this source whose properties were fully read, plus any already migrated"
+            now={source.imported_instances}
+            max={source.total_instances}
+            valueLabel={`${instanceCount(source.imported_instances, source.total_instances)} imported`}
+          />
+          <StatsImportIssueRow
+            id={`source-blocked-imports-${source.name}`}
+            header="Blocked from import"
+            tooltip="Instances left unsynced because this source was unavailable"
+            instances={source.blocked_imports}
+            total={source.total_instances}
+          />
+          <StatsImportIssueRow
+            id={`source-failed-imports-${source.name}`}
+            header="Imports failed"
+            tooltip="Instances left unsynced because this source reported an import failure"
+            instances={source.failed_imports}
+            total={source.total_instances}
+          />
+          <StatsImportIssueRow
+            id={`source-partial-imports-${source.name}`}
+            header="Partially imported"
+            tooltip="Instances where this source only reported some of their properties"
+            instances={source.partial_imports}
+            total={source.total_instances}
+          />
+          <StatsProgressRow
+            header="Migrated"
+            tooltipId={`tooltip-source-migrated-${source.name}`}
+            tooltip="Instances from this source that have finished migrating"
+            now={source.migrated_instances}
+            max={source.total_instances}
+            valueLabel={`${instanceCount(source.migrated_instances, source.total_instances)} migrated`}
+          />
+          {source.ineligible_instances > 0 && (
+            <StatsProgressRow
+              header={
+                <>
+                  Blocked from migration{" "}
+                  <span className="text-warning">
+                    <MdWarningAmber />
+                  </span>
+                </>
+              }
+              tooltipId={`tooltip-source-ineligible-${source.name}`}
+              tooltip="Instances from this source that cannot be migrated as currently configured"
+              now={source.ineligible_instances}
+              max={source.total_instances}
+              variant="warning"
+              valueLabel={`${instanceCount(source.ineligible_instances, source.total_instances)} blocked`}
+              caption={
+                <StatsReasons
+                  id={`reasons-source-ineligible-${source.name}`}
+                  reasons={source.ineligible_reasons}
+                  overridden={source.overridden_instances}
+                />
+              }
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default StatsSourceListItem;

--- a/ui/src/components/StatsSourcesSummary.tsx
+++ b/ui/src/components/StatsSourcesSummary.tsx
@@ -1,0 +1,90 @@
+import { FC } from "react";
+import { MdWarningAmber } from "react-icons/md";
+import { SourcesOverview } from "types/stats";
+import StatsImportIssueRow from "components/StatsImportIssueRow";
+import StatsProgressRow from "components/StatsProgressRow";
+import StatsReasons from "components/StatsReasons";
+import { instanceCount, maxWidth } from "util/stats";
+
+interface Props {
+  sources: SourcesOverview;
+}
+
+const StatsSourcesSummary: FC<Props> = ({ sources }) => {
+  if (sources.items.length === 0) {
+    return (
+      <div className="container" style={{ maxWidth }}>
+        <div className="text-muted">No sources defined</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container" style={{ maxWidth }}>
+      <StatsProgressRow
+        header="Total imported"
+        tooltipId="tooltip-instances-imported"
+        tooltip="Instances whose properties were fully read from their source, plus any already migrated"
+        now={sources.imported_instances}
+        max={sources.total_instances}
+        valueLabel={`${instanceCount(sources.imported_instances, sources.total_instances)} imported`}
+      />
+      <StatsImportIssueRow
+        id="instances-blocked-imports"
+        header="Total blocked from import"
+        tooltip="Instances left unsynced because their source was unavailable"
+        instances={sources.blocked_imports}
+        total={sources.total_instances}
+      />
+      <StatsImportIssueRow
+        id="instances-failed-imports"
+        header="Total imports failed"
+        tooltip="Instances left unsynced because their source reported an import failure"
+        instances={sources.failed_imports}
+        total={sources.total_instances}
+      />
+      <StatsImportIssueRow
+        id="instances-partial-imports"
+        header="Total partially imported"
+        tooltip="Instances whose source only reported some of their properties"
+        instances={sources.partial_imports}
+        total={sources.total_instances}
+      />
+      <StatsProgressRow
+        header="Total migrated"
+        tooltipId="tooltip-instances-migrated"
+        tooltip="Instances that have finished migrating"
+        now={sources.migrated_instances}
+        max={sources.total_instances}
+        valueLabel={`${instanceCount(sources.migrated_instances, sources.total_instances)} migrated`}
+      />
+      {sources.ineligible_instances > 0 && (
+        <StatsProgressRow
+          header={
+            <>
+              Total blocked from migration{" "}
+              <span className="text-warning">
+                <MdWarningAmber />
+              </span>
+            </>
+          }
+          tooltipId="tooltip-instances-ineligible"
+          tooltip="Instances that cannot be migrated as currently configured, regardless of any batch"
+          now={sources.ineligible_instances}
+          max={sources.total_instances}
+          variant="warning"
+          valueLabel={`${instanceCount(sources.ineligible_instances, sources.total_instances)} blocked`}
+          caption={
+            <StatsReasons
+              id="reasons-instances-ineligible"
+              reasons={sources.ineligible_reasons}
+              overridden={sources.overridden_instances}
+            />
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+export default StatsSourcesSummary;

--- a/ui/src/css/index.css
+++ b/ui/src/css/index.css
@@ -40,6 +40,20 @@ tr.overview-table-header th {
   background-color: transparent;
 }
 
+.stats-instance-list {
+  overflow-y: auto;
+  max-height: 10rem;
+  scrollbar-color: var(--bs-secondary-color) transparent;
+}
+
+.stats-instance-list::-webkit-scrollbar {
+  background-color: transparent;
+}
+
+.stats-instance-list::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
 .fixed-footer {
   z-index: 10;
 }

--- a/ui/src/css/index.css
+++ b/ui/src/css/index.css
@@ -1,10 +1,10 @@
-@import './dataTable.css';
-@import './keyValueWidget.css';
-@import './sidebar.css';
+@import "./dataTable.css";
+@import "./keyValueWidget.css";
+@import "./sidebar.css";
 @import "./yamlEditor";
 
 body {
-  font-family: 'Inter', sans-serif !important;
+  font-family: "Inter", sans-serif !important;
 }
 
 .detail-table-header {
@@ -29,6 +29,15 @@ tr.overview-table-header th {
   overflow-y: auto;
   min-height: calc(100vh - 100px);
   max-height: calc(100vh - 100px);
+  scrollbar-color: var(--bs-secondary-color) transparent;
+}
+
+.scroll-container::-webkit-scrollbar {
+  background-color: transparent;
+}
+
+.scroll-container::-webkit-scrollbar-track {
+  background-color: transparent;
 }
 
 .fixed-footer {

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -1,8 +1,16 @@
 import { Navigate } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { fetchSources } from "api/sources";
 import { useAuth } from "context/authContext";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
+
+  const { data: sources = [], isLoading } = useQuery({
+    queryKey: ["sources"],
+    queryFn: fetchSources,
+    enabled: isAuthenticated,
+  });
 
   if (!isAuthenticated) {
     return (
@@ -15,7 +23,13 @@ const Home = () => {
     );
   }
 
-  return <Navigate to={`/ui/sources`} replace={true} />;
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Navigate to={sources.length > 0 ? "/ui/stats" : "/ui/sources"} replace />
+  );
 };
 
 export default Home;

--- a/ui/src/pages/Stats.tsx
+++ b/ui/src/pages/Stats.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "react-bootstrap";
+import { fetchStats } from "api/stats";
+import StatsBatchesSummary from "components/StatsBatchesSummary";
+import StatsBatchListItem from "components/StatsBatchListItem";
+import StatsCollapsibleList from "components/StatsCollapsibleList";
+import StatsSourcesSummary from "components/StatsSourcesSummary";
+import StatsSourceListItem from "components/StatsSourceListItem";
+
+const Stats = () => {
+  const refetchInterval = 10000; // 10 seconds
+
+  const {
+    data: stats,
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: ["stats"],
+    queryFn: fetchStats,
+    refetchInterval: refetchInterval,
+  });
+
+  if (isLoading) {
+    return <div>Loading stats...</div>;
+  }
+
+  if (error || !stats) {
+    return <div>Error while loading stats</div>;
+  }
+
+  return (
+    <div className="d-flex flex-column">
+      <div className="mx-2 mx-md-4">
+        <div className="row">
+          <div className="col-12">
+            <Button variant="success" className="float-end invisible">
+              Placeholder
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="scroll-container flex-grow-1 mx-2 mx-md-4 pb-5">
+        <hr />
+
+        <h6 className="mb-3">Sources ({stats.sources.items.length})</h6>
+        <StatsSourcesSummary sources={stats.sources} />
+        <StatsCollapsibleList
+          count={stats.sources.items.length}
+          singular="source"
+          plural="sources"
+        >
+          {stats.sources.items.map((item, index) => (
+            <StatsSourceListItem key={item.name} source={item} index={index} />
+          ))}
+        </StatsCollapsibleList>
+
+        <hr />
+
+        <h6 className="mb-3">Batches ({stats.batches.items.length})</h6>
+        <StatsBatchesSummary batches={stats.batches} />
+        <StatsCollapsibleList
+          count={stats.batches.items.length}
+          singular="batch"
+          plural="batches"
+        >
+          {stats.batches.items.map((item, index) => (
+            <StatsBatchListItem key={item.name} batch={item} index={index} />
+          ))}
+        </StatsCollapsibleList>
+      </div>
+    </div>
+  );
+};
+
+export default Stats;

--- a/ui/src/types/stats.d.ts
+++ b/ui/src/types/stats.d.ts
@@ -1,8 +1,4 @@
-export interface BatchWindow {
-  name: string;
-  start: string;
-  end: string;
-}
+import { MigrationWindow } from "types/batch";
 
 export interface BatchSummary {
   name: string;
@@ -13,7 +9,7 @@ export interface BatchSummary {
   blocked_reasons: ReasonInstances[];
   total_disk_size: number;
   migrated_disk_size: number;
-  next_window?: BatchWindow;
+  next_window?: MigrationWindow;
 }
 
 export interface InstanceRef {

--- a/ui/src/types/stats.d.ts
+++ b/ui/src/types/stats.d.ts
@@ -1,0 +1,73 @@
+export interface BatchWindow {
+  name: string;
+  start: string;
+  end: string;
+}
+
+export interface BatchSummary {
+  name: string;
+  status: string;
+  total_instances: number;
+  migrated_instances: number;
+  blocked_instances: number;
+  blocked_reasons: ReasonInstances[];
+  total_disk_size: number;
+  migrated_disk_size: number;
+  next_window?: BatchWindow;
+}
+
+export interface InstanceRef {
+  uuid: string;
+  location: string;
+}
+
+export interface OverriddenInstance extends InstanceRef {
+  batch: string;
+}
+
+export interface ReasonInstances {
+  reason: string;
+  instances: InstanceRef[];
+}
+
+export interface SourceSummary {
+  name: string;
+  connectivity_status: string;
+  total_instances: number;
+  imported_instances: number;
+  migrated_instances: number;
+  ineligible_instances: number;
+  ineligible_reasons: ReasonInstances[];
+  overridden_instances: OverriddenInstance[];
+  blocked_imports: InstanceRef[];
+  failed_imports: InstanceRef[];
+  partial_imports: InstanceRef[];
+}
+
+export interface SourcesOverview {
+  total_instances: number;
+  imported_instances: number;
+  migrated_instances: number;
+  ineligible_instances: number;
+  ineligible_reasons: ReasonInstances[];
+  overridden_instances: OverriddenInstance[];
+  blocked_imports: InstanceRef[];
+  failed_imports: InstanceRef[];
+  partial_imports: InstanceRef[];
+  items: SourceSummary[];
+}
+
+export interface BatchesOverview {
+  total_instances: number;
+  migrated_instances: number;
+  blocked_instances: number;
+  blocked_reasons: ReasonInstances[];
+  total_disk_size: number;
+  migrated_disk_size: number;
+  items: BatchSummary[];
+}
+
+export interface StatsOverview {
+  sources: SourcesOverview;
+  batches: BatchesOverview;
+}

--- a/ui/src/util/date.ts
+++ b/ui/src/util/date.ts
@@ -14,3 +14,30 @@ export const formatDate = (dateStr: string | undefined): string => {
 
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 };
+
+// formatCountdown returns the duration until the given date, e.g. "2d 3h 15m", or "0m" if it has passed.
+export const formatCountdown = (dateStr: string | undefined): string => {
+  if (!dateStr || dateStr === "0001-01-01T00:00:00Z") {
+    return "";
+  }
+
+  const diffMs = Math.max(0, new Date(dateStr).getTime() - Date.now());
+  const totalMinutes = Math.round(diffMs / 60000);
+
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts = [];
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+
+  if (days > 0 || hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  parts.push(`${minutes}m`);
+
+  return parts.join(" ");
+};

--- a/ui/src/util/stats.ts
+++ b/ui/src/util/stats.ts
@@ -1,0 +1,89 @@
+import { BatchSummary } from "types/stats";
+import { BatchStatus } from "util/batch";
+import { formatCountdown, formatDate } from "util/date";
+import { ExternalConnectivityStatus } from "util/response";
+
+export const maxWidth = "900px";
+
+// instanceCount renders the "x of y instances" prefix shared by the stats progress rows.
+export const instanceCount = (count: number, total: number): string =>
+  `${count} of ${total} instance${total === 1 ? "" : "s"}`;
+
+// batchStatusVariant maps a batch status to a badge color variant.
+export const batchStatusVariant = (status: string): string => {
+  switch (status) {
+    case BatchStatus.Running:
+      return "primary";
+    case BatchStatus.Finished:
+      return "success";
+    case BatchStatus.Error:
+      return "danger";
+    case BatchStatus.Stopped:
+      return "warning";
+    default:
+      return "secondary";
+  }
+};
+
+// connectivityStatusVariant maps a source connectivity status to a badge color variant.
+export const connectivityStatusVariant = (status: string): string =>
+  status === ExternalConnectivityStatus.OK ? "success" : "danger";
+
+// nextWindowTooltip describes when the batch's migration window starts.
+export const nextWindowTooltip = (start: string): string =>
+  `Batch status, migration window starts at ${formatDate(start)}`;
+
+// pendingWindowStart returns when a running batch's migration window begins, if it hasn't already.
+export const pendingWindowStart = (batch: BatchSummary): string | undefined => {
+  const start = batch.next_window?.start;
+  if (batch.status !== BatchStatus.Running || !start) {
+    return undefined;
+  }
+
+  return new Date(start) > new Date() ? start : undefined;
+};
+
+// batchDisplayStatus returns the label, variant and tooltip for a batch, counting down to a pending window.
+export const batchDisplayStatus = (item: BatchSummary) => {
+  const start = pendingWindowStart(item);
+  if (start) {
+    return {
+      label: `Starts in ${formatCountdown(start)}`,
+      variant: batchStatusVariant(BatchStatus.Running),
+      tooltip: nextWindowTooltip(start),
+    };
+  }
+
+  return {
+    label: item.status,
+    variant: batchStatusVariant(item.status),
+    tooltip: "Batch status",
+  };
+};
+
+// runningBatches returns running batches that aren't still waiting on a migration window.
+export const runningBatches = (batches: BatchSummary[]): BatchSummary[] =>
+  batches.filter(
+    (item) => item.status === BatchStatus.Running && !pendingWindowStart(item),
+  );
+
+// nextWaitingBatches returns all batches tied for the soonest upcoming migration window.
+export const nextWaitingBatches = (batches: BatchSummary[]): BatchSummary[] => {
+  const waiting = [];
+  for (const batch of batches) {
+    const start = pendingWindowStart(batch);
+    if (start) {
+      waiting.push({ batch, start: new Date(start).getTime() });
+    }
+  }
+
+  if (waiting.length === 0) {
+    return [];
+  }
+
+  const earliest = Math.min(...waiting.map((item) => item.start));
+
+  return waiting
+    .filter((item) => item.start === earliest)
+    .map((item) => item.batch);
+};


### PR DESCRIPTION
This PR adds the stats page, served by a new `GET /1.0/stats` endpoint.
It provides a high level details of migration sources and batches, and highlights issues that can prevent migrations.

Resolves #553.

### Screenshot

<img width="1050" height="699" alt="image" src="https://github.com/user-attachments/assets/ef286eab-664e-4f33-a307-b1a2a21808e3" />

