### PR TITLE
Openmetrics integration

### DIFF
--- a/cmd/migration-managerd/internal/api/api_1.0.go
+++ b/cmd/migration-managerd/internal/api/api_1.0.go
@@ -32,6 +32,7 @@ var api10 = []APIEndpoint{
 	instancePowerCmd,
 	instanceDumpCmd,
 	instancesCmd,
+	metricsCmd,
 	networkCmd,
 	networkInstancesCmd,
 	networkOverrideCmd,

--- a/cmd/migration-managerd/internal/api/api_metrics.go
+++ b/cmd/migration-managerd/internal/api/api_metrics.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/internal/server/auth"
+	"github.com/FuturFusion/migration-manager/internal/server/metrics"
+	"github.com/FuturFusion/migration-manager/internal/server/response"
+	"github.com/FuturFusion/migration-manager/internal/transaction"
+	"github.com/FuturFusion/migration-manager/internal/util"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+// incusOSMetricsURL is the node exporter shipped with Incus OS.
+const incusOSMetricsURL = "http://127.0.0.1:9100/metrics"
+
+// incusOSMetricsSizeLimit is the maximum amount of Incus OS metrics data we accept.
+const incusOSMetricsSizeLimit = 8 * 1024 * 1024
+
+// startTime is set when the daemon binary starts, and is reported as its uptime.
+var startTime = time.Now()
+
+var metricsCmd = APIEndpoint{
+	Path: "metrics",
+
+	Get: APIEndpointAction{Handler: metricsGet, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanView)},
+}
+
+// swagger:operation GET /1.0/metrics metrics metrics_get
+//
+//	Get metrics
+//
+//	Gets the daemon metrics in the OpenMetrics text format.
+//
+//	---
+//	produces:
+//	  - text/plain
+//	responses:
+//	  "200":
+//	    description: Metrics
+//	    schema:
+//	      type: string
+//	      description: Daemon metrics
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func metricsGet(d *Daemon, r *http.Request) response.Response {
+	ctx := r.Context()
+
+	metricSet := metrics.NewMetricSet()
+
+	err := transaction.Do(ctx, func(ctx context.Context) error {
+		snapshot, err := loadStatsSnapshot(ctx, d)
+		if err != nil {
+			return err
+		}
+
+		addStatsMetrics(metricSet, snapshot)
+
+		return d.addEntityMetrics(ctx, metricSet)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	addRuntimeMetrics(metricSet, time.Since(startTime))
+
+	// On Incus OS, include the metrics of the OS itself.
+	if util.IsIncusOS() {
+		osMetrics, err := getIncusOSMetrics(ctx)
+		if err != nil {
+			slog.Warn("Failed to get Incus OS metrics", slog.Any("error", err))
+		} else {
+			metricSet.AddRaw(osMetrics)
+		}
+	}
+
+	return response.ManualResponse(func(w http.ResponseWriter) error {
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := io.WriteString(w, metricSet.String())
+		return err
+	})
+}
+
+// addStatsMetrics adds the metrics derived from the same overview as the stats endpoint.
+func addStatsMetrics(metricSet *metrics.MetricSet, snapshot *statsSnapshot) {
+	sourceTypes := make(map[string]string, len(snapshot.sources))
+	for _, source := range snapshot.sources {
+		sourceTypes[source.Name] = string(source.SourceType)
+	}
+
+	metrics.AddCounts(metricSet, metrics.Sources, snapshot.sources, func(source migration.Source) metrics.Labels {
+		return metrics.Labels{"type": string(source.SourceType)}
+	})
+
+	metrics.AddCounts(metricSet, metrics.Batches, snapshot.batches, func(batch migration.Batch) metrics.Labels {
+		return metrics.Labels{"status": string(batch.Status)}
+	})
+
+	queueEntries := slices.Collect(maps.Values(snapshot.queueEntryByInstance))
+	metrics.AddCounts(metricSet, metrics.QueueEntries, queueEntries, func(queueEntry migration.QueueEntry) metrics.Labels {
+		return metrics.Labels{"batch": queueEntry.BatchName, "status": string(queueEntry.MigrationStatus)}
+	})
+
+	sources := snapshot.sourcesOverview()
+
+	metricSet.Add(metrics.Instances, float64(sources.TotalInstances), nil)
+
+	for _, source := range sources.Items {
+		labels := metrics.Labels{"source": source.Name}
+
+		metricSet.Add(metrics.SourceInstances, float64(source.TotalInstances), metrics.Labels{"source": source.Name, "type": sourceTypes[source.Name]})
+		metricSet.Add(metrics.SourceImportedInstances, float64(source.ImportedInstances), labels)
+		metricSet.Add(metrics.SourceMigratedInstances, float64(source.MigratedInstances), labels)
+
+		for _, ineligible := range source.IneligibleReasons {
+			metricSet.Add(metrics.SourceIneligibleInstances, float64(len(ineligible.Instances)), metrics.Labels{"source": source.Name, "reason": ineligible.Reason})
+		}
+
+		importIssues := map[string][]api.InstanceRef{
+			"blocked": source.BlockedImports,
+			"failed":  source.FailedImports,
+			"partial": source.PartialImports,
+		}
+
+		for issue, instances := range importIssues {
+			metricSet.Add(metrics.SourceImportIssues, float64(len(instances)), metrics.Labels{"source": source.Name, "issue": issue})
+		}
+	}
+
+	for _, batch := range snapshot.batchesOverview().Items {
+		labels := metrics.Labels{"batch": batch.Name, "status": string(batch.Status)}
+
+		metricSet.Add(metrics.BatchInstances, float64(batch.TotalInstances), labels)
+		metricSet.Add(metrics.BatchMigratedInstances, float64(batch.MigratedInstances), labels)
+		metricSet.Add(metrics.BatchDiskBytes, float64(batch.TotalDiskSize), labels)
+		metricSet.Add(metrics.BatchMigratedDiskBytes, float64(batch.MigratedDiskSize), labels)
+
+		for _, blocked := range batch.BlockedReasons {
+			blockedLabels := maps.Clone(labels)
+			blockedLabels["reason"] = blocked.Reason
+
+			metricSet.Add(metrics.BatchBlockedInstances, float64(len(blocked.Instances)), blockedLabels)
+		}
+	}
+}
+
+// addEntityMetrics adds the metrics for the entities that the stats overview doesn't cover.
+func (d *Daemon) addEntityMetrics(ctx context.Context, metricSet *metrics.MetricSet) error {
+	networks, err := d.network.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get networks: %w", err)
+	}
+
+	metrics.AddCounts(metricSet, metrics.Networks, networks, func(network migration.Network) metrics.Labels {
+		return metrics.Labels{"source": network.Source}
+	})
+
+	targets, err := d.target.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get targets: %w", err)
+	}
+
+	metrics.AddCounts(metricSet, metrics.Targets, targets, func(target migration.Target) metrics.Labels {
+		return metrics.Labels{"type": string(target.TargetType)}
+	})
+
+	warnings, err := d.warning.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get warnings: %w", err)
+	}
+
+	metrics.AddCounts(metricSet, metrics.Warnings, warnings, func(warning migration.Warning) metrics.Labels {
+		return metrics.Labels{"type": string(warning.Type), "status": string(warning.Status)}
+	})
+
+	artifacts, err := d.artifact.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get artifacts: %w", err)
+	}
+
+	metrics.AddCounts(metricSet, metrics.Artifacts, artifacts, func(artifact migration.Artifact) metrics.Labels {
+		return metrics.Labels{"type": string(artifact.Type)}
+	})
+
+	return nil
+}
+
+// addRuntimeMetrics adds the metrics describing the daemon process itself.
+func addRuntimeMetrics(metricSet *metrics.MetricSet, uptime time.Duration) {
+	var memStats runtime.MemStats
+
+	runtime.ReadMemStats(&memStats)
+
+	metricSet.Add(metrics.Uptime, uptime.Seconds(), nil)
+	metricSet.Add(metrics.GoGoroutines, float64(runtime.NumGoroutine()), nil)
+	metricSet.Add(metrics.GoAllocBytes, float64(memStats.Alloc), nil)
+	metricSet.Add(metrics.GoAllocBytesTotal, float64(memStats.TotalAlloc), nil)
+	metricSet.Add(metrics.GoHeapObjects, float64(memStats.HeapObjects), nil)
+	metricSet.Add(metrics.GoSysBytes, float64(memStats.Sys), nil)
+}
+
+// getIncusOSMetrics returns the raw metrics reported by the Incus OS node exporter.
+func getIncusOSMetrics(ctx context.Context) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, incusOSMetricsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected status code %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, incusOSMetricsSizeLimit))
+}

--- a/cmd/migration-managerd/internal/api/api_metrics_test.go
+++ b/cmd/migration-managerd/internal/api/api_metrics_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/FuturFusion/migration-manager/internal/migration"
+	"github.com/FuturFusion/migration-manager/internal/migration/endpoint/mock"
+	"github.com/FuturFusion/migration-manager/shared/api"
+)
+
+func TestMetricsAPI_get(t *testing.T) {
+	d := daemonSetup(t)
+	client, srvURL := startTestDaemon(t, d, []APIEndpoint{metricsCmd}, nil)
+
+	u := uuidCache{}
+
+	_, err := d.source.Create(t.Context(), migration.Source{
+		Name:       "src",
+		SourceType: api.SOURCETYPE_VMWARE,
+		Properties: json.RawMessage(`{"endpoint": "bar", "username":"u", "password":"p"}`),
+		EndpointFunc: func(api.Source) (migration.SourceEndpoint, error) {
+			return &mock.SourceEndpointMock{
+				ConnectFunc: func(ctx context.Context) error { return nil },
+				DoBasicConnectivityCheckFunc: func() (api.ExternalConnectivityStatus, *x509.Certificate) {
+					return api.EXTERNALCONNECTIVITYSTATUS_OK, nil
+				},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	// Instance with a single 1 GiB disk, fully migrated.
+	instA := u.newTestInstance("vm-a", map[int]bool{0: true}, map[int]string{}, api.OSTYPE_LINUX, false)
+	_, err = d.instance.Create(t.Context(), instA)
+	require.NoError(t, err)
+
+	// Manually disabled instance, blocked from migrating.
+	instB := u.newTestInstance("vm-b", map[int]bool{0: true}, map[int]string{}, api.OSTYPE_LINUX, false)
+	instB.Overrides.DisableMigration = true
+	_, err = d.instance.Create(t.Context(), instB)
+	require.NoError(t, err)
+
+	_, err = d.batch.Create(t.Context(), migration.Batch{
+		Name: "b1",
+		Defaults: api.BatchDefaults{
+			Placement: api.BatchPlacement{Target: "default", TargetProject: "default", StoragePool: "default"},
+		},
+		Status:            api.BATCHSTATUS_DEFINED,
+		IncludeExpression: "true",
+		Config: api.BatchConfig{
+			BackgroundSyncInterval:   api.AsDuration(10 * time.Minute),
+			FinalBackgroundSyncLimit: api.AsDuration(10 * time.Minute),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:    instA.UUID,
+		BatchName:       "b1",
+		MigrationStatus: api.MIGRATIONSTATUS_FINISHED,
+		ImportStage:     migration.IMPORTSTAGE_COMPLETE,
+		SecretToken:     uuid.New(),
+		Placement:       api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	_, err = d.queue.CreateEntry(t.Context(), migration.QueueEntry{
+		InstanceUUID:           instB.UUID,
+		BatchName:              "b1",
+		MigrationStatus:        api.MIGRATIONSTATUS_BLOCKED,
+		MigrationStatusMessage: "Instance is disabled",
+		ImportStage:            migration.IMPORTSTAGE_BACKGROUND,
+		SecretToken:            uuid.New(),
+		Placement:              api.Placement{TargetName: "tgt", TargetProject: "default", StoragePools: map[string]string{"root": "default"}, Networks: map[string]api.NetworkPlacement{}},
+	})
+	require.NoError(t, err)
+
+	statusCode, body := probeAPI(t, client, http.MethodGet, srvURL+"/1.0/metrics", nil, nil)
+	require.Equal(t, http.StatusOK, statusCode, "body: %s", body)
+
+	expected := []string{
+		`migration_manager_batches{status="Defined"} 1`,
+		`migration_manager_batch_instances{batch="b1",status="Defined"} 2`,
+		`migration_manager_batch_migrated_instances{batch="b1",status="Defined"} 1`,
+		`migration_manager_batch_blocked_instances{batch="b1",reason="Manually disabled",status="Defined"} 1`,
+		`migration_manager_batch_disk_bytes{batch="b1",status="Defined"} 2.147483648e+09`,
+		`migration_manager_batch_migrated_disk_bytes{batch="b1",status="Defined"} 1.073741824e+09`,
+		`migration_manager_instances 2`,
+		`migration_manager_queue_entries{batch="b1",status="Blocked"} 1`,
+		`migration_manager_queue_entries{batch="b1",status="Finished"} 1`,
+		`migration_manager_sources{type="vmware"} 1`,
+		`migration_manager_source_instances{source="src",type="vmware"} 2`,
+		`migration_manager_source_imported_instances{source="src"} 2`,
+		`migration_manager_source_migrated_instances{source="src"} 1`,
+		`migration_manager_source_ineligible_instances{reason="Manually disabled",source="src"} 1`,
+		`migration_manager_source_import_issues{issue="blocked",source="src"} 0`,
+		"# EOF",
+	}
+
+	for _, line := range expected {
+		require.Contains(t, body, line+"\n")
+	}
+}

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -16,6 +16,7 @@ FuturFusion
 Furo
 github
 GitHub
+goroutines
 GPG
 https
 Incus
@@ -33,6 +34,7 @@ NICs
 NSX
 OIDC
 OpenFGA
+OpenMetrics
 pre
 preseed
 PKCS
@@ -45,6 +47,7 @@ SHA
 Starlark
 TLS
 unstarted
+uptime
 UI
 vCenter
 virtio

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -9,6 +9,7 @@ Sources </reference/sources>
 Targets </reference/targets>
 Settings </reference/settings>
 Events </reference/events>
+Metrics </reference/metrics>
 Artifacts </reference/artifacts>
 Batches </reference/batches>
 Queue </reference/queue>

--- a/doc/reference/metrics.md
+++ b/doc/reference/metrics.md
@@ -1,0 +1,47 @@
+# Metrics
+
+Migration Manager exposes metrics about the daemon and the entities it manages through the `/1.0/metrics` endpoint.
+The metrics are served in the [OpenMetrics](https://openmetrics.io) text format, which can be consumed by Prometheus and compatible scrapers.
+
+The endpoint requires the same authentication as the rest of the API, so the scraper needs either a trusted TLS client certificate or a valid OIDC token.
+
+```bash
+curl -s --cert client.crt --key client.key https://<server>:6443/1.0/metrics
+```
+
+## Available metrics
+
+| Metric | Labels | Description |
+| :--- | :--- | :--- |
+| `migration_manager_artifacts` | `type` | The number of defined artifacts. |
+| `migration_manager_batches` | `status` | The number of defined batches. |
+| `migration_manager_batch_instances` | `batch`, `status` | The number of instances assigned to a batch. |
+| `migration_manager_batch_migrated_instances` | `batch`, `status` | The number of instances of a batch that have been migrated. |
+| `migration_manager_batch_blocked_instances` | `batch`, `status`, `reason` | The number of instances of a batch that are blocked from migrating. |
+| `migration_manager_batch_disk_bytes` | `batch`, `status` | The disk size in bytes of the instances assigned to a batch. |
+| `migration_manager_batch_migrated_disk_bytes` | `batch`, `status` | The disk size in bytes of a batch that has been transferred to the target. |
+| `migration_manager_instances` | | The number of instances known to the daemon. |
+| `migration_manager_networks` | `source` | The number of networks known to the daemon. |
+| `migration_manager_queue_entries` | `batch`, `status` | The number of instances currently in a migration queue. |
+| `migration_manager_sources` | `type` | The number of configured sources. |
+| `migration_manager_source_instances` | `source`, `type` | The number of instances reported by a source. |
+| `migration_manager_source_imported_instances` | `source` | The number of instances of a source that were fully imported by the last sync. |
+| `migration_manager_source_migrated_instances` | `source` | The number of instances of a source that have been migrated. |
+| `migration_manager_source_ineligible_instances` | `source`, `reason` | The number of instances of a source that aren't eligible for migration. |
+| `migration_manager_source_import_issues` | `source`, `issue` | The number of instances of a source affected by an import issue. |
+| `migration_manager_targets` | `type` | The number of configured targets. |
+| `migration_manager_warnings` | `type`, `status` | The number of recorded warnings. |
+| `migration_manager_uptime_seconds` | | The daemon uptime in seconds. |
+| `migration_manager_go_goroutines` | | The number of goroutines that currently exist. |
+| `migration_manager_go_alloc_bytes` | | The number of bytes allocated and still in use. |
+| `migration_manager_go_alloc_bytes_total` | | The total number of bytes allocated, even if freed. |
+| `migration_manager_go_heap_objects` | | The number of allocated objects. |
+| `migration_manager_go_sys_bytes` | | The number of bytes obtained from the system. |
+
+The per-batch and per-source metrics report the same numbers as the [`/1.0/stats`](api.md) endpoint.
+An instance assigned to several batches is counted in each of them, so the per-batch series can add up to more than `migration_manager_instances`.
+
+## Incus OS metrics
+
+When Migration Manager runs on Incus OS, the system metrics reported by the Incus OS node exporter are appended to the output.
+This provides the usual `node_*` metrics for the host, such as CPU, memory, disk and network usage, alongside the Migration Manager metrics.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2741,6 +2741,25 @@ paths:
             summary: Get the instances
             tags:
                 - instances
+    /1.0/metrics:
+        get:
+            description: Gets the daemon metrics in the OpenMetrics text format.
+            operationId: metrics_get
+            produces:
+                - text/plain
+            responses:
+                "200":
+                    description: Metrics
+                    schema:
+                        description: Daemon metrics
+                        type: string
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get metrics
+            tags:
+                - metrics
     /1.0/networks:
         get:
             description: Returns a list of networks (structs).

--- a/internal/server/metrics/catalog.go
+++ b/internal/server/metrics/catalog.go
@@ -1,0 +1,34 @@
+package metrics
+
+const (
+	gauge   = "gauge"
+	counter = "counter"
+)
+
+// The metrics reported by the daemon.
+var (
+	Artifacts                 = Metric{name: "migration_manager_artifacts", kind: gauge, help: "The number of defined artifacts."}
+	Batches                   = Metric{name: "migration_manager_batches", kind: gauge, help: "The number of defined batches."}
+	BatchInstances            = Metric{name: "migration_manager_batch_instances", kind: gauge, help: "The number of instances assigned to a batch."}
+	BatchMigratedInstances    = Metric{name: "migration_manager_batch_migrated_instances", kind: gauge, help: "The number of instances of a batch that have been migrated."}
+	BatchBlockedInstances     = Metric{name: "migration_manager_batch_blocked_instances", kind: gauge, help: "The number of instances of a batch that are blocked from migrating."}
+	BatchDiskBytes            = Metric{name: "migration_manager_batch_disk_bytes", kind: gauge, help: "The disk size in bytes of the instances assigned to a batch."}
+	BatchMigratedDiskBytes    = Metric{name: "migration_manager_batch_migrated_disk_bytes", kind: gauge, help: "The disk size in bytes of a batch that has been transferred to the target."}
+	Instances                 = Metric{name: "migration_manager_instances", kind: gauge, help: "The number of instances known to the daemon."}
+	Networks                  = Metric{name: "migration_manager_networks", kind: gauge, help: "The number of networks known to the daemon."}
+	QueueEntries              = Metric{name: "migration_manager_queue_entries", kind: gauge, help: "The number of instances currently in a migration queue."}
+	Sources                   = Metric{name: "migration_manager_sources", kind: gauge, help: "The number of configured sources."}
+	SourceInstances           = Metric{name: "migration_manager_source_instances", kind: gauge, help: "The number of instances reported by a source."}
+	SourceImportedInstances   = Metric{name: "migration_manager_source_imported_instances", kind: gauge, help: "The number of instances of a source that were fully imported by the last sync."}
+	SourceMigratedInstances   = Metric{name: "migration_manager_source_migrated_instances", kind: gauge, help: "The number of instances of a source that have been migrated."}
+	SourceIneligibleInstances = Metric{name: "migration_manager_source_ineligible_instances", kind: gauge, help: "The number of instances of a source that aren't eligible for migration."}
+	SourceImportIssues        = Metric{name: "migration_manager_source_import_issues", kind: gauge, help: "The number of instances of a source affected by an import issue."}
+	Targets                   = Metric{name: "migration_manager_targets", kind: gauge, help: "The number of configured targets."}
+	Warnings                  = Metric{name: "migration_manager_warnings", kind: gauge, help: "The number of recorded warnings."}
+	Uptime                    = Metric{name: "migration_manager_uptime_seconds", kind: gauge, help: "The daemon uptime in seconds."}
+	GoGoroutines              = Metric{name: "migration_manager_go_goroutines", kind: gauge, help: "The number of goroutines that currently exist."}
+	GoAllocBytes              = Metric{name: "migration_manager_go_alloc_bytes", kind: gauge, help: "The number of bytes allocated and still in use."}
+	GoAllocBytesTotal         = Metric{name: "migration_manager_go_alloc_bytes_total", kind: counter, help: "The total number of bytes allocated, even if freed."}
+	GoHeapObjects             = Metric{name: "migration_manager_go_heap_objects", kind: gauge, help: "The number of allocated objects."}
+	GoSysBytes                = Metric{name: "migration_manager_go_sys_bytes", kind: gauge, help: "The number of bytes obtained from the system."}
+)

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -1,0 +1,120 @@
+// Package metrics renders daemon metrics using the OpenMetrics text format.
+package metrics
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Labels are the label names and values attached to a sample.
+type Labels map[string]string
+
+// Metric describes a metric family.
+type Metric struct {
+	name string
+	kind string
+	help string
+}
+
+type sample struct {
+	labels Labels
+	value  float64
+}
+
+// MetricSet holds the samples to report.
+type MetricSet struct {
+	samples map[Metric][]sample
+	suffix  []byte
+}
+
+// NewMetricSet returns an empty MetricSet.
+func NewMetricSet() *MetricSet {
+	return &MetricSet{samples: map[Metric][]sample{}}
+}
+
+// Add adds a sample of the given metric, with nil labels for a metric that has none.
+func (m *MetricSet) Add(metric Metric, value float64, labels Labels) {
+	m.samples[metric] = append(m.samples[metric], sample{labels: labels, value: value})
+}
+
+// AddCounts adds one sample per distinct label set, counting the items sharing it.
+func AddCounts[T any](metricSet *MetricSet, metric Metric, items []T, labelsOf func(T) Labels) {
+	counts := map[string]float64{}
+	labels := map[string]Labels{}
+
+	for _, item := range items {
+		itemLabels := labelsOf(item)
+		key := formatLabels(itemLabels)
+
+		counts[key]++
+		labels[key] = itemLabels
+	}
+
+	for key, count := range counts {
+		metricSet.Add(metric, count, labels[key])
+	}
+}
+
+// AddRaw appends already formatted metrics to the end of the output.
+func (m *MetricSet) AddRaw(rawData []byte) {
+	if len(rawData) == 0 {
+		return
+	}
+
+	m.suffix = append(m.suffix, rawData...)
+	if m.suffix[len(m.suffix)-1] != '\n' {
+		m.suffix = append(m.suffix, '\n')
+	}
+}
+
+// String renders the MetricSet using the OpenMetrics text format.
+func (m *MetricSet) String() string {
+	var out strings.Builder
+
+	families := slices.SortedFunc(maps.Keys(m.samples), func(a Metric, b Metric) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	for _, metric := range families {
+		fmt.Fprintf(&out, "# HELP %s %s\n", metric.name, metric.help)
+		fmt.Fprintf(&out, "# TYPE %s %s\n", metric.name, metric.kind)
+
+		// Samples are sorted so that repeated scrapes report them in the same order.
+		lines := make([]string, 0, len(m.samples[metric]))
+		for _, sample := range m.samples[metric] {
+			value := strconv.FormatFloat(sample.value, 'g', -1, 64)
+
+			labels := formatLabels(sample.labels)
+			if labels == "" {
+				lines = append(lines, fmt.Sprintf("%s %s\n", metric.name, value))
+				continue
+			}
+
+			lines = append(lines, fmt.Sprintf("%s{%s} %s\n", metric.name, labels, value))
+		}
+
+		slices.Sort(lines)
+		out.WriteString(strings.Join(lines, ""))
+	}
+
+	out.Write(m.suffix)
+	out.WriteString("# EOF\n")
+
+	return out.String()
+}
+
+// formatLabels renders the labels of a sample, sorted by label name.
+func formatLabels(labels Labels) string {
+	entries := make([]string, 0, len(labels))
+	for _, name := range slices.Sorted(maps.Keys(labels)) {
+		entries = append(entries, fmt.Sprintf(`%s="%s"`, name, labelValueEscaper.Replace(labels[name])))
+	}
+
+	return strings.Join(entries, ",")
+}
+
+// labelValueEscaper escapes the characters that can't appear as-is in a label value.
+var labelValueEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)

--- a/internal/server/metrics/metrics_test.go
+++ b/internal/server/metrics/metrics_test.go
@@ -1,0 +1,46 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/FuturFusion/migration-manager/internal/server/metrics"
+)
+
+func TestMetricSetString(t *testing.T) {
+	metricSet := metrics.NewMetricSet()
+	metricSet.Add(metrics.Batches, 2, metrics.Labels{"status": "Running"})
+	metricSet.Add(metrics.Batches, 1, metrics.Labels{"status": `weird "name"`})
+	metricSet.Add(metrics.GoGoroutines, 12, nil)
+	metricSet.AddRaw([]byte("node_boot_time_seconds 1.7e+09"))
+
+	expected := `# HELP migration_manager_batches The number of defined batches.
+# TYPE migration_manager_batches gauge
+migration_manager_batches{status="Running"} 2
+migration_manager_batches{status="weird \"name\""} 1
+# HELP migration_manager_go_goroutines The number of goroutines that currently exist.
+# TYPE migration_manager_go_goroutines gauge
+migration_manager_go_goroutines 12
+node_boot_time_seconds 1.7e+09
+# EOF
+`
+
+	require.Equal(t, expected, metricSet.String())
+}
+
+func TestAddCounts(t *testing.T) {
+	metricSet := metrics.NewMetricSet()
+	metrics.AddCounts(metricSet, metrics.Targets, []string{"incus", "incus", "other"}, func(targetType string) metrics.Labels {
+		return metrics.Labels{"type": targetType}
+	})
+
+	expected := `# HELP migration_manager_targets The number of configured targets.
+# TYPE migration_manager_targets gauge
+migration_manager_targets{type="incus"} 2
+migration_manager_targets{type="other"} 1
+# EOF
+`
+
+	require.Equal(t, expected, metricSet.String())
+}


### PR DESCRIPTION
This PR adds OpenMetrics integration at `/1.0/metrics`.

Resolves #563.

<details>
<summary>Sample response</summary>

```
# HELP migration_manager_artifacts The number of defined artifacts.
# TYPE migration_manager_artifacts gauge
migration_manager_artifacts{type="sdk"} 1
# HELP migration_manager_batch_disk_bytes The disk size in bytes of the instances assigned to a batch.
# TYPE migration_manager_batch_disk_bytes gauge
migration_manager_batch_disk_bytes{batch="fedora",status="Running"} 0
migration_manager_batch_disk_bytes{batch="suse-enterprise",status="Running"} 6.8719476736e+10
migration_manager_batch_disk_bytes{batch="ubuntu",status="Defined"} 0
# HELP migration_manager_batch_instances The number of instances assigned to a batch.
# TYPE migration_manager_batch_instances gauge
migration_manager_batch_instances{batch="fedora",status="Running"} 0
migration_manager_batch_instances{batch="suse-enterprise",status="Running"} 4
migration_manager_batch_instances{batch="ubuntu",status="Defined"} 0
# HELP migration_manager_batch_migrated_disk_bytes The disk size in bytes of a batch that has been transferred to the target.
# TYPE migration_manager_batch_migrated_disk_bytes gauge
migration_manager_batch_migrated_disk_bytes{batch="fedora",status="Running"} 0
migration_manager_batch_migrated_disk_bytes{batch="suse-enterprise",status="Running"} 0
migration_manager_batch_migrated_disk_bytes{batch="ubuntu",status="Defined"} 0
# HELP migration_manager_batch_migrated_instances The number of instances of a batch that have been migrated.
# TYPE migration_manager_batch_migrated_instances gauge
migration_manager_batch_migrated_instances{batch="fedora",status="Running"} 0
migration_manager_batch_migrated_instances{batch="suse-enterprise",status="Running"} 0
migration_manager_batch_migrated_instances{batch="ubuntu",status="Defined"} 0
# HELP migration_manager_batches The number of defined batches.
# TYPE migration_manager_batches gauge
migration_manager_batches{status="Defined"} 1
migration_manager_batches{status="Running"} 2
# HELP migration_manager_go_alloc_bytes The number of bytes allocated and still in use.
# TYPE migration_manager_go_alloc_bytes gauge
migration_manager_go_alloc_bytes 7.529384e+06
# HELP migration_manager_go_alloc_bytes_total The total number of bytes allocated, even if freed.
# TYPE migration_manager_go_alloc_bytes_total counter
migration_manager_go_alloc_bytes_total 1.786542032e+09
# HELP migration_manager_go_goroutines The number of goroutines that currently exist.
# TYPE migration_manager_go_goroutines gauge
migration_manager_go_goroutines 15
# HELP migration_manager_go_heap_objects The number of allocated objects.
# TYPE migration_manager_go_heap_objects gauge
migration_manager_go_heap_objects 63977
# HELP migration_manager_go_sys_bytes The number of bytes obtained from the system.
# TYPE migration_manager_go_sys_bytes gauge
migration_manager_go_sys_bytes 2.7715864e+07
# HELP migration_manager_instances The number of instances known to the daemon.
# TYPE migration_manager_instances gauge
migration_manager_instances 66
# HELP migration_manager_networks The number of networks known to the daemon.
# TYPE migration_manager_networks gauge
migration_manager_networks{source="vcenter"} 1
# HELP migration_manager_queue_entries The number of instances currently in a migration queue.
# TYPE migration_manager_queue_entries gauge
migration_manager_queue_entries{batch="suse-enterprise",status="Waiting"} 4
# HELP migration_manager_source_import_issues The number of instances of a source affected by an import issue.
# TYPE migration_manager_source_import_issues gauge
migration_manager_source_import_issues{issue="blocked",source="vcenter"} 0
migration_manager_source_import_issues{issue="failed",source="vcenter"} 0
migration_manager_source_import_issues{issue="partial",source="vcenter"} 65
# HELP migration_manager_source_imported_instances The number of instances of a source that were fully imported by the last sync.
# TYPE migration_manager_source_imported_instances gauge
migration_manager_source_imported_instances{source="vcenter"} 1
# HELP migration_manager_source_ineligible_instances The number of instances of a source that aren't eligible for migration.
# TYPE migration_manager_source_ineligible_instances gauge
migration_manager_source_ineligible_instances{reason="Unknown IP address",source="vcenter"} 64
migration_manager_source_ineligible_instances{reason="Unknown OS",source="vcenter"} 1
migration_manager_source_ineligible_instances{reason="Verifying background import",source="vcenter"} 1
# HELP migration_manager_source_instances The number of instances reported by a source.
# TYPE migration_manager_source_instances gauge
migration_manager_source_instances{source="vcenter",type="vmware"} 66
# HELP migration_manager_source_migrated_instances The number of instances of a source that have been migrated.
# TYPE migration_manager_source_migrated_instances gauge
migration_manager_source_migrated_instances{source="vcenter"} 0
# HELP migration_manager_sources The number of configured sources.
# TYPE migration_manager_sources gauge
migration_manager_sources{type="vmware"} 1
# HELP migration_manager_targets The number of configured targets.
# TYPE migration_manager_targets gauge
migration_manager_targets{type="incus"} 1
# HELP migration_manager_uptime_seconds The daemon uptime in seconds.
# TYPE migration_manager_uptime_seconds gauge
migration_manager_uptime_seconds 6624.371266749
# HELP migration_manager_warnings The number of recorded warnings.
# TYPE migration_manager_warnings gauge
migration_manager_warnings{status="new",type="Instance migration is restricted"} 1
migration_manager_warnings{status="new",type="Instances partially imported"} 1
migration_manager_warnings{status="new",type="Instances were ignored"} 1
# EOF
```
</details>

<details>
<summary>LLM generated POC dashboard for validation</summary>

https://github.com/user-attachments/assets/877e2956-b10a-405a-9f98-ca07d4b63a2e

</details>
