### PR TITLE
Fix worker source cert

### DIFF
--- a/cmd/migration-manager/internal/cmds/source.go
+++ b/cmd/migration-manager/internal/cmds/source.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"sort"
 	"strconv"
@@ -61,6 +62,7 @@ type cmdSourceAdd struct {
 	global *CmdGlobal
 
 	flagTrustedServerCertificateFingerprint string
+	flagTrustedCAFile                       string
 }
 
 func (c *cmdSourceAdd) Command() *cobra.Command {
@@ -79,6 +81,7 @@ func (c *cmdSourceAdd) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 	cmd.Flags().StringVar(&c.flagTrustedServerCertificateFingerprint, "trusted-cert-fingerprint", "", "Trusted SHA256 fingerprint of the source's TLS certificate")
+	cmd.Flags().StringVar(&c.flagTrustedCAFile, "trusted-ca-file", "", "Path to a PEM encoded CA certificate bundle used to verify the source's TLS certificate")
 
 	return cmd
 }
@@ -106,6 +109,11 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 	} else {
 		sourceName = args[0]
 		sourceEndpoint = args[1]
+	}
+
+	caCertificates, err := readCACertificates(c.flagTrustedCAFile)
+	if err != nil {
+		return err
 	}
 
 	// Add the source.
@@ -159,6 +167,7 @@ func (c *cmdSourceAdd) Run(cmd *cobra.Command, args []string) error {
 		vmwareProperties := api.VMwareProperties{
 			Endpoint:                            sourceEndpoint,
 			TrustedServerCertificateFingerprint: c.flagTrustedServerCertificateFingerprint,
+			TrustedServerCACertificates:         caCertificates,
 			Username:                            sourceUsername,
 			Password:                            sourcePassword,
 			ImportLimit:                         int(importLimit),
@@ -320,6 +329,8 @@ func (c *cmdSourceRemove) Run(cmd *cobra.Command, args []string) error {
 // Update the source.
 type cmdSourceUpdate struct {
 	global *CmdGlobal
+
+	flagTrustedCAFile string
 }
 
 func (c *cmdSourceUpdate) Command() *cobra.Command {
@@ -331,6 +342,7 @@ func (c *cmdSourceUpdate) Command() *cobra.Command {
 `
 
 	cmd.RunE = c.Run
+	cmd.Flags().StringVar(&c.flagTrustedCAFile, "trusted-ca-file", "", "Path to a PEM encoded CA certificate bundle used to verify the source's TLS certificate")
 
 	return cmd
 }
@@ -446,6 +458,13 @@ func (c *cmdSourceUpdate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if cmd.Flags().Changed("trusted-ca-file") {
+			vmwareProperties.TrustedServerCACertificates, err = readCACertificates(c.flagTrustedCAFile)
+			if err != nil {
+				return err
+			}
+		}
+
 		src.Properties, err = json.Marshal(vmwareProperties)
 		if err != nil {
 			return err
@@ -484,4 +503,18 @@ func (c *cmdSourceUpdate) Run(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Successfully updated source %q.\n", newSourceName)
 
 	return nil
+}
+
+// readCACertificates reads a PEM encoded CA certificate bundle from the given path.
+func readCACertificates(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read CA certificate file %q: %w", path, err)
+	}
+
+	return []string{string(contents)}, nil
 }

--- a/cmd/migration-managerd/internal/api/api_worker.go
+++ b/cmd/migration-managerd/internal/api/api_worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/FuturFusion/migration-manager/internal/server/response"
 	"github.com/FuturFusion/migration-manager/internal/source"
 	"github.com/FuturFusion/migration-manager/internal/transaction"
+	"github.com/FuturFusion/migration-manager/internal/util"
 	"github.com/FuturFusion/migration-manager/shared/api"
 	"github.com/FuturFusion/migration-manager/shared/api/event"
 )
@@ -126,6 +127,12 @@ func workerCommandPost(d *Daemon, r *http.Request) response.Response {
 
 		return nil
 	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Include any system level CA certificates so the worker can verify the source's TLS certificate.
+	err = workerCommand.Source.AddCACertificates(util.SystemCACertificates())
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/doc/reference/sources/vmware.md
+++ b/doc/reference/sources/vmware.md
@@ -114,3 +114,17 @@ They are applied to migrated instances as `user.sdn.tags.{index}.{scope}={tag}` 
 All data imported from sources will be updated every 10 minutes by default. This can be configured in [system settings](../settings.md).
 
 Once an instance is assigned to a batch, its syncing will be halted unless that instance is restricted from migration (such as missing guest-agent data or being powered off).
+
+## TLS certificate trust
+
+Migration Manager verifies the TLS certificate presented by a source against the system trust store.
+If the source uses a certificate that isn't trusted by default, either:
+
+* Confirm the certificate fingerprint when adding the source, which pins that exact certificate, or
+* Provide the issuing CA with `migration-manager source add --trusted-ca-file <file>` or `migration-manager source update --trusted-ca-file <file>`.
+
+When Migration Manager runs on Incus OS, the CA certificates configured at the Incus OS system security
+level are trusted as well, without any additional source configuration.
+
+Both the pinned certificate and the CA certificates are passed on to the migration worker, which doesn't
+share the trust store of the system Migration Manager runs on.

--- a/internal/migration/source_model.go
+++ b/internal/migration/source_model.go
@@ -171,6 +171,12 @@ func (s Source) validateSourceTypeVMware() error {
 		return NewValidationErrf("Invalid source, specified datacenter must not be empty")
 	}
 
+	for i, caCertificate := range properties.TrustedServerCACertificates {
+		if !x509.NewCertPool().AppendCertsFromPEM([]byte(caCertificate)) {
+			return NewValidationErrf("Invalid source, trusted CA certificate at index %d is not a valid PEM encoded certificate", i)
+		}
+	}
+
 	return nil
 }
 
@@ -260,6 +266,39 @@ func (s *Source) SetServerCertificate(cert *x509.Certificate) {
 		properties.ServerCertificate = cert.Raw
 		s.Properties, _ = json.Marshal(properties)
 	}
+}
+
+// AddCACertificates records the given PEM encoded CA certificates in the source properties, so that
+// consumers of those properties without access to the local system configuration can use them too.
+func (s *Source) AddCACertificates(caCertificates []string) error {
+	if len(caCertificates) == 0 {
+		return nil
+	}
+
+	switch s.SourceType {
+	case api.SOURCETYPE_NSX_T:
+		properties, err := s.GetNSXProperties()
+		if err != nil {
+			return err
+		}
+
+		properties.TrustedServerCACertificates = append(properties.TrustedServerCACertificates, caCertificates...)
+		s.Properties, err = json.Marshal(properties)
+
+		return err
+	case api.SOURCETYPE_VMWARE:
+		properties, err := s.GetVMwareProperties()
+		if err != nil {
+			return err
+		}
+
+		properties.TrustedServerCACertificates = append(properties.TrustedServerCACertificates, caCertificates...)
+		s.Properties, err = json.Marshal(properties)
+
+		return err
+	}
+
+	return nil
 }
 
 type Sources []Source

--- a/internal/migration/source_service_test.go
+++ b/internal/migration/source_service_test.go
@@ -225,6 +225,26 @@ func TestSourceService_Create(t *testing.T) {
 			},
 		},
 		{
+			name: "error - VMware invalid trusted CA certificate",
+			source: migration.Source{
+				ID:         1,
+				Name:       "one",
+				SourceType: api.SOURCETYPE_VMWARE,
+				Properties: json.RawMessage(`{
+  "endpoint": "enpoint.url",
+  "username": "user",
+  "password": "pass",
+  "trusted_server_ca_certificates": ["not a certificate"]
+}
+`),
+			},
+
+			assertErr: func(tt require.TestingT, err error, a ...any) {
+				var verr migration.ErrValidation
+				require.ErrorAs(tt, err, &verr, a...)
+			},
+		},
+		{
 			name: "error - repo",
 			source: migration.Source{
 				ID:         1,

--- a/internal/source/nsx.go
+++ b/internal/source/nsx.go
@@ -3,7 +3,6 @@ package source
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -57,6 +56,8 @@ func NewInternalNSXSourceFrom(apiSource api.Source) (*InternalNSXSource, error) 
 		return nil, err
 	}
 
+	connProperties.TrustedServerCACertificates = append(connProperties.TrustedServerCACertificates, util.SystemCACertificates()...)
+
 	return &InternalNSXSource{
 		InternalSource: InternalSource{
 			Source: apiSource,
@@ -97,8 +98,10 @@ func (s *InternalNSXSource) Connect(ctx context.Context) error {
 		serverCert = nil
 	}
 
-	tlsConfig := &tls.Config{}
-	incusTLS.TLSConfigWithTrustedCert(tlsConfig, serverCert)
+	tlsConfig, err := util.TLSClientConfig(serverCert, s.TrustedServerCACertificates)
+	if err != nil {
+		return err
+	}
 
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	s.c = &http.Client{Transport: transport}
@@ -163,7 +166,7 @@ func (s *InternalNSXSource) DoBasicConnectivityCheck() (api.ExternalConnectivity
 		return api.EXTERNALCONNECTIVITYSTATUS_AUTH_ERROR, nil
 	}
 
-	status, cert := util.DoBasicConnectivityCheck(s.Endpoint, s.TrustedServerCertificateFingerprint)
+	status, cert := util.DoBasicConnectivityCheck(s.Endpoint, s.TrustedServerCertificateFingerprint, s.TrustedServerCACertificates)
 	if cert != nil && s.ServerCertificate == nil {
 		// We got an untrusted certificate; if one hasn't already been set, add it to this source.
 		s.ServerCertificate = cert.Raw

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -71,6 +71,7 @@ func newInternalVMwareSourceFrom(apiSource api.Source) (*InternalVMwareSource, e
 	}
 
 	connProperties.SetDefaults()
+	connProperties.TrustedServerCACertificates = append(connProperties.TrustedServerCACertificates, util.SystemCACertificates()...)
 
 	return &InternalVMwareSource{
 		InternalSource: InternalSource{
@@ -113,7 +114,12 @@ func (s *InternalVMwareSource) Connect(ctx context.Context) error {
 		serverCert = nil
 	}
 
-	s.govmomiClient, err = soapWithKeepalive(ctx, endpointURL, serverCert)
+	tlsConfig, err := util.TLSClientConfig(serverCert, s.TrustedServerCACertificates)
+	if err != nil {
+		return err
+	}
+
+	s.govmomiClient, err = soapWithKeepalive(ctx, endpointURL, tlsConfig)
 	if err != nil {
 		return err
 	}
@@ -133,7 +139,7 @@ func (s *InternalVMwareSource) Connect(ctx context.Context) error {
 }
 
 func (s *InternalVMwareSource) DoBasicConnectivityCheck() (api.ExternalConnectivityStatus, *x509.Certificate) {
-	status, cert := util.DoBasicConnectivityCheck(s.Endpoint, s.TrustedServerCertificateFingerprint)
+	status, cert := util.DoBasicConnectivityCheck(s.Endpoint, s.TrustedServerCertificateFingerprint, s.TrustedServerCACertificates)
 	if cert != nil && s.ServerCertificate == nil {
 		// We got an untrusted certificate; if one hasn't already been set, add it to this source.
 		s.ServerCertificate = cert.Raw

--- a/internal/source/vsphere.go
+++ b/internal/source/vsphere.go
@@ -11,12 +11,10 @@ package source
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net/url"
 	"time"
 
-	incusTLS "github.com/lxc/incus/v7/shared/tls"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/session/keepalive"
@@ -27,10 +25,8 @@ import (
 
 const keepaliveInterval = 5 * time.Minute // vCenter APIs keep-alive
 
-func soapWithKeepalive(ctx context.Context, clientURL *url.URL, additionalRootCert *x509.Certificate) (*govmomi.Client, error) {
+func soapWithKeepalive(ctx context.Context, clientURL *url.URL, tlsConfig *tls.Config) (*govmomi.Client, error) {
 	soapClient := soap.NewClient(clientURL, false)
-	tlsConfig := &tls.Config{}
-	incusTLS.TLSConfigWithTrustedCert(tlsConfig, additionalRootCert)
 	soapClient.DefaultTransport().TLSClientConfig = tlsConfig
 
 	vimClient, err := vim25.NewClient(ctx, soapClient)

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -166,7 +166,7 @@ func (t *InternalIncusTarget) client(ctx context.Context) (*incus.ConnectionArgs
 }
 
 func (t *InternalIncusTarget) DoBasicConnectivityCheck() (api.ExternalConnectivityStatus, *x509.Certificate) {
-	status, cert := util.DoBasicConnectivityCheck(t.Endpoint, t.TrustedServerCertificateFingerprint)
+	status, cert := util.DoBasicConnectivityCheck(t.Endpoint, t.TrustedServerCertificateFingerprint, nil)
 	if cert != nil && t.ServerCertificate == nil {
 		// We got an untrusted certificate; if one hasn't already been set, add it to this target.
 		t.ServerCertificate = cert.Raw

--- a/internal/util/connectivity.go
+++ b/internal/util/connectivity.go
@@ -12,10 +12,19 @@ import (
 	"github.com/FuturFusion/migration-manager/shared/api"
 )
 
-func DoBasicConnectivityCheck(endpoint string, trustedCertFingerprint string) (api.ExternalConnectivityStatus, *x509.Certificate) {
+func DoBasicConnectivityCheck(endpoint string, trustedCertFingerprint string, caCertificates []string) (api.ExternalConnectivityStatus, *x509.Certificate) {
+	tlsConfig, err := TLSClientConfig(nil, caCertificates)
+	if err != nil {
+		return api.EXTERNALCONNECTIVITYSTATUS_TLS_ERROR, nil
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
 	// Do a basic connectivity test.
 	client := &http.Client{
-		Timeout: 3 * time.Second, // Timeout quickly if we cannot connect to the endpoint.
+		Timeout:   3 * time.Second, // Timeout quickly if we cannot connect to the endpoint.
+		Transport: transport,
 	}
 
 	resp, err := client.Get(endpoint)

--- a/internal/util/incusos.go
+++ b/internal/util/incusos.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	incusOSAPI "github.com/lxc/incus-os/incus-osd/api"
+	incusAPI "github.com/lxc/incus/v7/shared/api"
+)
+
+// incusOSTimeout is the maximum time to wait for a response from the Incus OS API.
+const incusOSTimeout = 5 * time.Second
+
+// incusOSResponseSizeLimit is the maximum amount of Incus OS response data we accept.
+const incusOSResponseSizeLimit = 1024 * 1024
+
+// incusOSCACertificatesTTL is how long the CA certificates fetched from Incus OS remain valid.
+const incusOSCACertificatesTTL = time.Minute
+
+var incusOSCACertificates struct {
+	mu      sync.Mutex
+	certs   []string
+	expires time.Time
+}
+
+// SystemCACertificates returns the PEM encoded CA certificates trusted at the system level, which
+// aren't part of our own trust store. Currently this only covers the custom CA certificates
+// configured in Incus OS, so nothing is returned when we aren't running on Incus OS.
+func SystemCACertificates() []string {
+	if !IsIncusOS() {
+		return nil
+	}
+
+	incusOSCACertificates.mu.Lock()
+	defer incusOSCACertificates.mu.Unlock()
+
+	if time.Now().Before(incusOSCACertificates.expires) {
+		return slices.Clone(incusOSCACertificates.certs)
+	}
+
+	certs, err := fetchIncusOSCACertificates()
+	if err != nil {
+		// Keep using the certificates we last fetched, if any, but don't retry until the next interval.
+		slog.Warn("Failed to fetch CA certificates from Incus OS", slog.Any("err", err))
+	} else {
+		incusOSCACertificates.certs = certs
+	}
+
+	incusOSCACertificates.expires = time.Now().Add(incusOSCACertificatesTTL)
+
+	return slices.Clone(incusOSCACertificates.certs)
+}
+
+// fetchIncusOSCACertificates queries the Incus OS security API over its unix socket.
+func fetchIncusOSCACertificates() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), incusOSTimeout)
+	defer cancel()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _ string, _ string) (net.Conn, error) {
+				var d net.Dialer
+
+				return d.DialContext(ctx, "unix", IncusOSSocket)
+			},
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://incus-os/1.0/system/security", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Incus OS returned %q when fetching the system security configuration", resp.Status)
+	}
+
+	var apiResp incusAPI.Response
+
+	err = json.NewDecoder(io.LimitReader(resp.Body, incusOSResponseSizeLimit)).Decode(&apiResp)
+	if err != nil {
+		return nil, err
+	}
+
+	var security incusOSAPI.SystemSecurity
+
+	err = apiResp.MetadataAsStruct(&security)
+	if err != nil {
+		return nil, err
+	}
+
+	return security.Config.CustomCACerts, nil
+}

--- a/internal/util/tls.go
+++ b/internal/util/tls.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	incusTLS "github.com/lxc/incus/v7/shared/tls"
+)
+
+// TLSClientConfig returns a TLS configuration for outgoing connections, trusting the system
+// certificates, the given PEM encoded CA certificates and, if set, the pinned server certificate.
+func TLSClientConfig(serverCert *x509.Certificate, caCertificates []string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	incusTLS.TLSConfigWithTrustedCert(tlsConfig, serverCert)
+
+	if len(caCertificates) == 0 {
+		return tlsConfig, nil
+	}
+
+	if tlsConfig.RootCAs == nil {
+		tlsConfig.RootCAs = x509.NewCertPool()
+	} else {
+		// Don't modify a potentially shared certificate pool.
+		tlsConfig.RootCAs = tlsConfig.RootCAs.Clone()
+	}
+
+	for i, caCert := range caCertificates {
+		if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(caCert)) {
+			return nil, fmt.Errorf("Failed to parse PEM encoded CA certificate at index %d", i)
+		}
+	}
+
+	return tlsConfig, nil
+}

--- a/internal/util/tls_test.go
+++ b/internal/util/tls_test.go
@@ -1,0 +1,87 @@
+package util_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/FuturFusion/migration-manager/internal/util"
+)
+
+func TestTLSClientConfig(t *testing.T) {
+	caPEM, caCert := generateCACertificate(t)
+
+	tests := []struct {
+		name           string
+		caCertificates []string
+		assertErr      require.ErrorAssertionFunc
+		wantTrusted    bool
+	}{
+		{
+			name:      "no CA certificates",
+			assertErr: require.NoError,
+		},
+		{
+			name:           "valid CA certificate",
+			caCertificates: []string{caPEM},
+			assertErr:      require.NoError,
+			wantTrusted:    true,
+		},
+		{
+			name:           "invalid CA certificate",
+			caCertificates: []string{"not a certificate"},
+			assertErr:      require.Error,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tlsConfig, err := util.TLSClientConfig(nil, tc.caCertificates)
+			tc.assertErr(t, err)
+
+			if err != nil {
+				return
+			}
+
+			_, err = caCert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
+			if tc.wantTrusted {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func generateCACertificate(t *testing.T) (string, *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Migration Manager Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), cert
+}

--- a/shared/api/source.go
+++ b/shared/api/source.go
@@ -64,6 +64,9 @@ type VMwareProperties struct {
 	// Example: b51b3046a03164a2ca279222744b12fe0878a8c12311c88fad427f4e03eca42d
 	TrustedServerCertificateFingerprint string `json:"trusted_server_certificate_fingerprint,omitempty" yaml:"trusted_server_certificate_fingerprint,omitempty"`
 
+	// PEM encoded CA certificates to trust in addition to the system ones. Useful when the source uses a certificate issued by an internal CA.
+	TrustedServerCACertificates []string `json:"trusted_server_ca_certificates,omitempty" yaml:"trusted_server_ca_certificates,omitempty"`
+
 	// Username to authenticate against the endpoint
 	// Example: admin
 	Username string `json:"username" yaml:"username"`


### PR DESCRIPTION
Currently, workers fail to connect to sources using a certificate issued by an internal CA.

```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

This PR addresses the issue with the following.

- Added a `trusted_server_ca_certificates` property to sources, which is used to pass the CA certficates to the worker.
- Picks up the CA certificates configured at the Incus OS system security level automatically.
- Added `migration-manager source add|update --trusted-ca-file` for deployments that aren't running on Incus OS.