### PR TITLE
Change data format for vCenter VM tags

### DIFF
--- a/doc/reference/filters.md
+++ b/doc/reference/filters.md
@@ -30,8 +30,9 @@ Migration Manager has the following extended functions:
 | `hasPrefix(os, 'Windows')`                                             | Match the instances whose `os` starts with `Windows`                                                                        |
 | `path_base(location) == 'ubuntu2404' and source == 'esxi01'`           | Match the instances whose `location` path has the final segment `ubuntu2404`, from the source `esxi01`                      |
 | `config['key'] == 'value'`                                             | Match the instances whose `config` key-value pairs contain `value` for the key `key`                                        |
-| `len(split(config['tags.mycategory'], ',')) == 3`                      | Match the instances where that have 3 tags in category `mycategory`                                                         |
-| `any(split(config['tags.mycategory'], ','), # == 'tag1')`              | Match the instances that have the tag `tag1` under `mycategory`                                                             |
+| `len(filter(tags, .category == 'mycategory')) == 3`                    | Match the instances where that have 3 tags in category `mycategory`                                                         |
+| `any(tags, .category == 'mycategory' and .tag == 'tag1')`              | Match the instances that have the tag `tag1` under `mycategory`                                                             |
+| `any(tags, .tag == 'tag1')`                                            | Match the instances that have the tag `tag1` under any category                                                             |
 | `has_tag('mycategory', 'tag1')`                                        | Match the instances that have the tag `tag1` under `mycategory`                                                             |
 | `matches_tag('mycategory', 'mytag')`                                   | Match the instances that have any tag under `mycategory` that contain the text `mytag`                                      |
 | `has_tag('*', 'tag1')`                                                 | Match the instances that have the tag `tag1` under any category                                                             |

--- a/doc/reference/sources/vmware.md
+++ b/doc/reference/sources/vmware.md
@@ -92,7 +92,7 @@ By default, migrations will expect the same network name to be present on the mi
 
 All of the properties available for ESXi sources are also available for vCenter sources, with some additions:
 
-* Tags (Imported as key-value config with the prefix `tag.`)
+* Tags (Imported as the `tags` instance property, and applied to migrated instances as `user.tags.{index}.{category}={tag}` config keys)
 * Resource pools (Imported as key-value config with the prefix `vmware.resource_pool.`)
 * NSX manager sources will be auto-imported by their IP addresses. Credentials will not be assigned by default.
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -537,6 +537,12 @@ definitions:
                 x-go-name: SourceSpecificID
             source_type:
                 $ref: '#/definitions/SourceType'
+            tags:
+                description: List of tags applied to the Instance on its source.
+                items:
+                    $ref: '#/definitions/InstancePropertiesTag'
+                type: array
+                x-go-name: Tags
             tpm:
                 description: Whether the Instance has a TPM.
                 example: true
@@ -728,6 +734,12 @@ definitions:
                 example: vm-123 (vmware)
                 type: string
                 x-go-name: SourceSpecificID
+            tags:
+                description: List of tags applied to the Instance on its source.
+                items:
+                    $ref: '#/definitions/InstancePropertiesTag'
+                type: array
+                x-go-name: Tags
             tpm:
                 description: Whether the Instance has a TPM.
                 example: true
@@ -865,6 +877,21 @@ definitions:
                 type: string
                 x-go-name: Name
         title: InstancePropertiesSnapshot are all properties supported by snapshots.
+        type: object
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    InstancePropertiesTag:
+        properties:
+            category:
+                description: Category of the tag, empty if the tag has none.
+                example: environment
+                type: string
+                x-go-name: Category
+            tag:
+                description: Value of the tag.
+                example: production
+                type: string
+                x-go-name: Tag
+        title: InstancePropertiesTag are all properties supported by source tags.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
     InstanceRef:

--- a/doc/tutorials/migrate_vcenter.md
+++ b/doc/tutorials/migrate_vcenter.md
@@ -68,7 +68,7 @@ Without change tracking, migrations cannot occur with running VMs, prolonging do
 
 On top of the default properties imported from ESXi sources, Migration Manager supports tags, resource pools, and folder structure from vCenter:
 
-- Tags are available as config keys, prefixed with `tag.<category>` with tags as comma-separated values
+- Tags are available as the `tags` property, as a list of `category` and `tag` pairs
 - Resource pools are available as config keys, prefixed with `vmware.resource_pool` with the resource pool name as the value
 - Folder structure is included in the `location` path identifying the instance
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -116,5 +116,5 @@ CREATE TABLE warnings (
     UNIQUE (type, scope, entity_type, entity)
 	);
 
-INSERT INTO schema (version, updated_at) VALUES (19, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (20, strftime("%s"))
 `

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -3,9 +3,12 @@
 package db
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -80,6 +83,108 @@ var updates = map[int]schema.Update{
 	17: updateFromV16,
 	18: updateFromV17,
 	19: updateFromV18,
+	20: updateFromV19,
+}
+
+// updateFromV19 converts the legacy `tag.<category>` instance config keys into the `tags` property.
+//
+// For example, an instance whose properties are:
+//
+//	{"config": {"tag.env": "prod,staging", "vmware.resource_pool": "pool"}}
+//
+// becomes:
+//
+//	{"config": {"vmware.resource_pool": "pool"}, "tags": [{"category": "env", "tag": "prod"}, {"category": "env", "tag": "staging"}]}
+func updateFromV19(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id, properties FROM instances;`)
+	if err != nil {
+		return err
+	}
+
+	propertiesByID := map[int]string{}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int
+		var props string
+		err := rows.Scan(&id, &props)
+		if err != nil {
+			return err
+		}
+
+		propertiesByID[id] = props
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return err
+	}
+
+	err = rows.Close()
+	if err != nil {
+		return err
+	}
+
+	for id, props := range propertiesByID {
+		var instProps map[string]any
+		err := json.Unmarshal([]byte(props), &instProps)
+		if err != nil {
+			return err
+		}
+
+		config, ok := instProps["config"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		legacyKeys := []string{}
+		tags := []api.InstancePropertiesTag{}
+		for key, value := range config {
+			if !strings.HasPrefix(key, "tag.") {
+				continue
+			}
+
+			legacyKeys = append(legacyKeys, key)
+
+			tagList, ok := value.(string)
+			if !ok {
+				continue
+			}
+
+			for _, tag := range strings.Split(tagList, ",") {
+				if tag == "" {
+					continue
+				}
+
+				tags = append(tags, api.InstancePropertiesTag{Category: strings.TrimPrefix(key, "tag."), Tag: tag})
+			}
+		}
+
+		if len(legacyKeys) == 0 {
+			continue
+		}
+
+		// Match the order the next sync produces, to avoid recording a spurious update.
+		slices.SortFunc(tags, func(a api.InstancePropertiesTag, b api.InstancePropertiesTag) int {
+			return cmp.Or(cmp.Compare(a.Category, b.Category), cmp.Compare(a.Tag, b.Tag))
+		})
+
+		for _, key := range legacyKeys {
+			delete(config, key)
+		}
+
+		instProps["tags"] = tags
+		b, err := json.Marshal(instProps)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `UPDATE instances SET properties = ? WHERE id = ?;`, string(b), id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func updateFromV18(ctx context.Context, tx *sql.Tx) error {

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -181,25 +181,46 @@ func (i Instance) DisabledReason(overrides api.InstanceRestrictionOverride) erro
 	return nil
 }
 
-// SDNTagsKeyPrefix is the instance config key prefix used for SDN tags on the target.
-const SDNTagsKeyPrefix = "user.sdn.tags"
+const (
+	// SDNTagsKeyPrefix is the instance config key prefix used for SDN tags on the target.
+	SDNTagsKeyPrefix = "user.sdn.tags"
+	// TagsKeyPrefix is the instance config key prefix used for source tags on the target.
+	TagsKeyPrefix = "user.tags"
+)
 
-// SDNTagConfig returns the instance's SDN tags as `user.sdn.tags.{index}.{scope}={tag}` config keys.
-// The index only distinguishes tags sharing a scope, and tags without a scope use the tag itself as scope.
-func (i Instance) SDNTagConfig() map[string]string {
+// tagParser returns the group a tag is recorded under, and the tag's value.
+type tagParser[T any] func(tag T) (group string, value string)
+
+// tagConfig returns tags as `{prefix}.{index}.{group}={value}` config keys.
+// The index only distinguishes tags sharing a group, and tags without a group use the value as group.
+func tagConfig[T any](prefix string, tags []T, parse tagParser[T]) map[string]string {
 	config := map[string]string{}
-	indexByScope := map[string]int{}
-	for _, tag := range i.Properties.SDNTags {
-		scope := tag.Scope
-		if scope == "" {
-			scope = tag.Tag
+	indexByGroup := map[string]int{}
+	for _, tag := range tags {
+		group, value := parse(tag)
+		if group == "" {
+			group = value
 		}
 
-		config[fmt.Sprintf("%s.%d.%s", SDNTagsKeyPrefix, indexByScope[scope], scope)] = tag.Tag
-		indexByScope[scope]++
+		config[fmt.Sprintf("%s.%d.%s", prefix, indexByGroup[group], group)] = value
+		indexByGroup[group]++
 	}
 
 	return config
+}
+
+// SDNTagConfig returns the instance's SDN tags as `user.sdn.tags.{index}.{scope}={tag}` config keys.
+func (i Instance) SDNTagConfig() map[string]string {
+	return tagConfig(SDNTagsKeyPrefix, i.Properties.SDNTags, func(tag api.InstancePropertiesSDNTag) (string, string) {
+		return tag.Scope, tag.Tag
+	})
+}
+
+// TagConfig returns the instance's source tags as `user.tags.{index}.{category}={tag}` config keys.
+func (i Instance) TagConfig() map[string]string {
+	return tagConfig(TagsKeyPrefix, i.Properties.Tags, func(tag api.InstancePropertiesTag) (string, string) {
+		return tag.Category, tag.Tag
+	})
 }
 
 // GetName returns the name of the instance, which may not be unique among all instances for a given source.
@@ -531,6 +552,12 @@ func (i Instance) ApplyUpdates(srcInst Instance) (Instance, bool) {
 		instanceUpdated = true
 	}
 
+	if !slices.Equal(inst.Properties.Tags, srcInst.Properties.Tags) {
+		log.Debug("Instance tags changed")
+		inst.Properties.Tags = srcInst.Properties.Tags
+		instanceUpdated = true
+	}
+
 	return inst, instanceUpdated
 }
 
@@ -580,23 +607,14 @@ func (i Instance) CompileIncludeExpression(expression string, locationAlias bool
 			}
 		}
 
-		if category == "*" {
-			for k, v := range filterable.Config {
-				if strings.HasPrefix(k, "tag.") && containsFunc(v) {
-					return true, nil
-				}
+		for _, instTag := range filterable.Tags {
+			if category != "*" && instTag.Category != category {
+				continue
 			}
 
-			return false, nil
-		}
-
-		tagList, ok := filterable.Config["tag."+category]
-		if !ok {
-			return false, nil
-		}
-
-		if slices.ContainsFunc(strings.Split(tagList, ","), containsFunc) {
-			return true, nil
+			if containsFunc(instTag.Tag) {
+				return true, nil
+			}
 		}
 
 		return false, nil
@@ -623,6 +641,7 @@ func (i Instance) CompileIncludeExpression(expression string, locationAlias bool
 			Disks:     []api.InstancePropertiesDisk{},
 			Snapshots: []api.InstancePropertiesSnapshot{},
 			SDNTags:   []api.InstancePropertiesSDNTag{},
+			Tags:      []api.InstancePropertiesTag{},
 		},
 	}
 

--- a/internal/migration/instance_model.go
+++ b/internal/migration/instance_model.go
@@ -601,7 +601,7 @@ func (i Instance) CompileIncludeExpression(expression string, locationAlias bool
 			return s == tag
 		}
 
-		if exact {
+		if !exact {
 			containsFunc = func(s string) bool {
 				return strings.Contains(s, tag)
 			}

--- a/internal/migration/instance_model_test.go
+++ b/internal/migration/instance_model_test.go
@@ -87,6 +87,49 @@ func TestInstance_SDNTagConfig(t *testing.T) {
 	}
 }
 
+func TestInstance_TagConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []api.InstancePropertiesTag
+
+		want map[string]string
+	}{
+		{
+			name: "no tags",
+			tags: nil,
+
+			want: map[string]string{},
+		},
+		{
+			name: "tags sharing a category are indexed",
+			tags: []api.InstancePropertiesTag{
+				{Category: "app", Tag: "web"},
+				{Category: "app", Tag: "api"},
+				{Category: "dtap", Tag: "prod"},
+			},
+
+			want: map[string]string{
+				"user.tags.0.app":  "web",
+				"user.tags.1.app":  "api",
+				"user.tags.0.dtap": "prod",
+			},
+		},
+		{
+			name: "categoryless tags use the tag as category",
+			tags: []api.InstancePropertiesTag{{Tag: "foo"}},
+
+			want: map[string]string{"user.tags.0.foo": "foo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := migration.Instance{Properties: api.InstanceProperties{Tags: tc.tags}}
+
+			require.Equal(t, tc.want, instance.TagConfig())
+		})
+	}
+}
 func TestInstance_ApplyUpdatesSDNTags(t *testing.T) {
 	instance := func(tags []api.InstancePropertiesSDNTag) migration.Instance {
 		return migration.Instance{

--- a/internal/migration/instance_model_test.go
+++ b/internal/migration/instance_model_test.go
@@ -130,6 +130,43 @@ func TestInstance_TagConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestInstance_MatchesCriteriaTags(t *testing.T) {
+	instance := migration.Instance{
+		Properties: api.InstanceProperties{
+			Tags: []api.InstancePropertiesTag{
+				{Category: "mycategory", Tag: "tag1"},
+				{Tag: "uncategorized"},
+			},
+		},
+	}
+
+	tests := []struct {
+		expression string
+
+		want bool
+	}{
+		{expression: `has_tag('mycategory', 'tag1')`, want: true},
+		{expression: `has_tag('mycategory', 'tag')`, want: false},
+		{expression: `has_tag('othercategory', 'tag1')`, want: false},
+		{expression: `has_tag('*', 'tag1')`, want: true},
+		{expression: `matches_tag('mycategory', 'tag')`, want: true},
+		{expression: `matches_tag('*', 'categorized')`, want: true},
+		{expression: `matches_tag('*', 'nomatch')`, want: false},
+		{expression: `any(tags, .category == 'mycategory' and .tag == 'tag1')`, want: true},
+		{expression: `any(tags, .tag == 'uncategorized')`, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expression, func(t *testing.T) {
+			got, err := instance.MatchesCriteria(tc.expression, false)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestInstance_ApplyUpdatesSDNTags(t *testing.T) {
 	instance := func(tags []api.InstancePropertiesSDNTag) migration.Instance {
 		return migration.Instance{

--- a/internal/properties/definitions.go
+++ b/internal/properties/definitions.go
@@ -354,6 +354,10 @@ func (p RawPropertySet[T]) ToAPI(unsupportedDisks map[string]bool) (*api.Instanc
 		detectedProperties.Config = map[string]string{}
 	}
 
+	if detectedProperties.Tags == nil {
+		detectedProperties.Tags = []api.InstancePropertiesTag{}
+	}
+
 	// NIC UUIDs are not a source property so ensure they aren't set in error.
 	for i, nic := range detectedProperties.NICs {
 		if nic.UUID != uuid.Nil {

--- a/internal/source/vmware.go
+++ b/internal/source/vmware.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"cmp"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -404,13 +405,17 @@ func (s *InternalVMwareSource) getVM(ctx context.Context, vm *object.VirtualMach
 		}
 
 		for _, tag := range vmTags {
-			prefix := "tag." + catMap[tag.CategoryID]
-			if vmProps.Config[prefix] == "" {
-				vmProps.Config[prefix] = tag.Name
-			} else {
-				vmProps.Config[prefix] = vmProps.Config[prefix] + "," + tag.Name
+			if tag.Name == "" {
+				continue
 			}
+
+			vmProps.Tags = append(vmProps.Tags, api.InstancePropertiesTag{Category: catMap[tag.CategoryID], Tag: tag.Name})
 		}
+
+		// vCenter doesn't guarantee a tag order, so sort them to keep syncs and target config keys stable.
+		slices.SortFunc(vmProps.Tags, func(a api.InstancePropertiesTag, b api.InstancePropertiesTag) int {
+			return cmp.Or(cmp.Compare(a.Category, b.Category), cmp.Compare(a.Tag, b.Tag))
+		})
 
 		// Guarding against VMs with no resource pool.
 		if vmProperties.ResourcePool != nil {

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -370,6 +370,13 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(ctx context.Context, i mi
 	apiDef.Config["volatile.uuid"] = props.UUID.String()
 	apiDef.Config["volatile.uuid.generation"] = props.UUID.String()
 
+	// Drop tags recorded by an earlier migration, as their indexes may no longer match the current ones.
+	for k := range apiDef.Config {
+		if strings.HasPrefix(k, migration.SDNTagsKeyPrefix+".") || strings.HasPrefix(k, migration.TagsKeyPrefix+".") {
+			delete(apiDef.Config, k)
+		}
+	}
+
 	// Record the SDN tags imported from the source.
 	maps.Copy(apiDef.Config, i.SDNTagConfig())
 

--- a/internal/target/incus.go
+++ b/internal/target/incus.go
@@ -373,6 +373,9 @@ func (t *InternalIncusTarget) SetPostMigrationVMConfig(ctx context.Context, i mi
 	// Record the SDN tags imported from the source.
 	maps.Copy(apiDef.Config, i.SDNTagConfig())
 
+	// Record the tags imported from the source.
+	maps.Copy(apiDef.Config, i.TagConfig())
+
 	// Apply CPU and memory limits.
 	for name, info := range defs.GetAll() {
 		switch name {

--- a/shared/api/properties.go
+++ b/shared/api/properties.go
@@ -70,6 +70,9 @@ type InstanceProperties struct {
 
 	// List of tags applied to the Instance by the SDN manager of its networks.
 	SDNTags []InstancePropertiesSDNTag `json:"sdn_tags" yaml:"sdn_tags" expr:"sdn_tags"`
+
+	// List of tags applied to the Instance on its source.
+	Tags []InstancePropertiesTag `json:"tags" yaml:"tags" expr:"tags"`
 }
 
 // InstancePropertiesConfigurable are the configurable properties of an instance.
@@ -160,6 +163,17 @@ type InstancePropertiesSDNTag struct {
 	// Value of the tag.
 	// Example: web
 	Tag string `json:"tag"   yaml:"tag"   expr:"tag"`
+}
+
+// InstancePropertiesTag are all properties supported by source tags.
+type InstancePropertiesTag struct {
+	// Category of the tag, empty if the tag has none.
+	// Example: environment
+	Category string `json:"category" yaml:"category" expr:"category"`
+
+	// Value of the tag.
+	// Example: production
+	Tag string `json:"tag"      yaml:"tag"      expr:"tag"`
 }
 
 // SupportsBackgroundImport returns whether the instance has background import support, and all supported disks have been verified.

--- a/ui/src/types/instance.d.ts
+++ b/ui/src/types/instance.d.ts
@@ -28,6 +28,11 @@ export interface InstancePropertiesSDNTag {
   tag: string;
 }
 
+export interface InstancePropertiesTag {
+  category: string;
+  tag: string;
+}
+
 export interface InstanceProperties {
   uuid: string;
   name: string;
@@ -48,6 +53,7 @@ export interface InstanceProperties {
   disks: InstancePropertiesDisk[];
   snapshots: InstanceSnapshotInfo[];
   sdn_tags: InstancePropertiesSDNTag[];
+  tags: InstancePropertiesTag[];
 }
 
 export interface InstancePropertiesConfigurable {
@@ -99,6 +105,7 @@ export interface Instance {
   disks: InstancePropertiesDisk[];
   snapshots: InstanceSnapshotInfo[];
   sdn_tags: InstancePropertiesSDNTag[];
+  tags: InstancePropertiesTag[];
   overrides: InstanceOverride;
 }
 


### PR DESCRIPTION
Resolves #561.

This PR moves vCenter tags out of instance `config` into a dedicated `tags` property, following the same model as the SDN tags added in #567.

- Addition of `tags` to instance properties as a list of category/tag pairs, replacing the `tag.<category>` config keys.                     
- Record of tags on the migrated VM as `user.tags.<index>.<category>=<tag>`, clearing stale keys on re-runs.                            
- Migration of existing instances to the new property on schema update.                                                                   
- Fixing of `has_tag` and `matches_tag`, whose exact and substring matching were inverted.

### Notes

- Batch include expressions referencing `config['tag.<category>']` will no longer resolve and should be updated to use `has_tag`, `matches_tag` or the `tags` property.
- `has_tag` now matches exactly while `matches_tag` matches by substring, according to the docs.